### PR TITLE
Add status coordinator support

### DIFF
--- a/Mastodon/Protocol/StatusProvider/StatusProviderFacade.swift
+++ b/Mastodon/Protocol/StatusProvider/StatusProviderFacade.swift
@@ -129,7 +129,17 @@ extension StatusProviderFacade {
             coordinateToStatusMentionProfileScene(for: .primary, provider: provider, cell: cell, mention: text)
         case .url(_, _, let url, _):
             guard let url = URL(string: url) else { return }
-            provider.coordinator.present(scene: .safari(url: url), from: nil, transition: .safariPresent(animated: true, completion: nil))
+            if let domain = provider.context.authenticationService.activeMastodonAuthenticationBox.value?.domain, url.host == domain,
+               url.pathComponents.count >= 4,
+               url.pathComponents[0] == "/",
+               url.pathComponents[1] == "web",
+               url.pathComponents[2] == "statuses" {
+                let statusID = url.pathComponents[3]
+                let threadViewModel = RemoteThreadViewModel(context: provider.context, statusID: statusID)
+                provider.coordinator.present(scene: .thread(viewModel: threadViewModel), from: nil, transition: .show)
+            } else {
+                provider.coordinator.present(scene: .safari(url: url), from: nil, transition: .safariPresent(animated: true, completion: nil))
+            }
         default:
             break
         }


### PR DESCRIPTION
When the currently active domain matching the status URL host. The app will try to parse the URL and display the status thread directly. Otherwise, the app shows in-app Safari browser.