### PR TITLE
Fix authentication session not using exist Safari token issue

### DIFF
--- a/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewController.swift
+++ b/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewController.swift
@@ -44,7 +44,6 @@ final class MastodonPickServerViewController: UIViewController, NeedsDependency 
         tableView.backgroundColor = .clear
         tableView.keyboardDismissMode = .onDrag
         tableView.translatesAutoresizingMaskIntoConstraints = false
-        
         return tableView
     }()
     
@@ -319,7 +318,6 @@ extension MastodonPickServerViewController {
                 )
                 
                 self.mastodonAuthenticationController = authenticationController
-                authenticationController.authenticationSession?.prefersEphemeralWebBrowserSession = true
                 authenticationController.authenticationSession?.presentationContextProvider = self
                 authenticationController.authenticationSession?.start()
                 


### PR DESCRIPTION
resolve #178 

Currently, we set always using an ephemeral session to sign in. So user token in Safari not using. Remove the flag then the app will use that token to continue OAuth.

This PR set this [flag](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio) to false. So:
1. User sign-in a server in Safari  
2. User pick the same server to login in app
3. App alert user to request using Safari token

A. User tap "Continue" and the authentication panel display
B. User tap "Cancel" but the authentication panel will not display. App will get a callback with the cancel error.

That's should works. And if needs more behavior. Please let me known. :D