### PR TITLE
Fix app not respect web finger issue

### DIFF
--- a/Mastodon.xcodeproj/project.pbxproj
+++ b/Mastodon.xcodeproj/project.pbxproj
@@ -415,6 +415,7 @@
 		DBA0A10925FB3C2B0079C110 /* RoundedEdgesButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA0A10825FB3C2B0079C110 /* RoundedEdgesButton.swift */; };
 		DBA0A11325FB3FC10079C110 /* ComposeToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA0A11225FB3FC10079C110 /* ComposeToolbarView.swift */; };
 		DBA1DB80268F84F80052DB59 /* NotificationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA1DB7F268F84F80052DB59 /* NotificationType.swift */; };
+		DBA465932696B495002B41DB /* APIService+WebFinger.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA465922696B495002B41DB /* APIService+WebFinger.swift */; };
 		DBA5E7A3263AD0A3004598BB /* PhotoLibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA5E7A2263AD0A3004598BB /* PhotoLibraryService.swift */; };
 		DBA5E7A5263BD28C004598BB /* ContextMenuImagePreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA5E7A4263BD28C004598BB /* ContextMenuImagePreviewViewModel.swift */; };
 		DBA5E7A9263BD3A4004598BB /* ContextMenuImagePreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA5E7A8263BD3A4004598BB /* ContextMenuImagePreviewViewController.swift */; };
@@ -1044,6 +1045,7 @@
 		DBA0A10825FB3C2B0079C110 /* RoundedEdgesButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedEdgesButton.swift; sourceTree = "<group>"; };
 		DBA0A11225FB3FC10079C110 /* ComposeToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeToolbarView.swift; sourceTree = "<group>"; };
 		DBA1DB7F268F84F80052DB59 /* NotificationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationType.swift; sourceTree = "<group>"; };
+		DBA465922696B495002B41DB /* APIService+WebFinger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIService+WebFinger.swift"; sourceTree = "<group>"; };
 		DBA5E7A2263AD0A3004598BB /* PhotoLibraryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLibraryService.swift; sourceTree = "<group>"; };
 		DBA5E7A4263BD28C004598BB /* ContextMenuImagePreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuImagePreviewViewModel.swift; sourceTree = "<group>"; };
 		DBA5E7A8263BD3A4004598BB /* ContextMenuImagePreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuImagePreviewViewController.swift; sourceTree = "<group>"; };
@@ -1935,6 +1937,7 @@
 				2D04F42425C255B9003F936F /* APIService+PublicTimeline.swift */,
 				DB45FB1C25CA9D23005A8AC7 /* APIService+HomeTimeline.swift */,
 				DB482A4A261340A7008AE74C /* APIService+UserTimeline.swift */,
+				DBA465922696B495002B41DB /* APIService+WebFinger.swift */,
 				DB0AC6FB25CD02E600D75117 /* APIService+Instance.swift */,
 				DB59F10D25EF724F001F1DAB /* APIService+Poll.swift */,
 				DB71FD5125F8CCAA00512AE1 /* APIService+Status.swift */,
@@ -3430,6 +3433,7 @@
 				DB6D9F8426358EEC008423CD /* SettingsItem.swift in Sources */,
 				2D364F7825E66D8300204FDC /* MastodonResendEmailViewModel.swift in Sources */,
 				DBCBCC052680AFB9000F5B51 /* AsyncHomeTimelineViewController+Provider.swift in Sources */,
+				DBA465932696B495002B41DB /* APIService+WebFinger.swift in Sources */,
 				DB8AF54525C13647002E6C99 /* NeedsDependency.swift in Sources */,
 				DB9D6BF825E4F5690051B173 /* NotificationViewController.swift in Sources */,
 				2DAC9E46262FC9FD0062E1A6 /* SuggestionAccountTableViewCell.swift in Sources */,

--- a/Mastodon.xcodeproj/xcuserdata/mainasuk.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Mastodon.xcodeproj/xcuserdata/mainasuk.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -12,7 +12,7 @@
 		<key>CoreDataStack.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>21</integer>
+			<integer>20</integer>
 		</dict>
 		<key>Mastodon - ASDK.xcscheme_^#shared#^_</key>
 		<dict>
@@ -37,7 +37,7 @@
 		<key>NotificationService.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>20</integer>
+			<integer>21</integer>
 		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>

--- a/Mastodon/Service/APIService/APIService+WebFinger.swift
+++ b/Mastodon/Service/APIService/APIService+WebFinger.swift
@@ -1,0 +1,36 @@
+//
+//  APIService+WebFinger.swift
+//  Mastodon
+//
+//  Created by MainasuK Cirno on 2021-7-8.
+//
+
+import Foundation
+import Combine
+import CoreData
+import CoreDataStack
+import CommonOSLog
+import DateToolsSwift
+import MastodonSDK
+
+extension APIService {
+
+    private static func webFingerEndpointURL(domain: String) -> URL {
+        return URL(string: "https://\(domain)/")!
+            .appendingPathComponent(".well-known")
+            .appendingPathComponent("webfinger")
+    }
+
+    func webFinger(
+        domain: String
+    ) -> AnyPublisher<String, Error> {
+        let url = APIService.webFingerEndpointURL(domain: domain)
+        let request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 3)
+        return session.dataTaskPublisher(for: request)
+            .tryMap { data, response in
+                return response.url?.host ?? domain
+            }
+            .eraseToAnyPublisher()
+    }
+
+}

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Server.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Server.swift
@@ -38,8 +38,8 @@ extension Mastodon.Entity {
             case category
         }
         
-        public init(instance: Instance) {
-            self.domain = instance.uri
+        public init(domain: String, instance: Instance) {
+            self.domain = domain        // make domain configurable for WebFinger
             self.version = instance.version ?? ""
             self.description = instance.shortDescription ?? instance.description
             self.language = instance.languages?.first ?? ""

--- a/MastodonSDK/Tests/MastodonSDKTests/API/MastodonSDK+API+AppTests.swift
+++ b/MastodonSDK/Tests/MastodonSDKTests/API/MastodonSDK+API+AppTests.swift
@@ -21,6 +21,7 @@ extension MastodonSDKTests {
         
         let query = Mastodon.API.App.CreateQuery(
             clientName: "XCTest",
+            redirectURIs: "mastodon://joinmastodon.org/oauth",
             website: nil
         )
         Mastodon.API.App.create(session: session, domain: domain, query: query)

--- a/MastodonSDK/Tests/MastodonSDKTests/API/MastodonSDK+API+OAuthTests.swift
+++ b/MastodonSDK/Tests/MastodonSDKTests/API/MastodonSDK+API+OAuthTests.swift
@@ -17,12 +17,12 @@ extension MastodonSDKTests {
     }
     
     func _testOAuthAuthorize(domain: String) throws {
-        let query = Mastodon.API.OAuth.AuthorizeQuery(clientID: "StubClientID")
+        let query = Mastodon.API.OAuth.AuthorizeQuery(clientID: "StubClientID", redirectURI: "mastodon://joinmastodon.org/oauth")
         let authorizeURL = Mastodon.API.OAuth.authorizeURL(domain: domain, query: query)
         os_log("%{public}s[%{public}ld], %{public}s: (%s) authorizeURL %s", ((#file as NSString).lastPathComponent), #line, #function, domain, authorizeURL.absoluteString)
         XCTAssertEqual(
             authorizeURL.absoluteString,
-            "https://\(domain)/oauth/authorize?response_type=code&client_id=StubClientID&redirect_uri=urn:ietf:wg:oauth:2.0:oob&scope=read%20write%20follow%20push"
+            "https://\(domain)/oauth/authorize?response_type=code&client_id=StubClientID&redirect_uri=mastodon://joinmastodon.org/oauth&scope=read%20write%20follow%20push"
         )
     }
 
@@ -31,7 +31,7 @@ extension MastodonSDKTests {
     }
 
     func _testRevokeTokenFail() {
-        let theExpectation = expectation(description: "Revoke Instance Infomation")
+        let theExpectation = expectation(description: "Revoke Instance Information")
         let query = Mastodon.API.OAuth.RevokeTokenQuery(clientID: "StubClientID", clientSecret: "", token: "")
         Mastodon.API.OAuth.revokeToken(session: session, domain: domain, query: query)
             .receive(on: DispatchQueue.main)

--- a/MastodonTests/MastodonTests.swift
+++ b/MastodonTests/MastodonTests.swift
@@ -31,3 +31,16 @@ class MastodonTests: XCTestCase {
     }
 
 }
+
+extension MastodonTests {
+    func testWebFinger() {
+        let expectation = expectation(description: "webfinger")
+        let cancellable = AppContext.shared.apiService.webFinger(domain: "pawoo.net")
+            .sink { completion in
+                expectation.fulfill()
+            } receiveValue: { domain in
+                expectation.fulfill()
+            }
+        wait(for: [expectation], timeout: 10)
+    }
+}


### PR DESCRIPTION
The Federation server may use the `WEB_DOMAIN` [configuration](https://docs.joinmastodon.org/admin/config/). The app can not use `uri` property from `/api/v1/instance` as server `domain`. Otherwise, the request for the server will use the wrong endpoint URL and get a 404 error code.

The app now always query `/.well-known/webfinger` to locate the final server domain during sign-in/sign-up. And the app will use the `host` from the HTTP response whatever the endpoint returns. That `domain` will persist with account authentication and use by consequence API query.