### PR TITLE
Handle onboarding authentication errors in /api/v1/instance

### DIFF
--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Instance.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Instance.swift
@@ -22,7 +22,7 @@ extension Mastodon.Entity {
         public let title: String
         public let description: String
         public let shortDescription: String?
-        public let email: String
+        public let email: String?
         public let version: String?
         public let languages: [String]?     // (ISO 639 Part 1-5 language codes)
         public let registrations: Bool?
@@ -37,6 +37,25 @@ extension Mastodon.Entity {
         
         // https://github.com/mastodon/mastodon/pull/16485
         public let configuration: Configuration?
+
+        public init(domain: String) {
+            self.uri = domain
+            self.title = domain
+            self.description = ""
+            self.shortDescription = nil
+            self.email = nil
+            self.version = nil
+            self.languages = nil
+            self.registrations = nil
+            self.approvalRequired = nil
+            self.invitesEnabled = nil
+            self.urls = nil
+            self.statistics = nil
+            self.thumbnail = nil
+            self.contactAccount = nil
+            self.rules = nil
+            self.configuration = nil
+        }
 
         enum CodingKeys: String, CodingKey {
             case uri

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Instance.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Instance.swift
@@ -22,7 +22,7 @@ extension Mastodon.Entity {
         public let title: String
         public let description: String
         public let shortDescription: String?
-        public let email: String?
+        public let email: String
         public let version: String?
         public let languages: [String]?     // (ISO 639 Part 1-5 language codes)
         public let registrations: Bool?
@@ -43,7 +43,7 @@ extension Mastodon.Entity {
             self.title = domain
             self.description = ""
             self.shortDescription = nil
-            self.email = nil
+            self.email = ""
             self.version = nil
             self.languages = nil
             self.registrations = nil


### PR DESCRIPTION
When `AUTHORIZED_FETCH` is enabled, the `/api/v1/instance` API response returns errors like:

```json
{"error":"This method requires an authenticated user"}
```

The server's still able to handle to handle the rest of the login flow, but the user experience of this error is an indefinite activity indicator that never goes away. The change here recovers from this error by filling in a minimal amount of discovery info for the instance which is enough to populate the server list and continue onboarding.

| Before | After |
| ------ | ----- |
| <img src="https://user-images.githubusercontent.com/74188/158510697-57aab4ea-4297-4705-9f87-a9ddda8c6ef0.png"> | <img src="https://user-images.githubusercontent.com/74188/158510729-bd6a3a1f-4075-4006-a742-9f6c5b3670c4.png"> |

