### PR TITLE
fix: cursor jumping when entering text before non-ascii char in share extension

### DIFF
--- a/ShareActionExtension/Scene/View/StatusEditorView.swift
+++ b/ShareActionExtension/Scene/View/StatusEditorView.swift
@@ -54,6 +54,9 @@ public struct StatusEditorView: UIViewRepresentable {
     }
 
     public func updateUIView(_ textView: UITextView, context: Context) {
+        // preserve currently selected text range to prevent cursor jump
+        let currentlySelectedRange = textView.selectedRange
+
         // update content
         // textView.attributedText = attributedString
         textView.text = string
@@ -66,6 +69,9 @@ public struct StatusEditorView: UIViewRepresentable {
             viewDidAppear = false
             textView.becomeFirstResponder()
         }
+        
+        // restore selected text range
+        textView.selectedRange = currentlySelectedRange
     }
 
     public func makeCoordinator() -> Coordinator {


### PR DESCRIPTION
# Rationale / Bug

When using the ShareActionExtension with a non-ascii char in the text input (e.g. an emoji) the cursor jumps to the end of the text when altering the text.

# How to reproduce

Open share action extension, enter any arbitrary text include any arbitrary emoji, move curse before emoji and type text

## Expected

Editing continues at cursor position

## Currently behavior

Cursor jumps to end of text

# Solution

Store current cursor position before and restore after text of `UIViewRepresentable` is being set.

| Before | After |
|---|---|
| ![Simulator Screen Recording - iPhone 13 Pro - 2022-04-28 at 21 04 18 mp4](https://user-images.githubusercontent.com/126418/165829427-78b77277-bf63-41d6-ae0e-536d6daa8c32.gif) | ![Simulator Screen Recording - iPhone 13 Pro - 2022-04-28 at 21 06 22 mp4](https://user-images.githubusercontent.com/126418/165829469-1fe0d45d-19ee-4898-bfdf-f104bc211d60.gif) |