### PR TITLE
Fix auto complete items may raise crash issue

### DIFF
--- a/Mastodon/Scene/Compose/AutoComplete/AutoCompleteViewModel.swift
+++ b/Mastodon/Scene/Compose/AutoComplete/AutoCompleteViewModel.swift
@@ -46,7 +46,7 @@ final class AutoCompleteViewModel {
 
                 var snapshot = NSDiffableDataSourceSnapshot<AutoCompleteSection, AutoCompleteItem>()
                 snapshot.appendSections([.main])
-                snapshot.appendItems(items, toSection: .main)
+                snapshot.appendItems(items.removingDuplicates(), toSection: .main)
                 if let currentState = self.stateMachine.currentState {
                     switch currentState {
                     case is State.Loading, is State.Fail:

--- a/Mastodon/Scene/Discovery/Hashtags/DiscoveryHashtagsViewModel+Diffable.swift
+++ b/Mastodon/Scene/Discovery/Hashtags/DiscoveryHashtagsViewModel+Diffable.swift
@@ -32,7 +32,7 @@ extension DiscoveryHashtagsViewModel {
                 snapshot.appendSections([.hashtags])
                 
                 let items = hashtags.map { DiscoveryItem.hashtag($0) }
-                snapshot.appendItems(items, toSection: .hashtags)
+                snapshot.appendItems(items.removingDuplicates(), toSection: .hashtags)
                 
                 diffableDataSource.apply(snapshot)
             }


### PR DESCRIPTION
The items has the same hash value can raise a crash.
Remove duplicated incoming item for auto complete content to fix it. 
