### PR TITLE
Fix app enter background break profile header layout issue

### DIFF
--- a/Mastodon/Scene/Profile/Header/View/ProfileHeaderView.swift
+++ b/Mastodon/Scene/Profile/Header/View/ProfileHeaderView.swift
@@ -407,8 +407,14 @@ extension ProfileHeaderView {
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        
-        updateLayoutMargins()
+
+        // workaround enter background breaking the layout issue
+        switch UIApplication.shared.applicationState {
+        case .active:
+            updateLayoutMargins()
+        default:
+            break
+        }
     }
 
 }


### PR DESCRIPTION
The profile header view layout will be broken when app enter background then return.

Step to trigger issue:
1. Tap profile tab
2. Scroll the posts timeline
3. Tap Home button to make app enter background state
4. Tap Mastodon app make it active

The header view `layoutMargins` somehow should not be set when app in background state. Always check the app state to workaround this issue.