### PR TITLE
Display familiar followers for profile card

### DIFF
--- a/AppShared/Info.plist
+++ b/AppShared/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.4.2</string>
 	<key>CFBundleVersion</key>
-	<string>127</string>
+	<string>128</string>
 </dict>
 </plist>

--- a/Mastodon.xcodeproj/project.pbxproj
+++ b/Mastodon.xcodeproj/project.pbxproj
@@ -4756,7 +4756,7 @@
 				CODE_SIGN_ENTITLEMENTS = Mastodon/Mastodon.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_ASSET_PATHS = "Mastodon/Resources/Preview\\ Assets.xcassets";
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = Mastodon/Info.plist;
@@ -4786,7 +4786,7 @@
 				CODE_SIGN_ENTITLEMENTS = Mastodon/Mastodon.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_ASSET_PATHS = "Mastodon/Resources/Preview\\ Assets.xcassets";
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = Mastodon/Info.plist;
@@ -4894,11 +4894,11 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 127;
+				DYLIB_CURRENT_VERSION = 128;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AppShared/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -4925,11 +4925,11 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 127;
+				DYLIB_CURRENT_VERSION = 128;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AppShared/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -5020,7 +5020,7 @@
 				CODE_SIGN_ENTITLEMENTS = Mastodon/Mastodon.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_ASSET_PATHS = "Mastodon/Resources/Preview\\ Assets.xcassets";
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = Mastodon/Info.plist;
@@ -5088,11 +5088,11 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 127;
+				DYLIB_CURRENT_VERSION = 128;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AppShared/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -5117,7 +5117,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = NotificationService/NotificationService.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = NotificationService/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5140,7 +5140,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShareActionExtension/ShareActionExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = ShareActionExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5164,7 +5164,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = MastodonIntent/MastodonIntent.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = MastodonIntent/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5188,7 +5188,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = MastodonIntent/MastodonIntent.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = MastodonIntent/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5212,7 +5212,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = MastodonIntent/MastodonIntent.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = MastodonIntent/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5236,7 +5236,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShareActionExtension/ShareActionExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = ShareActionExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5260,7 +5260,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShareActionExtension/ShareActionExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = ShareActionExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5347,7 +5347,7 @@
 				CODE_SIGN_ENTITLEMENTS = Mastodon/Mastodon.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_ASSET_PATHS = "Mastodon/Resources/Preview\\ Assets.xcassets";
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = Mastodon/Info.plist;
@@ -5414,11 +5414,11 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 127;
+				DYLIB_CURRENT_VERSION = 128;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AppShared/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -5442,7 +5442,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = NotificationService/NotificationService.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = NotificationService/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5465,7 +5465,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShareActionExtension/ShareActionExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = ShareActionExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5489,7 +5489,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = MastodonIntent/MastodonIntent.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = MastodonIntent/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5513,7 +5513,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = NotificationService/NotificationService.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = NotificationService/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5536,7 +5536,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = NotificationService/NotificationService.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 127;
+				CURRENT_PROJECT_VERSION = 128;
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
 				INFOPLIST_FILE = NotificationService/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Mastodon.xcodeproj/xcuserdata/mainasuk.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Mastodon.xcodeproj/xcuserdata/mainasuk.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -114,7 +114,7 @@
 		<key>MastodonIntent.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>20</integer>
+			<integer>29</integer>
 		</dict>
 		<key>MastodonIntents.xcscheme_^#shared#^_</key>
 		<dict>
@@ -129,12 +129,12 @@
 		<key>NotificationService.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>21</integer>
+			<integer>27</integer>
 		</dict>
 		<key>ShareActionExtension.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>22</integer>
+			<integer>28</integer>
 		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>

--- a/Mastodon/Info.plist
+++ b/Mastodon/Info.plist
@@ -43,7 +43,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>127</string>
+	<string>128</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/Mastodon/Scene/Discovery/ForYou/DiscoveryForYouViewModel+Diffable.swift
+++ b/Mastodon/Scene/Discovery/ForYou/DiscoveryForYouViewModel+Diffable.swift
@@ -19,7 +19,8 @@ extension DiscoveryForYouViewModel {
             tableView: tableView,
             context: context,
             configuration: DiscoverySection.Configuration(
-                profileCardTableViewCellDelegate: profileCardTableViewCellDelegate
+                profileCardTableViewCellDelegate: profileCardTableViewCellDelegate,
+                familiarFollowers: $familiarFollowers
             )
         )
         

--- a/Mastodon/Service/APIService/APIService+Recommend.swift
+++ b/Mastodon/Service/APIService/APIService+Recommend.swift
@@ -74,3 +74,36 @@ extension APIService {
     }
 
 }
+
+extension APIService {
+    
+    func familiarFollowers(
+        query: Mastodon.API.Account.FamiliarFollowersQuery,
+        authenticationBox: MastodonAuthenticationBox
+    ) async throws -> Mastodon.Response.Content<[Mastodon.Entity.Account]> {
+        let response = try await Mastodon.API.Account.familiarFollowers(
+            session: session,
+            domain: authenticationBox.domain,
+            query: query,
+            authorization: authenticationBox.userAuthorization
+        ).singleOutput()
+
+//        let managedObjectContext = backgroundManagedObjectContext
+//        try await managedObjectContext.performChanges {
+//            for entity in response.value {
+//                _ = Persistence.MastodonUser.createOrMerge(
+//                    in: managedObjectContext,
+//                    context: Persistence.MastodonUser.PersistContext(
+//                        domain: authenticationBox.domain,
+//                        entity: entity.account,
+//                        cache: nil,
+//                        networkDate: response.networkDate
+//                    )
+//                )
+//            }   // end for … in
+//        }
+
+        return response
+    }
+    
+}

--- a/MastodonIntent/Info.plist
+++ b/MastodonIntent/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.4.2</string>
 	<key>CFBundleVersion</key>
-	<string>127</string>
+	<string>128</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+Account+FamiliarFollowers.swift
+++ b/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+Account+FamiliarFollowers.swift
@@ -1,0 +1,71 @@
+//
+//  Mastodon+API+Account+FamiliarFollowers.swift
+//  
+//
+//  Created by MainasuK on 2022-5-13.
+//
+
+import Foundation
+import Combine
+
+// https://github.com/mastodon/mastodon/pull/17700
+extension Mastodon.API.Account {
+    
+    private static func familiarFollowersEndpointURL(domain: String) -> URL {
+        return Mastodon.API.endpointURL(domain: domain)
+            .appendingPathComponent("accounts")
+            .appendingPathComponent("familiar_followers")
+    }
+    
+    /// Fetch familiar followers
+    ///
+    /// - Since: 3.5.?
+    /// - Version: 3.5.2
+    /// # Last Update
+    ///   2022/5/13
+    /// # Reference
+    ///   [Document](none)
+    /// - Parameters:
+    ///   - session: `URLSession`
+    ///   - domain: Mastodon instance domain. e.g. "example.com"
+    ///   - query: `FamiliarFollowersQuery`
+    ///   - authorization: User token
+    /// - Returns: `AnyPublisher` contains `[Mastodon.Entity.Account]` nested in the response
+    public static func familiarFollowers(
+        session: URLSession,
+        domain: String,
+        query: FamiliarFollowersQuery,
+        authorization: Mastodon.API.OAuth.Authorization
+    ) -> AnyPublisher<Mastodon.Response.Content<[Mastodon.Entity.Account]>, Error> {
+        let request = Mastodon.API.get(
+            url: familiarFollowersEndpointURL(domain: domain),
+            query: query,
+            authorization: authorization
+        )
+        return session.dataTaskPublisher(for: request)
+            .tryMap { data, response in
+                let value = try Mastodon.API.decode(type: [Mastodon.Entity.Account].self, from: data, response: response)
+                return Mastodon.Response.Content(value: value, response: response)
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    public struct FamiliarFollowersQuery: GetQuery {
+        public let accounts: [Mastodon.Entity.Account.ID]
+        
+        public init(accounts: [Mastodon.Entity.Account.ID]) {
+            self.accounts = accounts
+        }
+        
+        var queryItems: [URLQueryItem]? {
+            var items: [URLQueryItem] = []
+            let accountsValue = accounts.joined(separator: ",")
+            if !accountsValue.isEmpty {
+                items.append(URLQueryItem(name: "accounts", value: accountsValue))
+            }
+            guard !items.isEmpty else { return nil }
+            return items
+        }
+    }
+    
+}

--- a/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+Account+FamiliarFollowers.swift
+++ b/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+Account+FamiliarFollowers.swift
@@ -36,7 +36,7 @@ extension Mastodon.API.Account {
         domain: String,
         query: FamiliarFollowersQuery,
         authorization: Mastodon.API.OAuth.Authorization
-    ) -> AnyPublisher<Mastodon.Response.Content<[Mastodon.Entity.Account]>, Error> {
+    ) -> AnyPublisher<Mastodon.Response.Content<[Mastodon.Entity.FamiliarFollowers]>, Error> {
         let request = Mastodon.API.get(
             url: familiarFollowersEndpointURL(domain: domain),
             query: query,
@@ -44,24 +44,23 @@ extension Mastodon.API.Account {
         )
         return session.dataTaskPublisher(for: request)
             .tryMap { data, response in
-                let value = try Mastodon.API.decode(type: [Mastodon.Entity.Account].self, from: data, response: response)
+                let value = try Mastodon.API.decode(type: [Mastodon.Entity.FamiliarFollowers].self, from: data, response: response)
                 return Mastodon.Response.Content(value: value, response: response)
             }
             .eraseToAnyPublisher()
     }
     
     public struct FamiliarFollowersQuery: GetQuery {
-        public let accounts: [Mastodon.Entity.Account.ID]
+        public let ids: [Mastodon.Entity.Account.ID]
         
-        public init(accounts: [Mastodon.Entity.Account.ID]) {
-            self.accounts = accounts
+        public init(ids: [Mastodon.Entity.Account.ID]) {
+            self.ids = ids
         }
         
         var queryItems: [URLQueryItem]? {
             var items: [URLQueryItem] = []
-            let accountsValue = accounts.joined(separator: ",")
-            if !accountsValue.isEmpty {
-                items.append(URLQueryItem(name: "accounts", value: accountsValue))
+            for id in ids {
+                items.append(URLQueryItem(name: "id[]", value: id))
             }
             guard !items.isEmpty else { return nil }
             return items

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+FamiliarFollowers.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+FamiliarFollowers.swift
@@ -1,0 +1,24 @@
+//
+//  Mastodon+Entity+FamiliarFollowers.swift
+//  
+//
+//  Created by MainasuK on 2022-5-16.
+//
+
+import Foundation
+
+extension Mastodon.Entity {
+    
+    /// FamiliarFollowers
+    ///
+    /// - Since: 3.5.2
+    /// - Version: 3.5.2
+    /// # Last Update
+    ///   2022/5/16
+    /// # Reference
+    ///  [Document](TBD)
+    public class FamiliarFollowers: Codable {
+        public let id: Mastodon.Entity.Account.ID
+        public let accounts: [Mastodon.Entity.Account]
+    }
+}

--- a/MastodonSDK/Sources/MastodonUI/Extension/MastodonSDK/Mastodon+Entity+Account.swift
+++ b/MastodonSDK/Sources/MastodonUI/Extension/MastodonSDK/Mastodon+Entity+Account.swift
@@ -1,0 +1,30 @@
+//
+//  Mastodon+Entity+Account.swift
+//  
+//
+//  Created by MainasuK on 2022-5-16.
+//
+
+import Foundation
+import MastodonSDK
+
+extension Mastodon.Entity.Account {
+    public var displayNameWithFallback: String {
+        if displayName.isEmpty {
+            return username
+        } else {
+            return displayName
+        }
+    }
+}
+
+extension Mastodon.Entity.Account {    
+    public func avatarImageURL() -> URL? {
+        let string = UserDefaults.shared.preferredStaticAvatar ? avatarStatic ?? avatar : avatar
+        return URL(string: string)
+    }
+    
+    public func avatarImageURLWithFallback(domain: String) -> URL {
+        return avatarImageURL() ?? URL(string: "https://\(domain)/avatars/original/missing.png")!
+    }
+}

--- a/MastodonSDK/Sources/MastodonUI/View/Content/FamiliarFollowersDashboardView+Configuration.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/FamiliarFollowersDashboardView+Configuration.swift
@@ -1,0 +1,20 @@
+//
+//  FamiliarFollowersDashboardView+Configuration.swift
+//  
+//
+//  Created by MainasuK on 2022-5-16.
+//
+
+import UIKit
+import MastodonSDK
+
+extension FamiliarFollowersDashboardView {
+    public func configure(familiarFollowers: Mastodon.Entity.FamiliarFollowers?) {
+        assert(Thread.isMainThread)
+        
+        let accounts = familiarFollowers?.accounts.prefix(4) ?? []
+        
+        viewModel.avatarURLs = accounts.map { $0.avatarImageURL() }
+        viewModel.names = accounts.map { $0.displayNameWithFallback }
+    }
+}

--- a/MastodonSDK/Sources/MastodonUI/View/Content/FamiliarFollowersDashboardView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/FamiliarFollowersDashboardView+ViewModel.swift
@@ -1,0 +1,63 @@
+//
+//  FamiliarFollowersDashboardView+ViewModel.swift
+//  
+//
+//  Created by MainasuK on 2022-5-16.
+//
+
+import os.log
+import UIKit
+import Combine
+
+extension FamiliarFollowersDashboardView {
+    public final class ViewModel: ObservableObject {
+        public var disposeBag = Set<AnyCancellable>()
+
+        let logger = Logger(subsystem: "FamiliarFollowersDashboardView", category: "ViewModel")
+        
+        @Published var avatarURLs: [URL?] = []
+        @Published var names: [String] = []
+        @Published var backgroundColor: UIColor?
+    }
+}
+
+extension FamiliarFollowersDashboardView.ViewModel {
+    func bind(view: FamiliarFollowersDashboardView) {
+        Publishers.CombineLatest(
+            $avatarURLs,
+            $backgroundColor
+        )
+        .sink { avatarURLs, backgroundColor in
+            view.avatarContainerView.subviews.forEach { $0.removeFromSuperview() }
+            for (i, avatarURL) in avatarURLs.enumerated() {
+                let avatarButton = AvatarButton()
+                let origin = CGPoint(x: 20 * i, y: 0)
+                let size = CGSize(width: 32, height: 32)
+                avatarButton.size = size
+                avatarButton.frame = CGRect(origin: origin, size: size)
+                view.avatarContainerView.addSubview(avatarButton)
+                avatarButton.avatarImageView.configure(configuration: .init(url: avatarURL))
+                avatarButton.avatarImageView.configure(
+                    cornerConfiguration: .init(
+                        corner: .fixed(radius: 7),
+                        border: .init(
+                            color: backgroundColor ?? .clear,
+                            width: 1
+                        )
+                    )
+                )
+            }
+            
+            view.avatarContainerViewWidthLayoutConstraint.constant = CGFloat(12 + 20 * avatarURLs.count)
+        }
+        .store(in: &disposeBag)
+        
+        $names
+            .sink { names in
+                // TODO: i18n
+                let description = "Followed by" + names.joined(separator: ", ")
+                view.descriptionLabel.text = description
+            }
+            .store(in: &disposeBag)
+    }
+}

--- a/MastodonSDK/Sources/MastodonUI/View/Content/FamiliarFollowersDashboardView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/FamiliarFollowersDashboardView.swift
@@ -1,0 +1,85 @@
+//
+//  FamiliarFollowersDashboardView.swift
+//  
+//
+//  Created by MainasuK on 2022-5-16.
+//
+
+import UIKit
+import MastodonAsset
+
+public final class FamiliarFollowersDashboardView: UIView {
+    
+    let avatarContainerView = UIView()
+    var avatarContainerViewWidthLayoutConstraint: NSLayoutConstraint!
+    
+    let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFontMetrics(forTextStyle: .subheadline).scaledFont(for: .systemFont(ofSize: 13, weight: .regular))
+        label.text = "Followed by Pixelflowers, Lee’s Food, and 4 other mutuals"
+        label.textColor = Asset.Colors.Label.secondary.color
+        label.numberOfLines = 0
+        return label
+    }()
+    
+    public private(set) lazy var viewModel: ViewModel = {
+        let viewModel = ViewModel()
+        viewModel.bind(view: self)
+        return viewModel
+    }()
+    
+    public func prepareForReuse() {
+        
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        _init()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        _init()
+    }
+    
+}
+
+extension FamiliarFollowersDashboardView {
+    
+    private func _init() {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stackView)
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+        
+        avatarContainerView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.addArrangedSubview(avatarContainerView)
+        avatarContainerViewWidthLayoutConstraint = avatarContainerView.widthAnchor.constraint(equalToConstant: 32).priority(.required - 1)
+        NSLayoutConstraint.activate([
+            avatarContainerViewWidthLayoutConstraint,
+            avatarContainerView.heightAnchor.constraint(equalToConstant: 32).priority(.required - 1)
+        ])
+        stackView.addArrangedSubview(descriptionLabel)
+    }
+    
+}
+
+
+#if DEBUG
+import SwiftUI
+struct FamiliarFollowersDashboardView_Preview: PreviewProvider {
+    static var previews: some View {
+        UIViewPreview {
+            FamiliarFollowersDashboardView()
+        }
+    }
+}
+#endif

--- a/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView+ViewModel.swift
@@ -18,7 +18,7 @@ extension NotificationView {
     public final class ViewModel: ObservableObject {
         public var disposeBag = Set<AnyCancellable>()
 
-        let logger = Logger(subsystem: "StatusView", category: "ViewModel")
+        let logger = Logger(subsystem: "NotificationView", category: "ViewModel")
         
         @Published public var userIdentifier: UserIdentifier?       // me
         

--- a/MastodonSDK/Sources/MastodonUI/View/Content/ProfileCardView+Configuration.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/ProfileCardView+Configuration.swift
@@ -10,6 +10,7 @@ import Combine
 import CoreDataStack
 import Meta
 import MastodonMeta
+import MastodonSDK
 
 extension ProfileCardView {
 

--- a/MastodonSDK/Sources/MastodonUI/View/Content/ProfileCardView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/ProfileCardView+ViewModel.swift
@@ -13,6 +13,7 @@ import AlamofireImage
 import CoreDataStack
 import MastodonLocalization
 import MastodonAsset
+import MastodonSDK
 
 extension ProfileCardView {
     public class ViewModel: ObservableObject {
@@ -43,6 +44,8 @@ extension ProfileCardView {
         @Published public var isBlockedBy = false
         
         @Published public var groupedAccessibilityLabel = ""
+        
+        @Published public var familiarFollowers: Mastodon.Entity.FamiliarFollowers?
         
         init() {
             backgroundColor = ThemeService.shared.currentTheme.value.systemBackgroundColor
@@ -77,6 +80,7 @@ extension ProfileCardView.ViewModel {
         bindBio(view: view)
         bindRelationship(view: view)
         bindDashboard(view: view)
+        bindFamiliarFollowers(view: view)
         bindAccessibility(view: view)
     }
     
@@ -186,6 +190,18 @@ extension ProfileCardView.ViewModel {
                 view.statusDashboardView.followersDashboardMeterView.isAccessibilityElement = true
                 view.statusDashboardView.followersDashboardMeterView.accessibilityLabel = L10n.Plural.Count.follower(count ?? 0)
             }
+            .store(in: &disposeBag)
+    }
+    
+    private func bindFamiliarFollowers(view: ProfileCardView) {
+        $familiarFollowers
+            .sink { familiarFollowers in
+                view.familiarFollowersDashboardViewAdaptiveMarginContainerView.isHidden = familiarFollowers.flatMap { $0.accounts.isEmpty } ?? true
+                view.familiarFollowersDashboardView.configure(familiarFollowers: familiarFollowers)
+            }
+            .store(in: &disposeBag)
+        $backgroundColor
+            .assign(to: \.backgroundColor, on: view.familiarFollowersDashboardView.viewModel)
             .store(in: &disposeBag)
     }
     

--- a/MastodonSDK/Sources/MastodonUI/View/Content/ProfileCardView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/ProfileCardView.swift
@@ -94,6 +94,9 @@ public final class ProfileCardView: UIView {
         return button
     }()
     
+    let familiarFollowersDashboardViewAdaptiveMarginContainerView = AdaptiveMarginContainerView()
+    let familiarFollowersDashboardView = FamiliarFollowersDashboardView()
+    
     public private(set) lazy var viewModel: ViewModel = {
         let viewModel = ViewModel()
         viewModel.bind(view: self)
@@ -126,7 +129,7 @@ extension ProfileCardView {
         bioMetaText.textView.isUserInteractionEnabled = false
         statusDashboardView.isUserInteractionEnabled = false        
         
-        // container: V - [ bannerContainer | authorContainer | bioMetaText | infoContainer ]
+        // container: V - [ bannerContainer | authorContainer | bioMetaText | infoContainer | familiarFollowersDashboardView ]
         container.axis = .vertical
         container.spacing = 8
         container.translatesAutoresizingMaskIntoConstraints = false
@@ -211,7 +214,7 @@ extension ProfileCardView {
         container.addArrangedSubview(bioMetaTextAdaptiveMarginContainerView)
         container.setCustomSpacing(16, after: bioMetaTextAdaptiveMarginContainerView)
 
-        // infoContainer: H - [ statusDashboardView | (spacer) | relationshipActionButton ]
+        // infoContainer: H - [ statusDashboardView | (spacer) | relationshipActionButton]
         infoContainer.axis = .horizontal
         infoContainer.spacing = 8
         infoContainerAdaptiveMarginContainerView.contentView = infoContainer
@@ -237,6 +240,10 @@ extension ProfileCardView {
             relationshipActionButtonShadowContainer.widthAnchor.constraint(greaterThanOrEqualToConstant: ProfileCardView.friendshipActionButtonSize.width).priority(.required - 1),
             relationshipActionButtonShadowContainer.heightAnchor.constraint(equalToConstant: ProfileCardView.friendshipActionButtonSize.height).priority(.required - 1),
         ])
+        
+        familiarFollowersDashboardViewAdaptiveMarginContainerView.contentView = familiarFollowersDashboardView
+        familiarFollowersDashboardViewAdaptiveMarginContainerView.margin = ProfileCardView.contentMargin
+        container.addArrangedSubview(familiarFollowersDashboardViewAdaptiveMarginContainerView)
 
         let bottomPadding = UIView()
         bottomPadding.translatesAutoresizingMaskIntoConstraints = false

--- a/MastodonSDK/Sources/MastodonUI/View/ImageView/AvatarImageView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/ImageView/AvatarImageView.swift
@@ -44,6 +44,11 @@ extension AvatarImageView {
         }
     }
     
+    private func setup(border: CornerConfiguration.Border?) {
+        layer.borderColor = border?.color.cgColor
+        layer.borderWidth = border?.width ?? .zero
+    }
+    
 }
 
 extension AvatarImageView {
@@ -107,9 +112,14 @@ extension AvatarImageView {
 extension AvatarImageView {
     public struct CornerConfiguration {
         public let corner: Corner
+        public let border: Border?
 
-        public init(corner: Corner = .circle) {
+        public init(
+            corner: Corner = .circle,
+            border: Border? = nil
+        ) {
             self.corner = corner
+            self.border = border
         }
         
         public enum Corner {
@@ -117,10 +127,16 @@ extension AvatarImageView {
             case fixed(radius: CGFloat)
             case scale(ratio: Int = 4)      //  width / ratio
         }
+        
+        public struct Border {
+            public let color: UIColor
+            public let width: CGFloat
+        }
     }
     
     public func configure(cornerConfiguration: CornerConfiguration) {
         self.cornerConfiguration = cornerConfiguration
         setup(corner: cornerConfiguration.corner)
+        setup(border: cornerConfiguration.border)
     }
 }

--- a/MastodonSDK/Sources/MastodonUI/View/TableViewCell/ProfileCardTableViewCell+Configuration.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/TableViewCell/ProfileCardTableViewCell+Configuration.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import CoreDataStack
+import MastodonSDK
 
 extension ProfileCardTableViewCell {
     

--- a/MastodonTests/Info.plist
+++ b/MastodonTests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.4.2</string>
 	<key>CFBundleVersion</key>
-	<string>127</string>
+	<string>128</string>
 </dict>
 </plist>

--- a/MastodonUITests/Info.plist
+++ b/MastodonUITests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.4.2</string>
 	<key>CFBundleVersion</key>
-	<string>127</string>
+	<string>128</string>
 </dict>
 </plist>

--- a/NotificationService/Info.plist
+++ b/NotificationService/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.4.2</string>
 	<key>CFBundleVersion</key>
-	<string>127</string>
+	<string>128</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ShareActionExtension/Info.plist
+++ b/ShareActionExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.4.2</string>
 	<key>CFBundleVersion</key>
-	<string>127</string>
+	<string>128</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
Display additonal information about "familiar followers" in the discovery tab "For You". The app display prefix N avatars with a description:

"Followed by N1 mutual"
"Followed by N2, N2 mutuals"
"Followed by N1, N2, and (N - 2) other mutuals"