### PR TITLE
Fix mention not works due to wrong types issue #452

### DIFF
--- a/Mastodon/Service/APIService/APIService+Notification.swift
+++ b/Mastodon/Service/APIService/APIService+Notification.swift
@@ -37,11 +37,8 @@ extension APIService {
                     ]
                 case .mentions:
                     return [
-                        .follow,
-                        .followRequest,
-                        .reblog,
-                        .favourite,
-                        .poll
+                        .mention,
+                        .status,
                     ]
                 }
             }(),


### PR DESCRIPTION
Resolve #452 

Fixing the "mentions" notification scope is not working for some servers that support new `types` API. 