### PR TITLE
Use LPLinkMetadata to improve sharing behavior

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
@@ -226,14 +226,13 @@ extension NotificationView {
             .store(in: &_disposeBag)
         
         // avatarButton
-        let authorAvatarButtonSize = CGSize(width: 46, height: 46)
-        avatarButton.size = authorAvatarButtonSize
-        avatarButton.avatarImageView.imageViewSize = authorAvatarButtonSize
+        avatarButton.size = CGSize.authorAvatarButtonSize
+        avatarButton.avatarImageView.imageViewSize = CGSize.authorAvatarButtonSize
         avatarButton.translatesAutoresizingMaskIntoConstraints = false
         authorContainerView.addArrangedSubview(avatarButton)
         NSLayoutConstraint.activate([
-            avatarButton.widthAnchor.constraint(equalToConstant: authorAvatarButtonSize.width).priority(.required - 1),
-            avatarButton.heightAnchor.constraint(equalToConstant: authorAvatarButtonSize.height).priority(.required - 1),
+            avatarButton.widthAnchor.constraint(equalToConstant: CGSize.authorAvatarButtonSize.width).priority(.required - 1),
+            avatarButton.heightAnchor.constraint(equalToConstant: CGSize.authorAvatarButtonSize.height).priority(.required - 1),
         ])
         avatarButton.setContentHuggingPriority(.required - 1, for: .vertical)
         avatarButton.setContentCompressionResistancePriority(.required - 1, for: .vertical)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusAuthorView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusAuthorView.swift
@@ -210,14 +210,13 @@ extension StatusAuthorView {
     // author container: H - [ avatarButton | authorMetaContainer ]
     private func layoutBase() {
         // avatarButton
-        let authorAvatarButtonSize = CGSize(width: 46, height: 46)
-        avatarButton.size = authorAvatarButtonSize
-        avatarButton.avatarImageView.imageViewSize = authorAvatarButtonSize
+        avatarButton.size = CGSize.authorAvatarButtonSize
+        avatarButton.avatarImageView.imageViewSize = CGSize.authorAvatarButtonSize
         avatarButton.translatesAutoresizingMaskIntoConstraints = false
         addArrangedSubview(avatarButton)
         NSLayoutConstraint.activate([
-            avatarButton.widthAnchor.constraint(equalToConstant: authorAvatarButtonSize.width).priority(.required - 1),
-            avatarButton.heightAnchor.constraint(equalToConstant: authorAvatarButtonSize.height).priority(.required - 1),
+            avatarButton.widthAnchor.constraint(equalToConstant: CGSize.authorAvatarButtonSize.width).priority(.required - 1),
+            avatarButton.heightAnchor.constraint(equalToConstant: CGSize.authorAvatarButtonSize.height).priority(.required - 1),
         ])
         avatarButton.setContentHuggingPriority(.required - 1, for: .vertical)
         avatarButton.setContentCompressionResistancePriority(.required - 1, for: .vertical)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -14,6 +14,10 @@ import MastodonAsset
 import MastodonCore
 import MastodonLocalization
 
+public extension CGSize {
+    static let authorAvatarButtonSize = CGSize(width: 46, height: 46)
+}
+
 public protocol StatusViewDelegate: AnyObject {
     func statusView(_ statusView: StatusView, headerDidPressed header: UIView)
     func statusView(_ statusView: StatusView, authorAvatarButtonDidPressed button: AvatarButton)


### PR DESCRIPTION
Before/After:

<img src="https://user-images.githubusercontent.com/25517624/199099882-91a64463-2a3b-46a0-9c66-fcc52a394782.png" alt="Share sheet showing no metadata for the shared post" width=300> <img src="https://user-images.githubusercontent.com/25517624/199100156-a68ae1fd-5c20-4e5d-88e7-0f29bc8b4503.png" alt="Share sheet showing automatically fetched metadata for the shared post" width=300>

<small>(sometimes the metadata loaded in the old version but only after a noticeable delay)</small>
