### PR TITLE
Add support for scrolling the discovery tab to the top/first tab

### DIFF
--- a/Mastodon/Protocol/ScrollViewContainer.swift
+++ b/Mastodon/Protocol/ScrollViewContainer.swift
@@ -14,6 +14,12 @@ protocol ScrollViewContainer: UIViewController {
 
 extension ScrollViewContainer {
     func scrollToTop(animated: Bool) {
-        scrollView.scrollRectToVisible(CGRect(origin: .zero, size: CGSize(width: 1, height: 1)), animated: animated)
+        scrollView.scrollToTop(animated: animated)
+    }
+}
+
+extension UIScrollView {
+    func scrollToTop(animated: Bool) {
+        scrollRectToVisible(CGRect(origin: .zero, size: CGSize(width: 1, height: 1)), animated: animated)
     }
 }

--- a/Mastodon/Scene/Discovery/DiscoveryViewController.swift
+++ b/Mastodon/Scene/Discovery/DiscoveryViewController.swift
@@ -131,6 +131,13 @@ extension DiscoveryViewController: ScrollViewContainer {
     var scrollView: UIScrollView {
         return (currentViewController as? ScrollViewContainer)?.scrollView ?? UIScrollView()
     }
+    func scrollToTop(animated: Bool) {
+        if scrollView.contentOffset.y <= 0 {
+            scrollToPage(.first, animated: animated)
+        } else {
+            scrollView.scrollToTop(animated: animated)
+        }
+    }
 }
 
 extension DiscoveryViewController {

--- a/Mastodon/Scene/Search/Search/SearchViewController.swift
+++ b/Mastodon/Scene/Search/Search/SearchViewController.swift
@@ -190,6 +190,16 @@ extension SearchViewController: UISearchControllerDelegate {
     }
 }
 
+// MARK: - ScrollViewContainer
+extension SearchViewController: ScrollViewContainer {
+    var scrollView: UIScrollView {
+        discoveryViewController?.scrollView ?? UIScrollView()
+    }
+    func scrollToTop(animated: Bool) {
+        discoveryViewController?.scrollToTop(animated: animated)
+    }
+}
+
 // MARK: - UICollectionViewDelegate
 //extension SearchViewController: UICollectionViewDelegate {
 //    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {


### PR DESCRIPTION
When tapping on the 🔍 icon in the tab bar while it is selected, the current scroll view will be scrolled to the top. If it’s already at the top, the “Posts” tab will be selected. This matches how all the other tabs scroll to the top when their tab item is tapped again.

I grabbed the “scroll to first tab” behavior from Twitter but am also happy to remove it.