### PR TITLE
Mark sidebar cells as buttons

### DIFF
--- a/Mastodon/Scene/Root/Sidebar/SidebarViewModel.swift
+++ b/Mastodon/Scene/Root/Sidebar/SidebarViewModel.swift
@@ -141,6 +141,7 @@ extension SidebarViewModel {
             cell.setNeedsUpdateConfiguration()
             cell.isAccessibilityElement = true
             cell.accessibilityLabel = item.title
+            cell.accessibilityTraits.insert(.button)
         }
         
         // header


### PR DESCRIPTION
@<span>Marco@</span>tech.lgbt [pointed out](https://tech.lgbt/@Marco/109296496757761928) that the items in the sidebar are not properly identified as buttons, but said they’re otherwise fine. This PR adds the missing trait.

> [the compose button on iPad] sounds different than the iPhone one with VoiceOver, so may just need to receive the button trait.
> [me: can you still activate the button?]
> I can activate them just fine. So giving them the proper traits should be enough.

Note: I’m unable to test this because I don’t have an iPad, running Mastodon in the iPad simulator results in crashes, and VoiceOver doesn’t work directly in the simulator.