### PR TITLE
[Welcome] Allow buttons to grow with Dynamic Type.

### DIFF
--- a/Mastodon/Scene/Onboarding/Share/OnboardingViewControllerAppearance.swift
+++ b/Mastodon/Scene/Onboarding/Share/OnboardingViewControllerAppearance.swift
@@ -22,6 +22,10 @@ extension OnboardingViewControllerAppearance {
     static var actionButtonMarginExtend: CGFloat { return 80 }
     static var viewBottomPaddingHeight: CGFloat { return 11 }
     static var viewBottomPaddingHeightExtend: CGFloat { return 22 }
+
+    // Typically assigned to the button's contentEdgeInsets. Ensures space around content, even when
+    // content is large due to Dynamic Type.
+    static var actionButtonPadding: UIEdgeInsets { return UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8) }
     
     static var largeTitleFont: UIFont {
         return UIFontMetrics(forTextStyle: .largeTitle).scaledFont(for: .systemFont(ofSize: 28, weight: .bold))

--- a/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
@@ -51,6 +51,7 @@ final class WelcomeViewController: UIViewController, NeedsDependency {
     private(set) lazy var signUpButton: PrimaryActionButton = {
         let button = PrimaryActionButton()
         button.adjustsBackgroundImageWhenUserInterfaceStyleChanges = false
+        button.contentEdgeInsets = WelcomeViewController.actionButtonPadding
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.titleLabel?.font = UIFontMetrics(forTextStyle: .headline).scaledFont(for: .systemFont(ofSize: 17, weight: .semibold))
         button.setTitle(L10n.Common.Controls.Actions.signUp, for: .normal)
@@ -66,6 +67,7 @@ final class WelcomeViewController: UIViewController, NeedsDependency {
     private(set) lazy var signInButton: PrimaryActionButton = {
         let button = PrimaryActionButton()
         button.adjustsBackgroundImageWhenUserInterfaceStyleChanges = false
+        button.contentEdgeInsets = WelcomeViewController.actionButtonPadding
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.titleLabel?.font = UIFontMetrics(forTextStyle: .headline).scaledFont(for: .systemFont(ofSize: 17, weight: .semibold))
         button.setTitle(L10n.Scene.Welcome.logIn, for: .normal)

--- a/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
@@ -51,6 +51,7 @@ final class WelcomeViewController: UIViewController, NeedsDependency {
     private(set) lazy var signUpButton: PrimaryActionButton = {
         let button = PrimaryActionButton()
         button.adjustsBackgroundImageWhenUserInterfaceStyleChanges = false
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.titleLabel?.font = UIFontMetrics(forTextStyle: .headline).scaledFont(for: .systemFont(ofSize: 17, weight: .semibold))
         button.setTitle(L10n.Common.Controls.Actions.signUp, for: .normal)
         let backgroundImageColor: UIColor = .white
@@ -65,6 +66,7 @@ final class WelcomeViewController: UIViewController, NeedsDependency {
     private(set) lazy var signInButton: PrimaryActionButton = {
         let button = PrimaryActionButton()
         button.adjustsBackgroundImageWhenUserInterfaceStyleChanges = false
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.titleLabel?.font = UIFontMetrics(forTextStyle: .headline).scaledFont(for: .systemFont(ofSize: 17, weight: .semibold))
         button.setTitle(L10n.Scene.Welcome.logIn, for: .normal)
         let backgroundImageColor = Asset.Scene.Welcome.signInButtonBackground.color
@@ -113,12 +115,12 @@ extension WelcomeViewController {
         signUpButton.translatesAutoresizingMaskIntoConstraints = false
         buttonContainer.addArrangedSubview(signUpButton)
         NSLayoutConstraint.activate([
-            signUpButton.heightAnchor.constraint(equalToConstant: WelcomeViewController.actionButtonHeight).priority(.required - 1),
+            signUpButton.heightAnchor.constraint(greaterThanOrEqualToConstant: WelcomeViewController.actionButtonHeight).priority(.required - 1),
         ])
         signInButton.translatesAutoresizingMaskIntoConstraints = false
         buttonContainer.addArrangedSubview(signInButton)
         NSLayoutConstraint.activate([
-            signInButton.heightAnchor.constraint(equalToConstant: WelcomeViewController.actionButtonHeight).priority(.required - 1),
+            signInButton.heightAnchor.constraint(greaterThanOrEqualToConstant: WelcomeViewController.actionButtonHeight).priority(.required - 1),
         ])
         
         signUpButtonShadowView.translatesAutoresizingMaskIntoConstraints = false
@@ -172,7 +174,9 @@ extension WelcomeViewController {
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        
+
+        view.layoutIfNeeded()
+
         setupIllustrationLayout()
         setupButtonShadowView()
     }
@@ -189,7 +193,7 @@ extension WelcomeViewController {
             y: 1,
             blur: 2,
             spread: 0,
-            roundedRect: signInButtonShadowView.bounds,
+            roundedRect: signUpButtonShadowView.bounds,
             byRoundingCorners: .allCorners,
             cornerRadii: CGSize(width: 10, height: 10)
         )


### PR DESCRIPTION
The buttons now have a minimum height rather than a constant height. Note that this primarily affects larger Dynamic Type modes. Smaller modes than "Large" will not change the button's size; this ensures that the buttons have a reasonable tap target in all Dynamic Type configurations.

Also made a couple minor improvements / bug fixes:

- Both buttons now react to Dynamic Type settings changes (enabled `adjustsFontForContentSizeCategory`).
- A layout pass is now enforced in traitCollectionDidChange to ensure that setupButtonShadowView is using the right bounds. This also fixes a landscape layout shadow bug.
- signUpButtonShadowView now uses signUpButton's bounds.
- The buttons are now configured with contentEdgeInsets so that there's always adequate padding, even at the largest Dynamic Type configurations.

Part of https://github.com/mastodon/mastodon-ios/issues/191

| Dynamic Type | Before | After |
|:----|:----:|:---:|
| **AX5**: buttons are larger | ![The Mastodon welcome screen in AX5 mode. The button titles are partially clipped](https://user-images.githubusercontent.com/45670/201495794-e5340725-d85b-467b-9357-1ebe2e64e780.png) | ![The Mastodon welcome screen in AX5 mode. The buttons are slightly larger, affording more space for the button titles](https://user-images.githubusercontent.com/45670/201505738-135df0f3-61b9-4758-92da-b99d3a82d8bf.png) |
| **Large**: no changes | ![The Mastodon welcome screen at the default size](https://user-images.githubusercontent.com/45670/201505895-6a5c7d14-ed48-4ba6-9cc9-d441f83f2976.png) | ![The Mastodon welcome screen in the default size. There are no visual changes from before](https://user-images.githubusercontent.com/45670/201505922-af49a0fe-305c-41c9-9937-431d30266423.png) |
