### PR TITLE
Resolve build failure when running tests from Xcode.

### DIFF
--- a/MastodonTests/MastodonTests.swift
+++ b/MastodonTests/MastodonTests.swift
@@ -7,6 +7,7 @@
 
 import XCTest
 @testable import Mastodon
+import MastodonCore
 
 @MainActor
 class MastodonTests: XCTestCase {


### PR DESCRIPTION
The build failure was:

```
MastodonTests/MastodonTests.swift:39:27: error build: Cannot find 'AppContext' in scope
```