### PR TITLE
[Header] Scale the avatar behind the banner rather than fade it.

### DIFF
--- a/Mastodon/Scene/Profile/Header/ProfileHeaderViewController.swift
+++ b/Mastodon/Scene/Profile/Header/ProfileHeaderViewController.swift
@@ -255,9 +255,8 @@ extension ProfileHeaderViewController {
     }
 
     private func setProfileAvatar(alpha: CGFloat) {
-        profileHeaderView.avatarImageViewBackgroundView.alpha = alpha
-        profileHeaderView.avatarButton.alpha = alpha
-        profileHeaderView.editAvatarBackgroundView.alpha = alpha
+        let scale = max(0.5, alpha * 0.5 + 0.5)
+        profileHeaderView.avatarImageViewBackgroundView.transform = CGAffineTransform(scaleX: scale, y: scale)
     }
     
 }

--- a/Mastodon/Scene/Profile/Header/View/ProfileHeaderView.swift
+++ b/Mastodon/Scene/Profile/Header/View/ProfileHeaderView.swift
@@ -91,6 +91,7 @@ final class ProfileHeaderView: UIView {
         view.layer.cornerCurve = .continuous
         view.layer.borderColor = ProfileHeaderView.avatarImageViewBorderColor.cgColor
         view.layer.borderWidth = ProfileHeaderView.avatarImageViewBorderWidth
+        view.layer.anchorPoint = CGPointMake(0.5, 1)
         return view
     }()
     
@@ -382,7 +383,7 @@ extension ProfileHeaderView {
         dashboardContainer.addArrangedSubview(statusDashboardView)
         
         NSLayoutConstraint.activate([
-            avatarImageViewBackgroundView.bottomAnchor.constraint(equalTo: dashboardContainer.bottomAnchor),
+            avatarImageViewBackgroundView.bottomAnchor.constraint(equalTo: dashboardContainer.bottomAnchor, constant: ProfileHeaderView.avatarImageViewSize.height / 2),
         ])
         
         // authorContainer: H - [ nameContainer | padding | relationshipActionButtonShadowContainer ]

--- a/Mastodon/Scene/Profile/ProfileViewController.swift
+++ b/Mastodon/Scene/Profile/ProfileViewController.swift
@@ -631,12 +631,28 @@ extension ProfileViewController: TabBarPagerDelegate {
             } else {
                 profileHeaderViewController.profileHeaderView.followsYouMaskView.frame.origin.y = .zero
             }
-            
+
+            let avatarProgress: CGFloat
+            let bottomEdge = tabBarPagerController.containerScrollView.safeAreaInsets.top + ProfileHeaderView.avatarImageViewSize.height / 2
+            if bannerContainerBottomOffset < bottomEdge {
+                let offset = bannerContainerBottomOffset - bottomEdge
+                // the progress for header move from banner bottom to header bottom (from 0 to 1)
+                avatarProgress = height != .zero ? abs(offset) / height : 0
+            } else {
+                avatarProgress = 0
+            }
+
             // setup titleView offset and fade avatar
-            profileHeaderViewController.updateHeaderScrollProgress(progress, throttle: throttle)
+            profileHeaderViewController.updateHeaderScrollProgress(avatarProgress, throttle: throttle)
             
             // setup buttonBar shadow
             profilePagingViewController.updateButtonBarShadow(progress: progress)
+
+            if avatarProgress >= throttle {
+                profileHeaderViewController.profileHeaderView.sendSubviewToBack(profileHeaderViewController.profileHeaderView.avatarImageViewBackgroundView)
+            } else {
+                profileHeaderViewController.profileHeaderView.bringSubviewToFront(profileHeaderViewController.profileHeaderView.avatarImageViewBackgroundView)
+            }
         }
     }
     


### PR DESCRIPTION
This gives the transition a stronger sense of permanence while reducing the amount of alpha compositing needed for the transition.

## Before

Note how the avatar fades out.

https://user-images.githubusercontent.com/45670/201512676-17ba2287-66a8-4d5d-a623-6eeb687d27fc.mp4

## After

Note now how the avatar scales down to 50% before hiding "behind" the banner.

https://user-images.githubusercontent.com/45670/201512604-8a4e708d-6297-48d5-bd77-91ac9a6d2c54.mp4

