### PR TITLE
Feature: Display just published toots in the thread immediately

### DIFF
--- a/Mastodon/Scene/Compose/ComposeViewModel+PublishState.swift
+++ b/Mastodon/Scene/Compose/ComposeViewModel+PublishState.swift
@@ -138,6 +138,7 @@ extension ComposeViewModel.PublishState {
                     }
                 } receiveValue: { response in
                     os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s: status %s published: %s", ((#file as NSString).lastPathComponent), #line, #function, response.value.id, response.value.uri)
+                    self.viewModel?.publishedStatus = response.value
                 }
         }
     }

--- a/Mastodon/Scene/Compose/ComposeViewModel.swift
+++ b/Mastodon/Scene/Compose/ComposeViewModel.swift
@@ -16,6 +16,7 @@ import MastodonAsset
 import MastodonLocalization
 import MastodonMeta
 import MastodonUI
+import Tabman
 
 final class ComposeViewModel: NSObject {
     
@@ -44,6 +45,8 @@ final class ComposeViewModel: NSObject {
     var isViewAppeared = false
     
     // output
+    var publishedStatus: Mastodon.Entity.Status?
+    
     let instanceConfiguration: Mastodon.Entity.Instance.Configuration?
     var composeContentLimit: Int {
         guard let maxCharacters = instanceConfiguration?.statuses?.maxCharacters else { return 500 }
@@ -120,6 +123,7 @@ final class ComposeViewModel: NSObject {
         self.context = context
         self.composeKind = composeKind
         self.authenticationBox = authenticationBox
+        self.publishedStatus = nil
         self.title = {
             switch composeKind {
             case .post, .hashtag, .mention:       return L10n.Scene.Compose.Title.newPost

--- a/Mastodon/Scene/Thread/ThreadViewController.swift
+++ b/Mastodon/Scene/Thread/ThreadViewController.swift
@@ -97,6 +97,23 @@ extension ThreadViewController {
             tableView: tableView,
             statusTableViewCellDelegate: self
         )
+        
+        context.statusPublishService.latestPublishingComposeViewModel
+            .receive(on: DispatchQueue.main)
+            .sink { [self] composeViewModel in
+                guard let composeViewModel = composeViewModel else { return }
+                guard let publishedStatus = composeViewModel.publishedStatus else { return }
+                guard let threadContext = self.viewModel.threadContext else {return }
+                
+                self.viewModel.mastodonStatusThreadViewModel.appendDescendant(
+                    domain: threadContext.domain,
+                    nodes: MastodonStatusThreadViewModel.Node.children(
+                        of: threadContext.statusID,
+                        from: [publishedStatus]
+                    )
+                )
+            }
+            .store(in: &disposeBag)
     }
     
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Hello folks! Thanks for the app ❤️‍🔥 

I'm a recent migrant from twitter and noticed in one of my recent tootnamis that I had to recur to this tiny dance:

1. toot something
2. tap reply
3. toot again
4. go out and back in to the toot in step 1 to see my toot from step 3
5. repeat steps from step 2 

And this adds a ton of awkwardness when doing stream-of-consciousness writing. If this isn't a valid use-case that's fine, but if it should be, I'd love to help make it happen.

In this branch I've been toying around with the codebase, and I've managed to get a flow that looks like this: 

https://user-images.githubusercontent.com/854222/201650281-61ce99fe-571d-4962-a08a-32856d27875f.mov

Would this be a welcome addition? If so I'd be happy to get some pointers on how to actually get the data flowing in the right way, and fix some other bugs I've seen with it (like a reply not moving the current thread root, so if you tap to reply on your reply, it is hidden!).

In any case, it was fun doing this live and toot about it as I went along: https://mas.to/@leostera/109340850992406029