### PR TITLE
Fix authenticated user account not reloaded

### DIFF
--- a/Mastodon/Scene/Profile/ProfileViewController.swift
+++ b/Mastodon/Scene/Profile/ProfileViewController.swift
@@ -552,6 +552,9 @@ extension ProfileViewController {
             userTimelineViewController.viewModel.stateMachine.enter(UserTimelineViewModel.State.Reloading.self)
         }
 
+        // trigger authenticated user account update
+        viewModel.context.instanceService.updateActiveUserAccountPublisher.send()
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             sender.endRefreshing()
         }

--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -312,7 +312,12 @@ extension MainTabBarController {
             guard let profileTabItem = _profileTabItem else { return }
             let currentUserDisplayName = user.displayNameWithFallback ?? "no user"
             profileTabItem.accessibilityHint = L10n.Scene.AccountList.tabBarHint(currentUserDisplayName)
-            
+
+            context.instanceService.updateActiveUserAccountPublisher
+                .sink { [weak self] in
+                    self?.updateUserAccount()
+                }
+                .store(in: &disposeBag)
         } else {
             self.avatarURLObserver = nil
         }
@@ -487,6 +492,26 @@ extension MainTabBarController {
         avatarButton.setNeedsLayout()
     }
     
+    private func updateUserAccount() {
+        guard let authContext = authContext else { return }
+        
+        Task { @MainActor in
+            let profileResponse = try await context.apiService.authenticatedUserInfo(
+                authenticationBox: authContext.mastodonAuthenticationBox
+            )
+            
+            if let user = authContext.mastodonAuthenticationBox.authenticationRecord.object(
+                in: context.managedObjectContext
+            )?.user {
+                user.update(
+                    property: .init(
+                        entity: profileResponse.value,
+                        domain: authContext.mastodonAuthenticationBox.domain
+                    )
+                )
+            }
+        }
+    }
 }
 
 extension MainTabBarController {

--- a/Mastodon/Supporting Files/SceneDelegate.swift
+++ b/Mastodon/Supporting Files/SceneDelegate.swift
@@ -109,6 +109,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         // trigger status filter update
         AppContext.shared.statusFilterService.filterUpdatePublisher.send()
+        
+        // trigger authenticated user account update
+        AppContext.shared.instanceService.updateActiveUserAccountPublisher.send()
 
         if let shortcutItem = savedShortCutItem {
             Task {

--- a/MastodonSDK/Sources/MastodonCore/Extension/CoreDataStack/MastodonUser+Property.swift
+++ b/MastodonSDK/Sources/MastodonCore/Extension/CoreDataStack/MastodonUser+Property.swift
@@ -10,6 +10,10 @@ import CoreDataStack
 import MastodonSDK
 
 extension MastodonUser.Property {
+    public init(entity: Mastodon.Entity.Account, domain: String) {
+        self.init(entity: entity, domain: domain, networkDate: Date())
+    }
+    
     init(entity: Mastodon.Entity.Account, domain: String, networkDate: Date) {
         self.init(
             identifier: entity.id + "@" + domain,

--- a/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Account.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Account.swift
@@ -13,6 +13,15 @@ import MastodonCommon
 import MastodonSDK
 
 extension APIService {
+    public func authenticatedUserInfo(
+        authenticationBox: MastodonAuthenticationBox
+    ) async throws -> Mastodon.Response.Content<Mastodon.Entity.Account> {
+        try await accountInfo(
+            domain: authenticationBox.domain,
+            userID: authenticationBox.userID,
+            authorization: authenticationBox.userAuthorization
+        )
+    }
 
     public func accountInfo(
         domain: String,

--- a/MastodonSDK/Sources/MastodonCore/Service/InstanceService.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/InstanceService.swift
@@ -24,7 +24,8 @@ public final class InstanceService {
     weak var authenticationService: AuthenticationService?
     
     // output
-    
+    public let updateActiveUserAccountPublisher = PassthroughSubject<Void, Never>()
+
     init(
         apiService: APIService,
         authenticationService: AuthenticationService


### PR DESCRIPTION
# Rationale

Currently the user profile won't be reloaded and will still reflect old user data (display name, avatar) e.g. when restarting / coming from background / using pull to refresh on the profile screen.

This PR fixes the behavior, now the user profile is reloaded when:

* the app is coming to foreground
* the user uses pull to refresh in their profile

This is easily extendible by emitting an event to `InstanceService.updateActiveUserAccountPublisher`.

# Demo

![mastodon-profile-refresh-fix mov](https://user-images.githubusercontent.com/126418/201657818-342fbd6b-66f1-4be5-996e-a8e1cb39c093.gif)
