### PR TITLE
Replace a deprecated property

### DIFF
--- a/Mastodon/Scene/Search/SearchDetail/SearchDetailViewController.swift
+++ b/Mastodon/Scene/Search/SearchDetail/SearchDetailViewController.swift
@@ -60,7 +60,7 @@ final class SearchDetailViewController: PageboyViewController, NeedsDependency {
     let searchController: CustomSearchController = {
         let searchController = CustomSearchController()
         searchController.automaticallyShowsScopeBar = false
-        searchController.dimsBackgroundDuringPresentation = false
+        searchController.obscuresBackgroundDuringPresentation = false
         return searchController
     }()
     private(set) lazy var searchBar: UISearchBar = {


### PR DESCRIPTION
Hi,

This PR replaces the deprecated `dimsBackgroundDuringPresentation` property to resolve the following compiler warning:

```
'dimsBackgroundDuringPresentation' was deprecated in iOS 12.0
```

https://developer.apple.com/documentation/uikit/uisearchcontroller/1618660-dimsbackgroundduringpresentation