### PR TITLE
Add Account Toggle Indicator to make Account Switch Feature more obvious

### DIFF
--- a/Mastodon.xcodeproj/project.pbxproj
+++ b/Mastodon.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		164F0EBC267D4FE400249499 /* BoopSound.caf in Resources */ = {isa = PBXBuildFile; fileRef = 164F0EBB267D4FE400249499 /* BoopSound.caf */; };
 		18BC7629F65E6DB12CB8416D /* Pods_Mastodon_MastodonUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C030226D3C73DCC23D67452 /* Pods_Mastodon_MastodonUITests.framework */; };
 		2A82294F29262EE000D2A1F7 /* AppContext+NextAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A82294E29262EE000D2A1F7 /* AppContext+NextAccount.swift */; };
+		2AE244482927831100BDBF7C /* UIImage+SFSymbols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE244472927831100BDBF7C /* UIImage+SFSymbols.swift */; };
 		2D198643261BF09500F0B013 /* SearchResultItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D198642261BF09500F0B013 /* SearchResultItem.swift */; };
 		2D198649261C0B8500F0B013 /* SearchResultSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D198648261C0B8500F0B013 /* SearchResultSection.swift */; };
 		2D206B8625F5FB0900143C56 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D206B8525F5FB0900143C56 /* Double.swift */; };
@@ -520,6 +521,7 @@
 		164F0EBB267D4FE400249499 /* BoopSound.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = BoopSound.caf; sourceTree = "<group>"; };
 		1D6D967E77A5357E2C6110D9 /* Pods-Mastodon.asdk - debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mastodon.asdk - debug.xcconfig"; path = "Target Support Files/Pods-Mastodon/Pods-Mastodon.asdk - debug.xcconfig"; sourceTree = "<group>"; };
 		2A82294E29262EE000D2A1F7 /* AppContext+NextAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppContext+NextAccount.swift"; sourceTree = "<group>"; };
+		2AE244472927831100BDBF7C /* UIImage+SFSymbols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+SFSymbols.swift"; sourceTree = "<group>"; };
 		2D198642261BF09500F0B013 /* SearchResultItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultItem.swift; sourceTree = "<group>"; };
 		2D198648261C0B8500F0B013 /* SearchResultSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultSection.swift; sourceTree = "<group>"; };
 		2D206B8525F5FB0900143C56 /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
@@ -2244,6 +2246,7 @@
 				2D3F9E0325DFA133004262D9 /* UITapGestureRecognizer.swift */,
 				2D84350425FF858100EECE90 /* UIScrollView.swift */,
 				DB9E0D6E25EE008500CFDD76 /* UIInterpolatingMotionEffect.swift */,
+				2AE244472927831100BDBF7C /* UIImage+SFSymbols.swift */,
 				DBCC3B2F261440A50045B23D /* UITabBarController.swift */,
 				DB73BF4827140BA300781945 /* UICollectionViewDiffableDataSource.swift */,
 				DB73BF4A27140C0800781945 /* UITableViewDiffableDataSource.swift */,
@@ -3273,6 +3276,7 @@
 				DB73BF4927140BA300781945 /* UICollectionViewDiffableDataSource.swift in Sources */,
 				DBA5E7AB263BD3F5004598BB /* TimelineTableViewCellContextMenuConfiguration.swift in Sources */,
 				DB73B490261F030A002E9E9F /* SafariActivity.swift in Sources */,
+				2AE244482927831100BDBF7C /* UIImage+SFSymbols.swift in Sources */,
 				DB63F7492799126300455B82 /* FollowerListViewController+DataSourceProvider.swift in Sources */,
 				2D198643261BF09500F0B013 /* SearchResultItem.swift in Sources */,
 				2DAC9E38262FC2320062E1A6 /* SuggestionAccountViewController.swift in Sources */,

--- a/Mastodon/Extension/UIImage+SFSymbols.swift
+++ b/Mastodon/Extension/UIImage+SFSymbols.swift
@@ -1,0 +1,12 @@
+//
+//  UIImage+SFSymbols.swift
+//  Mastodon
+//
+//  Created by Marcus Kida on 18.11.22.
+//
+
+import UIKit
+
+extension UIImage {
+    static let chevronUpChevronDown = UIImage(systemName: "chevron.up.chevron.down")
+}

--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -43,7 +43,7 @@ class MainTabBarController: UITabBarController {
     
     static let avatarButtonSize = CGSize(width: 25, height: 25)
     let avatarButton = CircleAvatarButton()
-    private let accountToggleIndicator = UIImageView(image: UIImage(systemName: "chevron.up.chevron.down"))
+    let accountSwitcherChevron = UIImageView(image: .chevronUpChevronDown)
     
     @Published var currentTab: Tab = .home
         
@@ -507,8 +507,8 @@ extension MainTabBarController {
         }
         anchorImageView.alpha = 0
         
-        accountToggleIndicator.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(accountToggleIndicator)
+        accountSwitcherChevron.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(accountSwitcherChevron)
         
         self.avatarButton.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(self.avatarButton)
@@ -517,10 +517,10 @@ extension MainTabBarController {
             self.avatarButton.centerYAnchor.constraint(equalTo: anchorImageView.centerYAnchor),
             self.avatarButton.widthAnchor.constraint(equalToConstant: MainTabBarController.avatarButtonSize.width).priority(.required - 1),
             self.avatarButton.heightAnchor.constraint(equalToConstant: MainTabBarController.avatarButtonSize.height).priority(.required - 1),
-            accountToggleIndicator.widthAnchor.constraint(equalToConstant: 10),
-            accountToggleIndicator.heightAnchor.constraint(equalToConstant: 18),
-            accountToggleIndicator.leadingAnchor.constraint(equalTo: avatarButton.trailingAnchor, constant: 8),
-            accountToggleIndicator.centerYAnchor.constraint(equalTo: avatarButton.centerYAnchor)
+            accountSwitcherChevron.widthAnchor.constraint(equalToConstant: 10),
+            accountSwitcherChevron.heightAnchor.constraint(equalToConstant: 18),
+            accountSwitcherChevron.leadingAnchor.constraint(equalTo: avatarButton.trailingAnchor, constant: 8),
+            accountSwitcherChevron.centerYAnchor.constraint(equalTo: avatarButton.centerYAnchor)
         ])
         self.avatarButton.setContentHuggingPriority(.required - 1, for: .horizontal)
         self.avatarButton.setContentHuggingPriority(.required - 1, for: .vertical)
@@ -528,7 +528,7 @@ extension MainTabBarController {
     }
     
     private func updateAvatarButtonAppearance() {
-        accountToggleIndicator.tintColor = currentTab == .me ? .label : .secondaryLabel
+        accountSwitcherChevron.tintColor = currentTab == .me ? .label : .secondaryLabel
         avatarButton.borderColor = currentTab == .me ? .label : .systemFill
         avatarButton.setNeedsLayout()
     }

--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -43,6 +43,7 @@ class MainTabBarController: UITabBarController {
     
     static let avatarButtonSize = CGSize(width: 25, height: 25)
     let avatarButton = CircleAvatarButton()
+    let accountSwitcherChevron = UIImageView(image: UIImage(systemName: "chevron.up.chevron.down"))
     
     @Published var currentTab: Tab = .home
         
@@ -506,13 +507,20 @@ extension MainTabBarController {
         }
         anchorImageView.alpha = 0
         
+        accountSwitcherChevron.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(accountSwitcherChevron)
+        
         self.avatarButton.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(self.avatarButton)
         NSLayoutConstraint.activate([
-            self.avatarButton.centerXAnchor.constraint(equalTo: anchorImageView.centerXAnchor),
+            self.avatarButton.centerXAnchor.constraint(equalTo: anchorImageView.centerXAnchor, constant: -16),
             self.avatarButton.centerYAnchor.constraint(equalTo: anchorImageView.centerYAnchor),
             self.avatarButton.widthAnchor.constraint(equalToConstant: MainTabBarController.avatarButtonSize.width).priority(.required - 1),
             self.avatarButton.heightAnchor.constraint(equalToConstant: MainTabBarController.avatarButtonSize.height).priority(.required - 1),
+            accountSwitcherChevron.widthAnchor.constraint(equalToConstant: 10),
+            accountSwitcherChevron.heightAnchor.constraint(equalToConstant: 18),
+            accountSwitcherChevron.leadingAnchor.constraint(equalTo: avatarButton.trailingAnchor, constant: 8),
+            accountSwitcherChevron.centerYAnchor.constraint(equalTo: avatarButton.centerYAnchor)
         ])
         self.avatarButton.setContentHuggingPriority(.required - 1, for: .horizontal)
         self.avatarButton.setContentHuggingPriority(.required - 1, for: .vertical)
@@ -520,6 +528,7 @@ extension MainTabBarController {
     }
     
     private func updateAvatarButtonAppearance() {
+        accountSwitcherChevron.tintColor = currentTab == .me ? .label : .secondaryLabel
         avatarButton.borderColor = currentTab == .me ? .label : .systemFill
         avatarButton.setNeedsLayout()
     }

--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -43,7 +43,7 @@ class MainTabBarController: UITabBarController {
     
     static let avatarButtonSize = CGSize(width: 25, height: 25)
     let avatarButton = CircleAvatarButton()
-    let accountSwitcherChevron = UIImageView(image: UIImage(systemName: "chevron.up.chevron.down"))
+    private let accountToggleIndicator = UIImageView(image: UIImage(systemName: "chevron.up.chevron.down"))
     
     @Published var currentTab: Tab = .home
         
@@ -507,8 +507,8 @@ extension MainTabBarController {
         }
         anchorImageView.alpha = 0
         
-        accountSwitcherChevron.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(accountSwitcherChevron)
+        accountToggleIndicator.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(accountToggleIndicator)
         
         self.avatarButton.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(self.avatarButton)
@@ -517,10 +517,10 @@ extension MainTabBarController {
             self.avatarButton.centerYAnchor.constraint(equalTo: anchorImageView.centerYAnchor),
             self.avatarButton.widthAnchor.constraint(equalToConstant: MainTabBarController.avatarButtonSize.width).priority(.required - 1),
             self.avatarButton.heightAnchor.constraint(equalToConstant: MainTabBarController.avatarButtonSize.height).priority(.required - 1),
-            accountSwitcherChevron.widthAnchor.constraint(equalToConstant: 10),
-            accountSwitcherChevron.heightAnchor.constraint(equalToConstant: 18),
-            accountSwitcherChevron.leadingAnchor.constraint(equalTo: avatarButton.trailingAnchor, constant: 8),
-            accountSwitcherChevron.centerYAnchor.constraint(equalTo: avatarButton.centerYAnchor)
+            accountToggleIndicator.widthAnchor.constraint(equalToConstant: 10),
+            accountToggleIndicator.heightAnchor.constraint(equalToConstant: 18),
+            accountToggleIndicator.leadingAnchor.constraint(equalTo: avatarButton.trailingAnchor, constant: 8),
+            accountToggleIndicator.centerYAnchor.constraint(equalTo: avatarButton.centerYAnchor)
         ])
         self.avatarButton.setContentHuggingPriority(.required - 1, for: .horizontal)
         self.avatarButton.setContentHuggingPriority(.required - 1, for: .vertical)
@@ -528,7 +528,7 @@ extension MainTabBarController {
     }
     
     private func updateAvatarButtonAppearance() {
-        accountSwitcherChevron.tintColor = currentTab == .me ? .label : .secondaryLabel
+        accountToggleIndicator.tintColor = currentTab == .me ? .label : .secondaryLabel
         avatarButton.borderColor = currentTab == .me ? .label : .systemFill
         avatarButton.setNeedsLayout()
     }

--- a/Mastodon/Scene/Root/Sidebar/SidebarViewModel.swift
+++ b/Mastodon/Scene/Root/Sidebar/SidebarViewModel.swift
@@ -16,6 +16,9 @@ import MastodonCore
 import MastodonLocalization
 
 final class SidebarViewModel {
+    private enum Constants {
+        static let accountToggleIndicator = UIImage(systemName: "chevron.up.chevron.down")
+    }
     
     var disposeBag = Set<AnyCancellable>()
     
@@ -80,7 +83,7 @@ extension SidebarViewModel {
             }()
             cell.item = SidebarListContentView.Item(
                 isActive: false,
-                accessoryImage: item == .me ? UIImage(systemName: "chevron.up.chevron.down") : nil,
+                accessoryImage: item == .me ? Constants.accountToggleIndicator : nil,
                 title: item.title,
                 image: item.image,
                 activeImage: item.selectedImage,
@@ -167,7 +170,7 @@ extension SidebarViewModel {
             case .compose:
                 let item = SidebarListContentView.Item(
                     isActive: false,
-                    accessoryImage: self.currentTab == .me ? UIImage(systemName: "chevron.up.chevron.down") : nil,
+                    accessoryImage: self.currentTab == .me ? Constants.accountToggleIndicator : nil,
                     title: L10n.Common.Controls.Actions.compose,
                     image: Asset.ObjectsAndTools.squareAndPencil.image.withRenderingMode(.alwaysTemplate),
                     activeImage: Asset.ObjectsAndTools.squareAndPencil.image.withRenderingMode(.alwaysTemplate),

--- a/Mastodon/Scene/Root/Sidebar/SidebarViewModel.swift
+++ b/Mastodon/Scene/Root/Sidebar/SidebarViewModel.swift
@@ -80,7 +80,7 @@ extension SidebarViewModel {
             }()
             cell.item = SidebarListContentView.Item(
                 isActive: false,
-                showAccountSwitcher: item == .me,
+                accessoryImage: item == .me ? UIImage(systemName: "chevron.up.chevron.down") : nil,
                 title: item.title,
                 image: item.image,
                 activeImage: item.selectedImage,
@@ -158,7 +158,6 @@ extension SidebarViewModel {
             case .setting:
                 let item = SidebarListContentView.Item(
                     isActive: false,
-                    showAccountSwitcher: false,
                     title: L10n.Common.Controls.Actions.settings,
                     image: Asset.ObjectsAndTools.gear.image.withRenderingMode(.alwaysTemplate),
                     activeImage: Asset.ObjectsAndTools.gear.image.withRenderingMode(.alwaysTemplate),
@@ -168,7 +167,7 @@ extension SidebarViewModel {
             case .compose:
                 let item = SidebarListContentView.Item(
                     isActive: false,
-                    showAccountSwitcher: self.currentTab == .me,
+                    accessoryImage: self.currentTab == .me ? UIImage(systemName: "chevron.up.chevron.down") : nil,
                     title: L10n.Common.Controls.Actions.compose,
                     image: Asset.ObjectsAndTools.squareAndPencil.image.withRenderingMode(.alwaysTemplate),
                     activeImage: Asset.ObjectsAndTools.squareAndPencil.image.withRenderingMode(.alwaysTemplate),
@@ -216,7 +215,6 @@ extension SidebarViewModel {
             
             let item = SidebarListContentView.Item(
                 isActive: false,
-                showAccountSwitcher: false,
                 title: L10n.Common.Controls.Actions.compose,
                 image: Asset.ObjectsAndTools.squareAndPencil.image.withRenderingMode(.alwaysTemplate),
                 activeImage: Asset.ObjectsAndTools.squareAndPencil.image.withRenderingMode(.alwaysTemplate),

--- a/Mastodon/Scene/Root/Sidebar/SidebarViewModel.swift
+++ b/Mastodon/Scene/Root/Sidebar/SidebarViewModel.swift
@@ -80,6 +80,7 @@ extension SidebarViewModel {
             }()
             cell.item = SidebarListContentView.Item(
                 isActive: false,
+                showAccountSwitcher: item == .me,
                 title: item.title,
                 image: item.image,
                 activeImage: item.selectedImage,
@@ -157,6 +158,7 @@ extension SidebarViewModel {
             case .setting:
                 let item = SidebarListContentView.Item(
                     isActive: false,
+                    showAccountSwitcher: false,
                     title: L10n.Common.Controls.Actions.settings,
                     image: Asset.ObjectsAndTools.gear.image.withRenderingMode(.alwaysTemplate),
                     activeImage: Asset.ObjectsAndTools.gear.image.withRenderingMode(.alwaysTemplate),
@@ -166,6 +168,7 @@ extension SidebarViewModel {
             case .compose:
                 let item = SidebarListContentView.Item(
                     isActive: false,
+                    showAccountSwitcher: self.currentTab == .me,
                     title: L10n.Common.Controls.Actions.compose,
                     image: Asset.ObjectsAndTools.squareAndPencil.image.withRenderingMode(.alwaysTemplate),
                     activeImage: Asset.ObjectsAndTools.squareAndPencil.image.withRenderingMode(.alwaysTemplate),
@@ -213,6 +216,7 @@ extension SidebarViewModel {
             
             let item = SidebarListContentView.Item(
                 isActive: false,
+                showAccountSwitcher: false,
                 title: L10n.Common.Controls.Actions.compose,
                 image: Asset.ObjectsAndTools.squareAndPencil.image.withRenderingMode(.alwaysTemplate),
                 activeImage: Asset.ObjectsAndTools.squareAndPencil.image.withRenderingMode(.alwaysTemplate),

--- a/Mastodon/Scene/Root/Sidebar/SidebarViewModel.swift
+++ b/Mastodon/Scene/Root/Sidebar/SidebarViewModel.swift
@@ -16,10 +16,6 @@ import MastodonCore
 import MastodonLocalization
 
 final class SidebarViewModel {
-    private enum Constants {
-        static let accountToggleIndicator = UIImage(systemName: "chevron.up.chevron.down")
-    }
-    
     var disposeBag = Set<AnyCancellable>()
     
     // input
@@ -83,7 +79,7 @@ extension SidebarViewModel {
             }()
             cell.item = SidebarListContentView.Item(
                 isActive: false,
-                accessoryImage: item == .me ? Constants.accountToggleIndicator : nil,
+                accessoryImage: item == .me ? .chevronUpChevronDown : nil,
                 title: item.title,
                 image: item.image,
                 activeImage: item.selectedImage,
@@ -170,7 +166,7 @@ extension SidebarViewModel {
             case .compose:
                 let item = SidebarListContentView.Item(
                     isActive: false,
-                    accessoryImage: self.currentTab == .me ? Constants.accountToggleIndicator : nil,
+                    accessoryImage: self.currentTab == .me ? .chevronUpChevronDown : nil,
                     title: L10n.Common.Controls.Actions.compose,
                     image: Asset.ObjectsAndTools.squareAndPencil.image.withRenderingMode(.alwaysTemplate),
                     activeImage: Asset.ObjectsAndTools.squareAndPencil.image.withRenderingMode(.alwaysTemplate),

--- a/Mastodon/Scene/Root/Sidebar/View/SidebarListContentView.swift
+++ b/Mastodon/Scene/Root/Sidebar/View/SidebarListContentView.swift
@@ -23,7 +23,7 @@ final class SidebarListContentView: UIView, UIContentView {
         button.borderColor = UIColor.label
         return button
     }()
-    private let accountToggleIndicator = UIImageView(image: UIImage(systemName: "chevron.up.chevron.down"))
+    private let accessoryImageView = UIImageView(image: nil)
 
     private var currentConfiguration: ContentConfiguration!
     var configuration: UIContentConfiguration {
@@ -62,8 +62,8 @@ extension SidebarListContentView {
             imageView.heightAnchor.constraint(equalToConstant: 40).priority(.required - 1),
         ])
         
-        accountToggleIndicator.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(accountToggleIndicator)
+        accessoryImageView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(accessoryImageView)
 
         avatarButton.translatesAutoresizingMaskIntoConstraints = false
         addSubview(avatarButton)
@@ -72,10 +72,10 @@ extension SidebarListContentView {
             avatarButton.centerYAnchor.constraint(equalTo: imageView.centerYAnchor),
             avatarButton.widthAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: 1.0).priority(.required - 2),
             avatarButton.heightAnchor.constraint(equalTo: imageView.heightAnchor, multiplier: 1.0).priority(.required - 2),
-            accountToggleIndicator.widthAnchor.constraint(equalToConstant: 12),
-            accountToggleIndicator.heightAnchor.constraint(equalToConstant: 22),
-            accountToggleIndicator.leadingAnchor.constraint(equalTo: avatarButton.trailingAnchor, constant: 4),
-            accountToggleIndicator.centerYAnchor.constraint(equalTo: avatarButton.centerYAnchor)
+            accessoryImageView.widthAnchor.constraint(equalToConstant: 12),
+            accessoryImageView.heightAnchor.constraint(equalToConstant: 22),
+            accessoryImageView.leadingAnchor.constraint(equalTo: avatarButton.trailingAnchor, constant: 4),
+            accessoryImageView.centerYAnchor.constraint(equalTo: avatarButton.centerYAnchor)
         ])
         avatarButton.setContentHuggingPriority(.defaultLow - 10, for: .vertical)
         avatarButton.setContentHuggingPriority(.defaultLow - 10, for: .horizontal)
@@ -104,8 +104,9 @@ extension SidebarListContentView {
         imageView.isHidden = item.imageURL != nil
         avatarButton.isHidden = item.imageURL == nil
         imageView.image = item.isActive ? item.activeImage.withRenderingMode(.alwaysTemplate) : item.image.withRenderingMode(.alwaysTemplate)
-        accountToggleIndicator.isHidden = !item.showAccountSwitcher
-        accountToggleIndicator.tintColor = item.isActive ? .label : .secondaryLabel
+        accessoryImageView.image = item.accessoryImage
+        accessoryImageView.isHidden = item.accessoryImage == nil
+        accessoryImageView.tintColor = item.isActive ? .label : .secondaryLabel
         avatarButton.avatarImageView.setImage(
             url: item.imageURL,
             placeholder: avatarButton.avatarImageView.image ?? .placeholder(color: .systemFill),  // reuse to avoid blink
@@ -122,7 +123,7 @@ extension SidebarListContentView {
         var isSelected: Bool = false
         var isHighlighted: Bool = false
         var isActive: Bool
-        var showAccountSwitcher: Bool
+        var accessoryImage: UIImage? = nil
 
         // model
         let title: String
@@ -135,7 +136,7 @@ extension SidebarListContentView {
             return lhs.isSelected == rhs.isSelected
                 && lhs.isHighlighted == rhs.isHighlighted
                 && lhs.isActive == rhs.isActive
-                && lhs.showAccountSwitcher == rhs.showAccountSwitcher
+                && lhs.accessoryImage == rhs.accessoryImage
                 && lhs.title == rhs.title
                 && lhs.image == rhs.image
                 && lhs.activeImage == rhs.activeImage
@@ -146,7 +147,7 @@ extension SidebarListContentView {
             hasher.combine(isSelected)
             hasher.combine(isHighlighted)
             hasher.combine(isActive)
-            hasher.combine(showAccountSwitcher)
+            hasher.combine(accessoryImage)
             hasher.combine(title)
             hasher.combine(image)
             hasher.combine(activeImage)

--- a/Mastodon/Scene/Root/Sidebar/View/SidebarListContentView.swift
+++ b/Mastodon/Scene/Root/Sidebar/View/SidebarListContentView.swift
@@ -23,7 +23,8 @@ final class SidebarListContentView: UIView, UIContentView {
         button.borderColor = UIColor.label
         return button
     }()
-    
+    let accountSwitcherChevron = UIImageView(image: UIImage(systemName: "chevron.up.chevron.down"))
+
     private var currentConfiguration: ContentConfiguration!
     var configuration: UIContentConfiguration {
         get {
@@ -60,6 +61,9 @@ extension SidebarListContentView {
             imageView.widthAnchor.constraint(equalToConstant: 40).priority(.required - 1),
             imageView.heightAnchor.constraint(equalToConstant: 40).priority(.required - 1),
         ])
+        
+        accountSwitcherChevron.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(accountSwitcherChevron)
 
         avatarButton.translatesAutoresizingMaskIntoConstraints = false
         addSubview(avatarButton)
@@ -68,6 +72,10 @@ extension SidebarListContentView {
             avatarButton.centerYAnchor.constraint(equalTo: imageView.centerYAnchor),
             avatarButton.widthAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: 1.0).priority(.required - 2),
             avatarButton.heightAnchor.constraint(equalTo: imageView.heightAnchor, multiplier: 1.0).priority(.required - 2),
+            accountSwitcherChevron.widthAnchor.constraint(equalToConstant: 12),
+            accountSwitcherChevron.heightAnchor.constraint(equalToConstant: 22),
+            accountSwitcherChevron.leadingAnchor.constraint(equalTo: avatarButton.trailingAnchor, constant: 4),
+            accountSwitcherChevron.centerYAnchor.constraint(equalTo: avatarButton.centerYAnchor)
         ])
         avatarButton.setContentHuggingPriority(.defaultLow - 10, for: .vertical)
         avatarButton.setContentHuggingPriority(.defaultLow - 10, for: .horizontal)
@@ -96,6 +104,8 @@ extension SidebarListContentView {
         imageView.isHidden = item.imageURL != nil
         avatarButton.isHidden = item.imageURL == nil
         imageView.image = item.isActive ? item.activeImage.withRenderingMode(.alwaysTemplate) : item.image.withRenderingMode(.alwaysTemplate)
+        accountSwitcherChevron.isHidden = !item.showAccountSwitcher
+        accountSwitcherChevron.tintColor = item.isActive ? .label : .secondaryLabel
         avatarButton.avatarImageView.setImage(
             url: item.imageURL,
             placeholder: avatarButton.avatarImageView.image ?? .placeholder(color: .systemFill),  // reuse to avoid blink
@@ -112,7 +122,8 @@ extension SidebarListContentView {
         var isSelected: Bool = false
         var isHighlighted: Bool = false
         var isActive: Bool
-        
+        var showAccountSwitcher: Bool
+
         // model
         let title: String
         var image: UIImage
@@ -124,6 +135,7 @@ extension SidebarListContentView {
             return lhs.isSelected == rhs.isSelected
                 && lhs.isHighlighted == rhs.isHighlighted
                 && lhs.isActive == rhs.isActive
+                && lhs.showAccountSwitcher == rhs.showAccountSwitcher
                 && lhs.title == rhs.title
                 && lhs.image == rhs.image
                 && lhs.activeImage == rhs.activeImage
@@ -134,6 +146,7 @@ extension SidebarListContentView {
             hasher.combine(isSelected)
             hasher.combine(isHighlighted)
             hasher.combine(isActive)
+            hasher.combine(showAccountSwitcher)
             hasher.combine(title)
             hasher.combine(image)
             hasher.combine(activeImage)

--- a/Mastodon/Scene/Root/Sidebar/View/SidebarListContentView.swift
+++ b/Mastodon/Scene/Root/Sidebar/View/SidebarListContentView.swift
@@ -23,7 +23,7 @@ final class SidebarListContentView: UIView, UIContentView {
         button.borderColor = UIColor.label
         return button
     }()
-    let accountSwitcherChevron = UIImageView(image: UIImage(systemName: "chevron.up.chevron.down"))
+    private let accountToggleIndicator = UIImageView(image: UIImage(systemName: "chevron.up.chevron.down"))
 
     private var currentConfiguration: ContentConfiguration!
     var configuration: UIContentConfiguration {
@@ -62,8 +62,8 @@ extension SidebarListContentView {
             imageView.heightAnchor.constraint(equalToConstant: 40).priority(.required - 1),
         ])
         
-        accountSwitcherChevron.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(accountSwitcherChevron)
+        accountToggleIndicator.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(accountToggleIndicator)
 
         avatarButton.translatesAutoresizingMaskIntoConstraints = false
         addSubview(avatarButton)
@@ -72,10 +72,10 @@ extension SidebarListContentView {
             avatarButton.centerYAnchor.constraint(equalTo: imageView.centerYAnchor),
             avatarButton.widthAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: 1.0).priority(.required - 2),
             avatarButton.heightAnchor.constraint(equalTo: imageView.heightAnchor, multiplier: 1.0).priority(.required - 2),
-            accountSwitcherChevron.widthAnchor.constraint(equalToConstant: 12),
-            accountSwitcherChevron.heightAnchor.constraint(equalToConstant: 22),
-            accountSwitcherChevron.leadingAnchor.constraint(equalTo: avatarButton.trailingAnchor, constant: 4),
-            accountSwitcherChevron.centerYAnchor.constraint(equalTo: avatarButton.centerYAnchor)
+            accountToggleIndicator.widthAnchor.constraint(equalToConstant: 12),
+            accountToggleIndicator.heightAnchor.constraint(equalToConstant: 22),
+            accountToggleIndicator.leadingAnchor.constraint(equalTo: avatarButton.trailingAnchor, constant: 4),
+            accountToggleIndicator.centerYAnchor.constraint(equalTo: avatarButton.centerYAnchor)
         ])
         avatarButton.setContentHuggingPriority(.defaultLow - 10, for: .vertical)
         avatarButton.setContentHuggingPriority(.defaultLow - 10, for: .horizontal)
@@ -104,8 +104,8 @@ extension SidebarListContentView {
         imageView.isHidden = item.imageURL != nil
         avatarButton.isHidden = item.imageURL == nil
         imageView.image = item.isActive ? item.activeImage.withRenderingMode(.alwaysTemplate) : item.image.withRenderingMode(.alwaysTemplate)
-        accountSwitcherChevron.isHidden = !item.showAccountSwitcher
-        accountSwitcherChevron.tintColor = item.isActive ? .label : .secondaryLabel
+        accountToggleIndicator.isHidden = !item.showAccountSwitcher
+        accountToggleIndicator.tintColor = item.isActive ? .label : .secondaryLabel
         avatarButton.avatarImageView.setImage(
             url: item.imageURL,
             placeholder: avatarButton.avatarImageView.image ?? .placeholder(color: .systemFill),  // reuse to avoid blink


### PR DESCRIPTION
# Rationale

The aim is to make the account toggle feature more discoverable by showing a visual indicator to the user.

## iPhone

| iPhone, Light Appearance, Deselected | iPhone Light Appearance, Selected |
|---|---|
|![RocketSim_Screenshot_iPhone_14_Pro_2022-11-15_13 50 22](https://user-images.githubusercontent.com/126418/201929287-d8a97e0b-d852-4777-a2f2-0c44833be4e2.png)|![RocketSim_Screenshot_iPhone_14_Pro_2022-11-15_13 50 26](https://user-images.githubusercontent.com/126418/201929292-624f64d0-ef15-4c2d-bb8d-e2e8c5d3ad8a.png)|

| iPhone Dark Appearance, Deselected | iPhone Dark Appearance, Selected |
|---|---|
|![RocketSim_Screenshot_iPhone_14_Pro_2022-11-15_13 50 01](https://user-images.githubusercontent.com/126418/201929417-dbb08dbd-df46-4745-9025-55bac8a7a6fa.png)|![RocketSim_Screenshot_iPhone_14_Pro_2022-11-15_13 50 07](https://user-images.githubusercontent.com/126418/201929413-0a523f08-f6eb-480b-9c8e-8b4c78b03b9e.png)|

## iPad

| iPad, Light Appearance, Deselected | iPad, Light Appearance, Selected |
|---|---|
|![RocketSim_Screenshot_iPad_Pro_(11-inch)_(3rd_generation)_2022-11-15_13 48 58](https://user-images.githubusercontent.com/126418/201929682-e9458d8a-7fde-4c1d-a0be-0c4f2cc35fac.png)|![RocketSim_Screenshot_iPad_Pro_(11-inch)_(3rd_generation)_2022-11-15_13 49 04](https://user-images.githubusercontent.com/126418/201929674-037bcd0b-3de6-4d25-b71d-da57a24127e1.png)|

| iPad, Dark Appearance, Deselected | iPad, Dark Appearance, Selected |
|---|---|
| ![RocketSim_Screenshot_iPad_Pro_(11-inch)_(3rd_generation)_2022-11-15_13 48 08](https://user-images.githubusercontent.com/126418/201929916-dfe05e99-861f-4095-abcc-6961ec944305.png)|![RocketSim_Screenshot_iPad_Pro_(11-inch)_(3rd_generation)_2022-11-15_13 48 32](https://user-images.githubusercontent.com/126418/201929921-21726700-a059-4c0b-9b08-199ff5343600.png)|

