### PR TITLE
Improve media inline appearance

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/View/ComposeContentView.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/View/ComposeContentView.swift
@@ -222,13 +222,17 @@ extension ComposeContentView {
         VStack(spacing: 16) {
             ForEach(viewModel.attachmentViewModels, id: \.self) { attachmentViewModel in
                 AttachmentView(viewModel: attachmentViewModel)
-                    .clipShape(Rectangle())
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
                     .badgeView(
                         Button {
                             viewModel.attachmentViewModels.removeAll(where: { $0 === attachmentViewModel })
                         } label: {
                             Image(systemName: "minus.circle.fill")
+                                .resizable()
+                                .frame(width: 20, height: 20)
                                 .foregroundColor(.red)
+                                .background(Color.white)
+                                .clipShape(Circle())
                         }
                     )
             }   // end ForEach


### PR DESCRIPTION
# Rationale

Adds rounded corners and fixes transparency (uploaded media was slightly visible through cut-out of stop-sign) glitch on "delete" button. Also size of delete button has been adjusted to 20pt as per design.

# Screenshots

| Before | After |
|---|---|
| ![IMG_0023](https://user-images.githubusercontent.com/126418/201948752-2908ffbd-9101-4fb7-b0ee-afac4be1238f.PNG)| ![IMG_0027](https://user-images.githubusercontent.com/126418/201948793-2535ef76-ce08-4bd3-aa6a-53f06d1265c6.PNG)|
