### PR TITLE
Add punycode support to the server search box

### DIFF
--- a/Mastodon/Scene/Onboarding/Share/AuthenticationViewModel.swift
+++ b/Mastodon/Scene/Onboarding/Share/AuthenticationViewModel.swift
@@ -66,9 +66,19 @@ extension AuthenticationViewModel {
     static func parseDomain(from input: String) -> String? {
         let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !trimmed.isEmpty else { return nil }
-        
-        let urlString = trimmed.hasPrefix("https://") ? trimmed : "https://" + trimmed
-        guard let url = URL(string: urlString),
+
+        let https = "https://"
+        let http = "http://"
+        var isHTTPS = true
+        let urlString = trimmed.hasPrefix(https) ? String(trimmed.dropFirst(https.count)) : {
+            if trimmed.hasPrefix(http) {
+                isHTTPS = false
+                return String(trimmed.dropFirst(http.count))
+            }
+            return trimmed
+        }()
+        let encodedHost = urlString.split(separator: ".").map(Punycode.encode).joined(separator: ".")
+        guard let url = URL(string: (isHTTPS ? https : http) + encodedHost),
               let host = url.host else {
             return nil
         }

--- a/MastodonSDK/Sources/MastodonCore/Service/Punycode.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/Punycode.swift
@@ -1,0 +1,85 @@
+//
+//  Punycode.swift
+//  
+//
+//  Created by Jed Fox on 2022-11-15.
+//
+
+import Foundation
+
+public enum Punycode {
+    // https://datatracker.ietf.org/doc/html/rfc3492#section-5
+    private static let base         = UInt32(36)
+    private static let tmin         = UInt32(1)
+    private static let tmax         = UInt32(26)
+    private static let skew         = UInt32(38)
+    private static let damp         = UInt32(700)
+    private static let initial_bias = UInt32(72)
+    private static let initial_n    = UInt32(128) // = 0x80
+
+    private static let digits: [String] = "abcdefghijklmnopqrstuvwxyz0123456789".map { String($0) }
+
+    public static func encode(_ input: String) -> String {
+        let codePoints = input.unicodeScalars
+        let basicCodePoints = codePoints.filter(\.isASCII)
+        let codePointsSorted = codePoints.map(\.value).sorted()
+        if basicCodePoints.count == codePoints.count { return input }
+
+        // https://datatracker.ietf.org/doc/html/rfc3492#section-6.3
+        // [Swift fails on overflow already, so no special consideration necessary]
+        var n = initial_n
+        var delta = UInt32(0)
+        var bias = initial_bias
+        // the number of basic code points in the input
+        let b = UInt32(basicCodePoints.count)
+        var h = b
+        // copy them to the output in order, followed by a delimiter if b > 0
+        var output = "xn--" + String(basicCodePoints)
+        if b > 0 {
+            output += "-"
+        }
+
+        while h < codePoints.count {
+            // the minimum code point >= n in the input
+            let m = codePointsSorted.first(where: { $0 >= n })!
+            delta = delta + (m - n) * (h + 1)
+            n = m
+            for codePoint in codePoints {
+                let c = codePoint.value
+                if c < n || codePoint.isASCII {
+                    delta += 1
+                }
+                if c == n {
+                    var q = delta
+                    var k = base
+                    repeat {
+                        let t = k <= bias + tmin ? tmin : (k >= bias + tmax ? tmax : k - bias)
+                        if q < t { break }
+                        output += digits[Int(t + ((q - t) % (base - t)))]
+                        q = (q - t) / (base - t)
+                        k += base
+                    } while true
+                    output += digits[Int(q)]
+                    bias = adapt(delta, h + 1, h == b)
+                    delta = 0
+                    h += 1
+                }
+            }
+            delta += 1
+            n += 1
+        }
+        return output
+    }
+
+    // https://datatracker.ietf.org/doc/html/rfc3492#section-6.1
+    private static func adapt(_ delta: UInt32, _ numpoints: UInt32, _ firsttime: Bool) -> UInt32 {
+        var delta = firsttime ? delta / damp : delta / 2
+        delta = delta + (delta / numpoints)
+        var k = UInt32(0)
+        while delta > ((base - tmin) * tmax) / 2 {
+            delta = delta / (base - tmin)
+            k = k + base
+        }
+        return k + (((base - tmin + 1) * delta) / (delta + skew))
+    }
+}

--- a/MastodonSDK/Sources/MastodonCore/Service/Punycode.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/Punycode.swift
@@ -19,11 +19,11 @@ public enum Punycode {
 
     private static let digits: [String] = "abcdefghijklmnopqrstuvwxyz0123456789".map { String($0) }
 
-    public static func encode(_ input: String) -> String {
+    public static func encode<S: StringProtocol>(_ input: S) -> String {
         let codePoints = input.unicodeScalars
-        let basicCodePoints = codePoints.filter(\.isASCII)
+        let basicCodePoints = String.UnicodeScalarView(codePoints.filter(\.isASCII))
         let codePointsSorted = codePoints.map(\.value).sorted()
-        if basicCodePoints.count == codePoints.count { return input }
+        if basicCodePoints.count == codePoints.count { return String(input) }
 
         // https://datatracker.ietf.org/doc/html/rfc3492#section-6.3
         // [Swift fails on overflow already, so no special consideration necessary]


### PR DESCRIPTION
Fixes #429. I chose to only implement support for showing non-internationalized domains so I don’t have to wade into the issue of disambiguating forged domains (like `mаstodon.social` / `xn--mstodon-2fg.social`). Still open is the question of how IDN domains on the official list will be handled. Ideally they’d be displayed in a more human-friendly way (since a human has verified that they’re not a scam) but that will have to be handled later when it actually happens.

<img width=390 src=https://user-images.githubusercontent.com/25517624/202013537-c1da8a8a-b480-416a-bb44-6fa856a3e102.png>
