### PR TITLE
feat: Implement double-tap on profile Tab to quickly cycle through logged in Accounts

### DIFF
--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -407,7 +407,7 @@ extension MainTabBarController {
             assert(Thread.isMainThread)
 
             let request = MastodonAuthentication.sortedFetchRequest
-            guard let accounts = try? context.managedObjectContext.fetch(request) else { return }
+            guard let accounts = try? context.managedObjectContext.fetch(request), accounts.count > 1 else { return }
             
             let nextSelectedAccountIndex: Int? = {
                 for (index, account) in accounts.enumerated() {


### PR DESCRIPTION
# Rationale

Enable double-tap gesture on Profile-Tab to allow user to cycle through logged in accounts. Long-Press gesture is usable as well.

**I've pointed this PR towards `release-1.4.7`**

# Demo

https://user-images.githubusercontent.com/126418/202175062-bd6e7fe0-d67d-46fb-a927-f855607ed0af.mp4

