### PR TITLE
fix: Local user's domain is shown for remote users when sharing a post

### DIFF
--- a/Mastodon/Protocol/Provider/DataSourceFacade+Status.swift
+++ b/Mastodon/Protocol/Provider/DataSourceFacade+Status.swift
@@ -84,7 +84,7 @@ extension DataSourceFacade {
             self.url = url
             self.metadata = LPLinkMetadata()
             metadata.url = url
-            metadata.title = "\(status.author.displayName) (@\(status.author.username)@\(status.author.domain))"
+            metadata.title = "\(status.author.displayName) (@\(status.author.acctWithDomain))"
             metadata.iconProvider = NSItemProvider(object: IconProvider(url: status.author.avatarImageURLWithFallback(domain: status.author.domain)))
         }
 


### PR DESCRIPTION
# Rationale

Fixes a bug where a wrong domain is shown on next to the shared user's post on the share sheet.