### PR TITLE
Fix Video Player Constraints issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,9 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-21
+  x86_64-darwin-22
 
 DEPENDENCIES
   arkana

--- a/Mastodon/Scene/MediaPreview/Video/MediaPreviewVideoViewController.swift
+++ b/Mastodon/Scene/MediaPreview/Video/MediaPreviewVideoViewController.swift
@@ -45,7 +45,6 @@ extension MediaPreviewVideoViewController {
             playerViewController.view.widthAnchor.constraint(equalTo: view.widthAnchor),
             playerViewController.view.heightAnchor.constraint(equalTo: view.heightAnchor),
         ])
-        playerViewController.didMove(toParent: self)
         
         if let contentOverlayView = playerViewController.contentOverlayView {
             previewImageView.translatesAutoresizingMaskIntoConstraints = false
@@ -88,6 +87,12 @@ extension MediaPreviewVideoViewController {
                 }
                 .store(in: &disposeBag)
         }
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        playerViewController.didMove(toParent: self)
     }
     
 }

--- a/MastodonSDK/Sources/MastodonCore/Service/API/APIService+APIError.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/API/APIService+APIError.swift
@@ -43,7 +43,7 @@ extension APIService.APIError: LocalizedError {
     
     public var errorDescription: String? {
         switch errorReason {
-        case .authenticationMissing:        return "Fail to Authenticatie"
+        case .authenticationMissing:        return "Fail to Authenticate"
         case .badRequest:                   return "Bad Request"
         case .badResponse:                  return "Bad Response"
         case .requestThrottle:              return "Request Throttled"


### PR DESCRIPTION
When viewing videos some controls are overlapping the safe area insets.
For now it is sufficient to move the `didMove` to `viewDidLayoutSubviews`.
I would also like to enable PIP and auto rotation in an upcoming PR.

| before | after |
|--------|------|
|  <img width="444" alt="Screenshot 2022-11-17 at 14 24 58" src="https://user-images.githubusercontent.com/4242986/202364120-4d2cc7ab-b96f-48ea-926a-34a809903be1.png"> | <img width="413" alt="Screenshot 2022-11-17 at 14 23 54" src="https://user-images.githubusercontent.com/4242986/202364129-a2c490b7-674e-45f8-a557-3c995df3de05.png"> | 