### PR TITLE
fix: TabBar has noticeable delay when selecting next tab

### DIFF
--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -329,6 +329,7 @@ extension MainTabBarController {
         let tabBarDoubleTapGestureRecognizer = UITapGestureRecognizer()
         tabBarDoubleTapGestureRecognizer.numberOfTapsRequired = 2
         tabBarDoubleTapGestureRecognizer.addTarget(self, action: #selector(MainTabBarController.tabBarDoubleTapGestureRecognizerHandler(_:)))
+        tabBarDoubleTapGestureRecognizer.delaysTouchesEnded = false
         tabBar.addGestureRecognizer(tabBarDoubleTapGestureRecognizer)
 
         self.isReadyForWizardAvatarButton = authContext != nil


### PR DESCRIPTION
# Rationale

https://github.com/mastodon/mastodon-ios/pull/604 has introduced a new `UITapGestureRecognizer` which added a delay on `UITabBar` tabs, this PR resolves this.
