### PR TITLE
[Refactor] Use UIView extension to create constraints (to parent view)

### DIFF
--- a/Mastodon/Scene/Compose/ComposeViewController.swift
+++ b/Mastodon/Scene/Compose/ComposeViewController.swift
@@ -58,12 +58,7 @@ final class ComposeViewController: UIViewController, NeedsDependency {
         let shadowBackgroundContainer = ShadowBackgroundContainer()
         publishButton.translatesAutoresizingMaskIntoConstraints = false
         shadowBackgroundContainer.addSubview(publishButton)
-        NSLayoutConstraint.activate([
-            publishButton.topAnchor.constraint(equalTo: shadowBackgroundContainer.topAnchor),
-            publishButton.leadingAnchor.constraint(equalTo: shadowBackgroundContainer.leadingAnchor),
-            publishButton.trailingAnchor.constraint(equalTo: shadowBackgroundContainer.trailingAnchor),
-            publishButton.bottomAnchor.constraint(equalTo: shadowBackgroundContainer.bottomAnchor),
-        ])
+        publishButton.pinToParent()
         let barButtonItem = UIBarButtonItem(customView: shadowBackgroundContainer)
         return barButtonItem
     }()
@@ -105,12 +100,7 @@ extension ComposeViewController {
         addChild(composeContentViewController)
         composeContentViewController.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(composeContentViewController.view)
-        NSLayoutConstraint.activate([
-            composeContentViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
-            composeContentViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            composeContentViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            composeContentViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        composeContentViewController.view.pinToParent()
         composeContentViewController.didMove(toParent: self)
 
         // bind title

--- a/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewController.swift
+++ b/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewController.swift
@@ -57,12 +57,7 @@ extension DiscoveryCommunityViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         tableView.refreshControl = refreshControl
         refreshControl.addTarget(self, action: #selector(DiscoveryCommunityViewController.refreshControlValueChanged(_:)), for: .valueChanged)

--- a/Mastodon/Scene/Discovery/ForYou/DiscoveryForYouViewController.swift
+++ b/Mastodon/Scene/Discovery/ForYou/DiscoveryForYouViewController.swift
@@ -56,12 +56,7 @@ extension DiscoveryForYouViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
 
         tableView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/Discovery/Hashtags/DiscoveryHashtagsViewController.swift
+++ b/Mastodon/Scene/Discovery/Hashtags/DiscoveryHashtagsViewController.swift
@@ -56,12 +56,7 @@ extension DiscoveryHashtagsViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         tableView.refreshControl = refreshControl
         refreshControl.addTarget(self, action: #selector(DiscoveryHashtagsViewController.refreshControlValueChanged(_:)), for: .valueChanged)

--- a/Mastodon/Scene/Discovery/News/DiscoveryNewsViewController.swift
+++ b/Mastodon/Scene/Discovery/News/DiscoveryNewsViewController.swift
@@ -56,12 +56,7 @@ extension DiscoveryNewsViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
 
         tableView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewController.swift
+++ b/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewController.swift
@@ -58,12 +58,7 @@ extension DiscoveryPostsViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         discoveryIntroBannerView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(discoveryIntroBannerView)

--- a/Mastodon/Scene/HashtagTimeline/HashtagTimelineViewController.swift
+++ b/Mastodon/Scene/HashtagTimeline/HashtagTimelineViewController.swift
@@ -80,12 +80,7 @@ extension HashtagTimelineViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
 
         tableView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewController.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewController.swift
@@ -158,12 +158,7 @@ extension HomeTimelineViewController {
 
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         // // layout publish progress
         publishProgressView.translatesAutoresizingMaskIntoConstraints = false

--- a/Mastodon/Scene/HomeTimeline/View/HomeTimelineNavigationBarTitleView.swift
+++ b/Mastodon/Scene/HomeTimeline/View/HomeTimelineNavigationBarTitleView.swift
@@ -47,12 +47,7 @@ extension HomeTimelineNavigationBarTitleView {
     private func _init() {
         containerView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(containerView)
-        NSLayoutConstraint.activate([
-            containerView.topAnchor.constraint(equalTo: topAnchor),
-            containerView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            containerView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            containerView.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        containerView.pinToParent()
         
         containerView.addArrangedSubview(logoButton)
         button.translatesAutoresizingMaskIntoConstraints = false

--- a/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
+++ b/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
@@ -65,12 +65,7 @@ extension MediaPreviewViewController {
         pagingViewController.view.translatesAutoresizingMaskIntoConstraints = false
         addChild(pagingViewController)
         visualEffectView.contentView.addSubview(pagingViewController.view)
-        NSLayoutConstraint.activate([
-            visualEffectView.topAnchor.constraint(equalTo: pagingViewController.view.topAnchor),
-            visualEffectView.bottomAnchor.constraint(equalTo: pagingViewController.view.bottomAnchor),
-            visualEffectView.leadingAnchor.constraint(equalTo: pagingViewController.view.leadingAnchor),
-            visualEffectView.trailingAnchor.constraint(equalTo: pagingViewController.view.trailingAnchor),
-        ])
+        visualEffectView.pinTo(to: pagingViewController.view)
         pagingViewController.didMove(toParent: self)
         
         closeButtonBackground.translatesAutoresizingMaskIntoConstraints = false

--- a/Mastodon/Scene/MediaPreview/Video/MediaPreviewVideoViewController.swift
+++ b/Mastodon/Scene/MediaPreview/Video/MediaPreviewVideoViewController.swift
@@ -39,7 +39,7 @@ extension MediaPreviewVideoViewController {
         addChild(playerViewController)
         playerViewController.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(playerViewController.view)
-        playerViewController.pinToParent()
+        playerViewController.view.pinToParent()
         playerViewController.didMove(toParent: self)
         
         if let contentOverlayView = playerViewController.contentOverlayView {

--- a/Mastodon/Scene/MediaPreview/Video/MediaPreviewVideoViewController.swift
+++ b/Mastodon/Scene/MediaPreview/Video/MediaPreviewVideoViewController.swift
@@ -39,23 +39,13 @@ extension MediaPreviewVideoViewController {
         addChild(playerViewController)
         playerViewController.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(playerViewController.view)
-        NSLayoutConstraint.activate([
-            playerViewController.view.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            playerViewController.view.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            playerViewController.view.widthAnchor.constraint(equalTo: view.widthAnchor),
-            playerViewController.view.heightAnchor.constraint(equalTo: view.heightAnchor),
-        ])
+        playerViewController.pinToParent()
         playerViewController.didMove(toParent: self)
         
         if let contentOverlayView = playerViewController.contentOverlayView {
             previewImageView.translatesAutoresizingMaskIntoConstraints = false
             contentOverlayView.addSubview(previewImageView)
-            NSLayoutConstraint.activate([
-                previewImageView.topAnchor.constraint(equalTo: contentOverlayView.topAnchor),
-                previewImageView.leadingAnchor.constraint(equalTo: contentOverlayView.leadingAnchor),
-                previewImageView.trailingAnchor.constraint(equalTo: contentOverlayView.trailingAnchor),
-                previewImageView.bottomAnchor.constraint(equalTo: contentOverlayView.bottomAnchor),
-            ])
+            previewImageView.pinToParent()
         }
         
         playerViewController.delegate = self

--- a/Mastodon/Scene/Notification/NotificationTimeline/NotificationTimelineViewController.swift
+++ b/Mastodon/Scene/Notification/NotificationTimeline/NotificationTimelineViewController.swift
@@ -55,12 +55,7 @@ extension NotificationTimelineViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         tableView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/Onboarding/PickServer/View/PickServerCategoryView.swift
+++ b/Mastodon/Scene/Onboarding/PickServer/View/PickServerCategoryView.swift
@@ -48,12 +48,7 @@ extension PickServerCategoryView {
         
         container.translatesAutoresizingMaskIntoConstraints = false
         addSubview(container)
-        NSLayoutConstraint.activate([
-            container.topAnchor.constraint(equalTo: topAnchor),
-            container.leadingAnchor.constraint(equalTo: leadingAnchor),
-            container.trailingAnchor.constraint(equalTo: trailingAnchor),
-            container.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        container.pinToParent()
         
         container.addArrangedSubview(titleLabel)
         highlightedIndicatorView.translatesAutoresizingMaskIntoConstraints = false

--- a/Mastodon/Scene/Onboarding/PickServer/View/PickServerServerSectionTableHeaderView.swift
+++ b/Mastodon/Scene/Onboarding/PickServer/View/PickServerServerSectionTableHeaderView.swift
@@ -83,11 +83,8 @@ final class PickServerServerSectionTableHeaderView: UIView {
             let paddingView = UIView()
             paddingView.translatesAutoresizingMaskIntoConstraints = false
             containerView.addSubview(paddingView)
+            paddingView.pinToParent()
             NSLayoutConstraint.activate([
-                paddingView.topAnchor.constraint(equalTo: containerView.topAnchor),
-                paddingView.leadingAnchor.constraint(equalTo: imageView.trailingAnchor),
-                paddingView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-                paddingView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
                 paddingView.widthAnchor.constraint(equalToConstant: 4).priority(.defaultHigh),
             ])
             return containerView

--- a/Mastodon/Scene/Onboarding/PickServer/View/PickServerServerSectionTableHeaderView.swift
+++ b/Mastodon/Scene/Onboarding/PickServer/View/PickServerServerSectionTableHeaderView.swift
@@ -83,8 +83,11 @@ final class PickServerServerSectionTableHeaderView: UIView {
             let paddingView = UIView()
             paddingView.translatesAutoresizingMaskIntoConstraints = false
             containerView.addSubview(paddingView)
-            paddingView.pinToParent()
             NSLayoutConstraint.activate([
+                paddingView.topAnchor.constraint(equalTo: containerView.topAnchor),
+                paddingView.leadingAnchor.constraint(equalTo: imageView.trailingAnchor),
+                paddingView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+                paddingView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
                 paddingView.widthAnchor.constraint(equalToConstant: 4).priority(.defaultHigh),
             ])
             return containerView

--- a/Mastodon/Scene/Onboarding/Register/MastodonRegisterViewController.swift
+++ b/Mastodon/Scene/Onboarding/Register/MastodonRegisterViewController.swift
@@ -85,12 +85,7 @@ extension MastodonRegisterViewController {
         addChild(hostingViewController)
         hostingViewController.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(hostingViewController.view)
-        NSLayoutConstraint.activate([
-            hostingViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
-            hostingViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            hostingViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            hostingViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        hostingViewController.view.pinToParent()
         
         navigationActionView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(navigationActionView)

--- a/Mastodon/Scene/Onboarding/ResendEmail/MastodonResendEmailViewController.swift
+++ b/Mastodon/Scene/Onboarding/ResendEmail/MastodonResendEmailViewController.swift
@@ -49,12 +49,7 @@ extension MastodonResendEmailViewController {
         
         webView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(webView)
-        NSLayoutConstraint.activate([
-            webView.topAnchor.constraint(equalTo: view.topAnchor),
-            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        webView.pinToParent()
         
         let request = URLRequest(url: viewModel.resendEmailURL)
         webView.navigationDelegate = self.viewModel.navigationDelegate

--- a/Mastodon/Scene/Onboarding/ServerRules/MastodonServerRulesViewController.swift
+++ b/Mastodon/Scene/Onboarding/ServerRules/MastodonServerRulesViewController.swift
@@ -69,12 +69,7 @@ extension MastodonServerRulesViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         navigationActionView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(navigationActionView)

--- a/Mastodon/Scene/Onboarding/Share/NavigationActionView.swift
+++ b/Mastodon/Scene/Onboarding/Share/NavigationActionView.swift
@@ -84,21 +84,11 @@ extension NavigationActionView {
         
         backButton.translatesAutoresizingMaskIntoConstraints = false
         backButtonShadowContainer.addSubview(backButton)
-        NSLayoutConstraint.activate([
-            backButton.topAnchor.constraint(equalTo: backButtonShadowContainer.topAnchor),
-            backButton.leadingAnchor.constraint(equalTo: backButtonShadowContainer.leadingAnchor),
-            backButton.trailingAnchor.constraint(equalTo: backButtonShadowContainer.trailingAnchor),
-            backButton.bottomAnchor.constraint(equalTo: backButtonShadowContainer.bottomAnchor),
-        ])
+        backButton.pinToParent()
         
         nextButton.translatesAutoresizingMaskIntoConstraints = false
         nextButtonShadowContainer.addSubview(nextButton)
-        NSLayoutConstraint.activate([
-            nextButton.topAnchor.constraint(equalTo: nextButtonShadowContainer.topAnchor),
-            nextButton.leadingAnchor.constraint(equalTo: nextButtonShadowContainer.leadingAnchor),
-            nextButton.trailingAnchor.constraint(equalTo: nextButtonShadowContainer.trailingAnchor),
-            nextButton.bottomAnchor.constraint(equalTo: nextButtonShadowContainer.bottomAnchor),
-        ])
+        nextButton.pinToParent()
     }
     
 }

--- a/Mastodon/Scene/Onboarding/Share/OnboardingNavigationController.swift
+++ b/Mastodon/Scene/Onboarding/Share/OnboardingNavigationController.swift
@@ -20,12 +20,7 @@ extension OnboardingNavigationController {
         
         gradientBorderView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(gradientBorderView)
-        NSLayoutConstraint.activate([
-            gradientBorderView.topAnchor.constraint(equalTo: view.topAnchor),
-            gradientBorderView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            gradientBorderView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            gradientBorderView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        gradientBorderView.pinToParent()
         
         updateBorderViewDisplay()
     }

--- a/Mastodon/Scene/Onboarding/Welcome/View/WelcomeIllustrationView.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/View/WelcomeIllustrationView.swift
@@ -96,12 +96,7 @@ extension WelcomeIllustrationView {
         ].forEach { imageView in
             imageView.translatesAutoresizingMaskIntoConstraints = false
             addSubview(imageView)
-            NSLayoutConstraint.activate([
-                imageView.topAnchor.constraint(equalTo: cloudBaseImageView.topAnchor),
-                imageView.leadingAnchor.constraint(equalTo: cloudBaseImageView.leadingAnchor),
-                imageView.trailingAnchor.constraint(equalTo: cloudBaseImageView.trailingAnchor),
-                imageView.bottomAnchor.constraint(equalTo: cloudBaseImageView.bottomAnchor),
-            ])
+            imageView.pinTo(to: cloudBaseImageView)
         }
         
         aspectLayoutConstraint = cloudBaseImageView.widthAnchor.constraint(equalTo: cloudBaseImageView.heightAnchor, multiplier: layout.artworkImageSize.width / layout.artworkImageSize.height)

--- a/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
@@ -124,22 +124,12 @@ extension WelcomeViewController {
         signUpButtonShadowView.translatesAutoresizingMaskIntoConstraints = false
         buttonContainer.addSubview(signUpButtonShadowView)
         buttonContainer.sendSubviewToBack(signUpButtonShadowView)
-        NSLayoutConstraint.activate([
-            signUpButtonShadowView.topAnchor.constraint(equalTo: signUpButton.topAnchor),
-            signUpButtonShadowView.leadingAnchor.constraint(equalTo: signUpButton.leadingAnchor),
-            signUpButtonShadowView.trailingAnchor.constraint(equalTo: signUpButton.trailingAnchor),
-            signUpButtonShadowView.bottomAnchor.constraint(equalTo: signUpButton.bottomAnchor),
-        ])
+        signUpButtonShadowView.pinTo(to: signUpButton)
         
         signInButtonShadowView.translatesAutoresizingMaskIntoConstraints = false
         buttonContainer.addSubview(signInButtonShadowView)
         buttonContainer.sendSubviewToBack(signInButtonShadowView)
-        NSLayoutConstraint.activate([
-            signInButtonShadowView.topAnchor.constraint(equalTo: signInButton.topAnchor),
-            signInButtonShadowView.leadingAnchor.constraint(equalTo: signInButton.leadingAnchor),
-            signInButtonShadowView.trailingAnchor.constraint(equalTo: signInButton.trailingAnchor),
-            signInButtonShadowView.bottomAnchor.constraint(equalTo: signInButton.bottomAnchor),
-        ])
+        signInButtonShadowView.pinTo(to: signInButton)
 
         signUpButton.addTarget(self, action: #selector(signUpButtonDidClicked(_:)), for: .touchUpInside)
         signInButton.addTarget(self, action: #selector(signInButtonDidClicked(_:)), for: .touchUpInside)

--- a/Mastodon/Scene/Profile/About/ProfileAboutViewController.swift
+++ b/Mastodon/Scene/Profile/About/ProfileAboutViewController.swift
@@ -60,12 +60,7 @@ extension ProfileAboutViewController {
         
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(collectionView)
-        NSLayoutConstraint.activate([
-            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
-            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        collectionView.pinToParent()
         
         collectionView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/Profile/Bookmark/BookmarkViewController.swift
+++ b/Mastodon/Scene/Profile/Bookmark/BookmarkViewController.swift
@@ -64,12 +64,7 @@ extension BookmarkViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
 
         tableView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/Profile/FamiliarFollowers/FamiliarFollowersViewController.swift
+++ b/Mastodon/Scene/Profile/FamiliarFollowers/FamiliarFollowersViewController.swift
@@ -53,12 +53,7 @@ extension FamiliarFollowersViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         tableView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/Profile/Favorite/FavoriteViewController.swift
+++ b/Mastodon/Scene/Profile/Favorite/FavoriteViewController.swift
@@ -67,12 +67,7 @@ extension FavoriteViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
 
         tableView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/Profile/Follower/FollowerListViewController.swift
+++ b/Mastodon/Scene/Profile/Follower/FollowerListViewController.swift
@@ -58,12 +58,7 @@ extension FollowerListViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         tableView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/Profile/Following/FollowingListViewController.swift
+++ b/Mastodon/Scene/Profile/Following/FollowingListViewController.swift
@@ -58,12 +58,7 @@ extension FollowingListViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         tableView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/Profile/Header/View/ProfileHeaderView.swift
+++ b/Mastodon/Scene/Profile/Header/View/ProfileHeaderView.swift
@@ -265,12 +265,7 @@ extension ProfileHeaderView {
         
         bannerImageViewOverlayVisualEffectView.translatesAutoresizingMaskIntoConstraints = false
         bannerImageView.addSubview(bannerImageViewOverlayVisualEffectView)
-        NSLayoutConstraint.activate([
-            bannerImageViewOverlayVisualEffectView.topAnchor.constraint(equalTo: bannerImageView.topAnchor),
-            bannerImageViewOverlayVisualEffectView.leadingAnchor.constraint(equalTo: bannerImageView.leadingAnchor),
-            bannerImageViewOverlayVisualEffectView.trailingAnchor.constraint(equalTo: bannerImageView.trailingAnchor),
-            bannerImageViewOverlayVisualEffectView.bottomAnchor.constraint(equalTo: bannerImageView.bottomAnchor),
-        ])
+        bannerImageViewOverlayVisualEffectView.pinToParent()
         
         // follows you
         followsYouBlurEffectView.translatesAutoresizingMaskIntoConstraints = false
@@ -286,12 +281,7 @@ extension ProfileHeaderView {
 
         followsYouVibrantEffectView.translatesAutoresizingMaskIntoConstraints = false
         followsYouBlurEffectView.contentView.addSubview(followsYouVibrantEffectView)
-        NSLayoutConstraint.activate([
-            followsYouVibrantEffectView.topAnchor.constraint(equalTo: followsYouBlurEffectView.topAnchor),
-            followsYouVibrantEffectView.leadingAnchor.constraint(equalTo: followsYouBlurEffectView.leadingAnchor),
-            followsYouVibrantEffectView.trailingAnchor.constraint(equalTo: followsYouBlurEffectView.trailingAnchor),
-            followsYouVibrantEffectView.bottomAnchor.constraint(equalTo: followsYouBlurEffectView.bottomAnchor),
-        ])
+        followsYouVibrantEffectView.pinToParent()
         
         followsYouLabel.translatesAutoresizingMaskIntoConstraints = false
         followsYouVibrantEffectView.contentView.addSubview(followsYouLabel)
@@ -327,30 +317,15 @@ extension ProfileHeaderView {
 
         avatarImageViewOverlayVisualEffectView.translatesAutoresizingMaskIntoConstraints = false
         avatarImageViewBackgroundView.addSubview(avatarImageViewOverlayVisualEffectView)
-        NSLayoutConstraint.activate([
-            avatarImageViewOverlayVisualEffectView.topAnchor.constraint(equalTo: avatarImageViewBackgroundView.topAnchor),
-            avatarImageViewOverlayVisualEffectView.leadingAnchor.constraint(equalTo: avatarImageViewBackgroundView.leadingAnchor),
-            avatarImageViewOverlayVisualEffectView.trailingAnchor.constraint(equalTo: avatarImageViewBackgroundView.trailingAnchor),
-            avatarImageViewOverlayVisualEffectView.bottomAnchor.constraint(equalTo: avatarImageViewBackgroundView.bottomAnchor),
-        ])
+        avatarImageViewOverlayVisualEffectView.pinToParent()
     
         editAvatarBackgroundView.translatesAutoresizingMaskIntoConstraints = false
         avatarButton.addSubview(editAvatarBackgroundView)
-        NSLayoutConstraint.activate([
-            editAvatarBackgroundView.topAnchor.constraint(equalTo: avatarButton.topAnchor),
-            editAvatarBackgroundView.leadingAnchor.constraint(equalTo: avatarButton.leadingAnchor),
-            editAvatarBackgroundView.trailingAnchor.constraint(equalTo: avatarButton.trailingAnchor),
-            editAvatarBackgroundView.bottomAnchor.constraint(equalTo: avatarButton.bottomAnchor),
-        ])
+        editAvatarBackgroundView.pinToParent()
         
         editAvatarButtonOverlayIndicatorView.translatesAutoresizingMaskIntoConstraints = false
         editAvatarBackgroundView.addSubview(editAvatarButtonOverlayIndicatorView)
-        NSLayoutConstraint.activate([
-            editAvatarButtonOverlayIndicatorView.topAnchor.constraint(equalTo: editAvatarBackgroundView.topAnchor),
-            editAvatarButtonOverlayIndicatorView.leadingAnchor.constraint(equalTo: editAvatarBackgroundView.leadingAnchor),
-            editAvatarButtonOverlayIndicatorView.trailingAnchor.constraint(equalTo: editAvatarBackgroundView.trailingAnchor),
-            editAvatarButtonOverlayIndicatorView.bottomAnchor.constraint(equalTo: editAvatarBackgroundView.bottomAnchor),
-        ])
+        editAvatarButtonOverlayIndicatorView.pinToParent()
         editAvatarBackgroundView.isUserInteractionEnabled = true
         avatarButton.isUserInteractionEnabled = true
         
@@ -436,11 +411,8 @@ extension ProfileHeaderView {
         
         relationshipActionButton.translatesAutoresizingMaskIntoConstraints = false
         relationshipActionButtonShadowContainer.addSubview(relationshipActionButton)
+        relationshipActionButton.pinToParent()
         NSLayoutConstraint.activate([
-            relationshipActionButton.topAnchor.constraint(equalTo: relationshipActionButtonShadowContainer.topAnchor),
-            relationshipActionButton.leadingAnchor.constraint(equalTo: relationshipActionButtonShadowContainer.leadingAnchor),
-            relationshipActionButton.trailingAnchor.constraint(equalTo: relationshipActionButtonShadowContainer.trailingAnchor),
-            relationshipActionButton.bottomAnchor.constraint(equalTo: relationshipActionButtonShadowContainer.bottomAnchor),
             relationshipActionButton.widthAnchor.constraint(greaterThanOrEqualToConstant: ProfileHeaderView.friendshipActionButtonSize.width).priority(.required - 1),
             relationshipActionButton.heightAnchor.constraint(equalToConstant: ProfileHeaderView.friendshipActionButtonSize.height).priority(.defaultHigh),
         ])

--- a/Mastodon/Scene/Profile/Header/View/ProfileHeaderView.swift
+++ b/Mastodon/Scene/Profile/Header/View/ProfileHeaderView.swift
@@ -281,7 +281,7 @@ extension ProfileHeaderView {
 
         followsYouVibrantEffectView.translatesAutoresizingMaskIntoConstraints = false
         followsYouBlurEffectView.contentView.addSubview(followsYouVibrantEffectView)
-        followsYouVibrantEffectView.pinToParent()
+        followsYouVibrantEffectView.pinTo(to: followsYouBlurEffectView)
         
         followsYouLabel.translatesAutoresizingMaskIntoConstraints = false
         followsYouVibrantEffectView.contentView.addSubview(followsYouLabel)

--- a/Mastodon/Scene/Profile/Paging/ProfilePagingViewController.swift
+++ b/Mastodon/Scene/Profile/Paging/ProfilePagingViewController.swift
@@ -99,12 +99,7 @@ extension ProfilePagingViewController {
         if let buttonBarView = self.buttonBarView {
             buttonBarShadowView.translatesAutoresizingMaskIntoConstraints = false
             view.insertSubview(buttonBarShadowView, belowSubview: buttonBarView)
-            NSLayoutConstraint.activate([
-                buttonBarShadowView.topAnchor.constraint(equalTo: buttonBarView.topAnchor),
-                buttonBarShadowView.leadingAnchor.constraint(equalTo: buttonBarView.leadingAnchor),
-                buttonBarShadowView.trailingAnchor.constraint(equalTo: buttonBarView.trailingAnchor),
-                buttonBarShadowView.bottomAnchor.constraint(equalTo: buttonBarView.bottomAnchor),
-            ])
+            buttonBarShadowView.pinTo(to: buttonBarView)
             
             viewModel.$needsSetupBottomShadow
                 .receive(on: DispatchQueue.main)

--- a/Mastodon/Scene/Profile/ProfileViewController.swift
+++ b/Mastodon/Scene/Profile/ProfileViewController.swift
@@ -259,12 +259,7 @@ extension ProfileViewController {
         tabBarPagerController.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tabBarPagerController.view)
         tabBarPagerController.didMove(toParent: self)
-        NSLayoutConstraint.activate([
-            tabBarPagerController.view.topAnchor.constraint(equalTo: view.topAnchor),
-            tabBarPagerController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tabBarPagerController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tabBarPagerController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tabBarPagerController.view.pinToParent()
 
         tabBarPagerController.delegate = self
         tabBarPagerController.dataSource = self

--- a/Mastodon/Scene/Profile/Timeline/UserTimelineViewController.swift
+++ b/Mastodon/Scene/Profile/Timeline/UserTimelineViewController.swift
@@ -60,12 +60,7 @@ extension UserTimelineViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
 
         tableView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/Profile/UserLIst/FavoritedBy/FavoritedByViewController.swift
+++ b/Mastodon/Scene/Profile/UserLIst/FavoritedBy/FavoritedByViewController.swift
@@ -61,12 +61,7 @@ extension FavoritedByViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         tableView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/Profile/UserLIst/RebloggedBy/RebloggedByViewController.swift
+++ b/Mastodon/Scene/Profile/UserLIst/RebloggedBy/RebloggedByViewController.swift
@@ -61,12 +61,7 @@ extension RebloggedByViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         tableView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/Report/Report/ReportViewController.swift
+++ b/Mastodon/Scene/Report/Report/ReportViewController.swift
@@ -61,12 +61,7 @@ extension ReportViewController {
         reportReasonViewController.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(reportReasonViewController.view)
         reportReasonViewController.didMove(toParent: self)
-        NSLayoutConstraint.activate([
-            reportReasonViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
-            reportReasonViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            reportReasonViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            reportReasonViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        reportReasonViewController.view.pinToParent()
     }
     
 }

--- a/Mastodon/Scene/Report/ReportReason/ReportReasonViewController.swift
+++ b/Mastodon/Scene/Report/ReportReason/ReportReasonViewController.swift
@@ -57,12 +57,7 @@ extension ReportReasonViewController {
         addChild(hostingViewController)
         hostingViewController.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(hostingViewController.view)
-        NSLayoutConstraint.activate([
-            hostingViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
-            hostingViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            hostingViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            hostingViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        hostingViewController.view.pinToParent()
         
         navigationActionView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(navigationActionView)

--- a/Mastodon/Scene/Report/ReportResult/ReportResultViewController.swift
+++ b/Mastodon/Scene/Report/ReportResult/ReportResultViewController.swift
@@ -60,12 +60,7 @@ extension ReportResultViewController {
         addChild(hostingViewController)
         hostingViewController.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(hostingViewController.view)
-        NSLayoutConstraint.activate([
-            hostingViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
-            hostingViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            hostingViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            hostingViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        hostingViewController.view.pinToParent()
         
         navigationActionView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(navigationActionView)

--- a/Mastodon/Scene/Report/ReportServerRules/ReportServerRulesViewController.swift
+++ b/Mastodon/Scene/Report/ReportServerRules/ReportServerRulesViewController.swift
@@ -63,12 +63,7 @@ extension ReportServerRulesViewController {
         addChild(hostingViewController)
         hostingViewController.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(hostingViewController.view)
-        NSLayoutConstraint.activate([
-            hostingViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
-            hostingViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            hostingViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            hostingViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        hostingViewController.view.pinToParent()
         
         navigationActionView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(navigationActionView)

--- a/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
+++ b/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
@@ -80,12 +80,7 @@ extension ReportStatusViewController {
                 
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         tableView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/Report/ReportSupplementary/ReportSupplementaryViewController.swift
+++ b/Mastodon/Scene/Report/ReportSupplementary/ReportSupplementaryViewController.swift
@@ -93,12 +93,7 @@ extension ReportSupplementaryViewController {
 
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         tableView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/Report/Share/Cell/ReportCommentTableViewCell.swift
+++ b/Mastodon/Scene/Report/Share/Cell/ReportCommentTableViewCell.swift
@@ -74,11 +74,8 @@ extension ReportCommentTableViewCell {
         
         commentTextView.translatesAutoresizingMaskIntoConstraints = false
         commentTextViewShadowBackgroundContainer.addSubview(commentTextView)
+        commentTextView.pinToParent()
         NSLayoutConstraint.activate([
-            commentTextView.topAnchor.constraint(equalTo: commentTextViewShadowBackgroundContainer.topAnchor),
-            commentTextView.leadingAnchor.constraint(equalTo: commentTextViewShadowBackgroundContainer.leadingAnchor),
-            commentTextView.trailingAnchor.constraint(equalTo: commentTextViewShadowBackgroundContainer.trailingAnchor),
-            commentTextView.bottomAnchor.constraint(equalTo: commentTextViewShadowBackgroundContainer.bottomAnchor),
             commentTextView.heightAnchor.constraint(greaterThanOrEqualToConstant: 100).priority(.defaultHigh),
         ])
     }

--- a/Mastodon/Scene/Report/Share/Cell/ReportResultActionTableViewCell.swift
+++ b/Mastodon/Scene/Report/Share/Cell/ReportResultActionTableViewCell.swift
@@ -103,12 +103,7 @@ extension ReportResultActionTableViewCell {
         
         reportBannerLabel.translatesAutoresizingMaskIntoConstraints = false
         reportBannerShadowContainer.addSubview(reportBannerLabel)
-        NSLayoutConstraint.activate([
-            reportBannerLabel.topAnchor.constraint(equalTo: reportBannerShadowContainer.topAnchor),
-            reportBannerLabel.leadingAnchor.constraint(equalTo: reportBannerShadowContainer.leadingAnchor),
-            reportBannerLabel.trailingAnchor.constraint(equalTo: reportBannerShadowContainer.trailingAnchor),
-            reportBannerLabel.bottomAnchor.constraint(equalTo: reportBannerShadowContainer.bottomAnchor),
-        ])
+        reportBannerLabel.pinToParent()
         
     }
     

--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -442,12 +442,7 @@ extension MainTabBarController {
         
         composeButton.translatesAutoresizingMaskIntoConstraints = false
         composeButttonShadowBackgroundContainer.addSubview(composeButton)
-        NSLayoutConstraint.activate([
-            composeButton.topAnchor.constraint(equalTo: composeButttonShadowBackgroundContainer.topAnchor),
-            composeButton.leadingAnchor.constraint(equalTo: composeButttonShadowBackgroundContainer.leadingAnchor),
-            composeButton.trailingAnchor.constraint(equalTo: composeButttonShadowBackgroundContainer.trailingAnchor),
-            composeButton.bottomAnchor.constraint(equalTo: composeButttonShadowBackgroundContainer.bottomAnchor),
-        ])
+        composeButton.pinToParent()
         composeButton.setContentHuggingPriority(.required - 1, for: .horizontal)
         composeButton.setContentHuggingPriority(.required - 1, for: .vertical)
     }

--- a/Mastodon/Scene/Root/Sidebar/SidebarViewController.swift
+++ b/Mastodon/Scene/Root/Sidebar/SidebarViewController.swift
@@ -101,12 +101,7 @@ extension SidebarViewController {
         
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(collectionView)
-        NSLayoutConstraint.activate([
-            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
-            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        collectionView.pinToParent()
         
         secondaryCollectionView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(secondaryCollectionView)

--- a/Mastodon/Scene/Search/Search/Cell/TrendCollectionViewCell.swift
+++ b/Mastodon/Scene/Search/Search/Cell/TrendCollectionViewCell.swift
@@ -48,12 +48,7 @@ extension TrendCollectionViewCell {
         
         trendView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(trendView)
-        NSLayoutConstraint.activate([
-            trendView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            trendView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            trendView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            trendView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-        ])
+        trendView.pinToParent()
     }
     
     override func updateConfiguration(using state: UICellConfigurationState) {

--- a/Mastodon/Scene/Search/Search/SearchViewController.swift
+++ b/Mastodon/Scene/Search/Search/SearchViewController.swift
@@ -105,12 +105,7 @@ extension SearchViewController {
         addChild(discoveryViewController)
         discoveryViewController.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(discoveryViewController.view)
-        NSLayoutConstraint.activate([
-            discoveryViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
-            discoveryViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            discoveryViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            discoveryViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        discoveryViewController.view.pinToParent()
 
 //        discoveryViewController.view.isHidden = true
 
@@ -151,12 +146,7 @@ extension SearchViewController {
         searchBar.delegate = self
         searchBar.translatesAutoresizingMaskIntoConstraints = false
         titleViewContainer.addSubview(searchBar)
-        NSLayoutConstraint.activate([
-            searchBar.topAnchor.constraint(equalTo: titleViewContainer.topAnchor),
-            searchBar.leadingAnchor.constraint(equalTo: titleViewContainer.leadingAnchor),
-            searchBar.trailingAnchor.constraint(equalTo: titleViewContainer.trailingAnchor),
-            searchBar.bottomAnchor.constraint(equalTo: titleViewContainer.bottomAnchor),
-        ])
+        searchBar.pinToParent()
         searchBar.setContentHuggingPriority(.required, for: .horizontal)
         searchBar.setContentHuggingPriority(.required, for: .vertical)
         navigationItem.titleView = titleViewContainer

--- a/Mastodon/Scene/Search/Search/View/SearchRecommendCollectionHeader.swift
+++ b/Mastodon/Scene/Search/Search/View/SearchRecommendCollectionHeader.swift
@@ -62,12 +62,7 @@ extension SearchRecommendCollectionHeader {
         containerStackView.isLayoutMarginsRelativeArrangement = true
         containerStackView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(containerStackView)
-        NSLayoutConstraint.activate([
-            containerStackView.topAnchor.constraint(equalTo: topAnchor),
-            containerStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            containerStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            containerStackView.trailingAnchor.constraint(equalTo: trailingAnchor)
-        ])
+        containerStackView.pinToParent()
         
         let horizontalStackView = UIStackView()
         horizontalStackView.spacing = 8

--- a/Mastodon/Scene/Search/SearchDetail/SearchDetailViewController.swift
+++ b/Mastodon/Scene/Search/SearchDetail/SearchDetailViewController.swift
@@ -116,12 +116,7 @@ extension SearchDetailViewController {
                 searchHistoryViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             ])
         } else {
-            NSLayoutConstraint.activate([
-                searchHistoryViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
-                searchHistoryViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                searchHistoryViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                searchHistoryViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            ])
+            searchHistoryViewController.view.pinToParent()
         }
 
         transition = Transition(style: .fade, duration: 0.1)
@@ -289,12 +284,7 @@ extension SearchDetailViewController {
             
             navigationBarVisualEffectBackgroundView.translatesAutoresizingMaskIntoConstraints = false
             view.insertSubview(navigationBarVisualEffectBackgroundView, belowSubview: navigationBarBackgroundView)
-            NSLayoutConstraint.activate([
-                navigationBarVisualEffectBackgroundView.topAnchor.constraint(equalTo: navigationBarBackgroundView.topAnchor),
-                navigationBarVisualEffectBackgroundView.leadingAnchor.constraint(equalTo: navigationBarBackgroundView.leadingAnchor),
-                navigationBarVisualEffectBackgroundView.trailingAnchor.constraint(equalTo: navigationBarBackgroundView.trailingAnchor),
-                navigationBarVisualEffectBackgroundView.bottomAnchor.constraint(equalTo: navigationBarBackgroundView.bottomAnchor),
-            ])
+            navigationBarVisualEffectBackgroundView.pinTo(to: navigationBarBackgroundView)
         } else {
             navigationItem.setHidesBackButton(true, animated: false)
             navigationItem.titleView = nil

--- a/Mastodon/Scene/Search/SearchDetail/SearchHistory/SearchHistoryViewController.swift
+++ b/Mastodon/Scene/Search/SearchDetail/SearchHistory/SearchHistoryViewController.swift
@@ -47,12 +47,7 @@ extension SearchHistoryViewController {
 
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(collectionView)
-        NSLayoutConstraint.activate([
-            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
-            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        collectionView.pinToParent()
         
         collectionView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/Mastodon/Scene/Search/SearchDetail/SearchResult/SearchResultViewController.swift
+++ b/Mastodon/Scene/Search/SearchDetail/SearchResult/SearchResultViewController.swift
@@ -49,12 +49,7 @@ extension SearchResultViewController {
 
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
 
         tableView.delegate = self
 //        tableView.prefetchDataSource = self

--- a/Mastodon/Scene/Settings/Cell/SettingsAppearanceTableViewCell.swift
+++ b/Mastodon/Scene/Settings/Cell/SettingsAppearanceTableViewCell.swift
@@ -101,12 +101,7 @@ extension SettingsAppearanceTableViewCell {
         
         stackView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(stackView)
-        NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-        ])
+        stackView.pinToParent()
         
         stackView.addArrangedSubview(systemAppearanceView)
         stackView.addArrangedSubview(darkAppearanceView)

--- a/Mastodon/Scene/Settings/SettingsViewController.swift
+++ b/Mastodon/Scene/Settings/SettingsViewController.swift
@@ -225,12 +225,7 @@ extension SettingsViewController {
 
         setupNavigation()
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         setupTableView()
         
         updateSectionHeaderStackViewLayout()

--- a/Mastodon/Scene/Settings/View/AppearanceView.swift
+++ b/Mastodon/Scene/Settings/View/AppearanceView.swift
@@ -85,12 +85,7 @@ extension AppearanceView {
     private func setupUI() {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageViewShadowBackgroundContainer.addSubview(imageView)
-        NSLayoutConstraint.activate([
-            imageView.topAnchor.constraint(equalTo: imageViewShadowBackgroundContainer.topAnchor),
-            imageView.leadingAnchor.constraint(equalTo: imageViewShadowBackgroundContainer.leadingAnchor),
-            imageView.trailingAnchor.constraint(equalTo: imageViewShadowBackgroundContainer.trailingAnchor),
-            imageView.bottomAnchor.constraint(equalTo: imageViewShadowBackgroundContainer.bottomAnchor),
-        ])
+        imageView.pinToParent()
         imageViewShadowBackgroundContainer.cornerRadius = 4
         
         stackView.addArrangedSubview(imageViewShadowBackgroundContainer)
@@ -100,11 +95,8 @@ extension AppearanceView {
         addSubview(stackView)
         translatesAutoresizingMaskIntoConstraints = false
         stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.pinToParent()
         NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: self.topAnchor),
-            stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-            stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: 121.0 / 100.0),        // height / width
         ])
     }

--- a/Mastodon/Scene/Share/ContextMenu/ImagePreview/ContextMenuImagePreviewViewController.swift
+++ b/Mastodon/Scene/Share/ContextMenu/ImagePreview/ContextMenuImagePreviewViewController.swift
@@ -31,12 +31,7 @@ extension ContextMenuImagePreviewViewController {
         
         imageView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(imageView)
-        NSLayoutConstraint.activate([
-            imageView.topAnchor.constraint(equalTo: view.topAnchor),
-            imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            imageView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        imageView.pinToParent()
         
         imageView.image = viewModel.thumbnail
         

--- a/Mastodon/Scene/Share/View/Content/ContentWarningOverlayView.swift
+++ b/Mastodon/Scene/Share/View/Content/ContentWarningOverlayView.swift
@@ -93,12 +93,7 @@ extension ContentWarningOverlayView {
 
         vibrancyVisualEffectView.translatesAutoresizingMaskIntoConstraints = false
         blurVisualEffectView.contentView.addSubview(vibrancyVisualEffectView)
-        NSLayoutConstraint.activate([
-            vibrancyVisualEffectView.topAnchor.constraint(equalTo: blurVisualEffectView.topAnchor),
-            vibrancyVisualEffectView.leadingAnchor.constraint(equalTo: blurVisualEffectView.leadingAnchor),
-            vibrancyVisualEffectView.trailingAnchor.constraint(equalTo: blurVisualEffectView.trailingAnchor),
-            vibrancyVisualEffectView.bottomAnchor.constraint(equalTo: blurVisualEffectView.bottomAnchor),
-        ])
+        vibrancyVisualEffectView.pinToParent()
 
         vibrancyContentWarningLabel.translatesAutoresizingMaskIntoConstraints = false
         vibrancyVisualEffectView.contentView.addSubview(vibrancyContentWarningLabel)
@@ -110,12 +105,7 @@ extension ContentWarningOverlayView {
 
         blurVisualEffectView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(blurVisualEffectView)
-        NSLayoutConstraint.activate([
-            blurVisualEffectView.topAnchor.constraint(equalTo: topAnchor),
-            blurVisualEffectView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            blurVisualEffectView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            blurVisualEffectView.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        blurVisualEffectView.pinToParent()
 
         // blur image style
         contentOverlayView.translatesAutoresizingMaskIntoConstraints = false
@@ -134,12 +124,7 @@ extension ContentWarningOverlayView {
         
         blurContentWarningLabelContainer.translatesAutoresizingMaskIntoConstraints = false
         contentOverlayView.addSubview(blurContentWarningLabelContainer)
-        NSLayoutConstraint.activate([
-            blurContentWarningLabelContainer.topAnchor.constraint(equalTo: topAnchor),
-            blurContentWarningLabelContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
-            blurContentWarningLabelContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
-            blurContentWarningLabelContainer.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        blurContentWarningLabelContainer.pinTo(to: self)
 
         let topPaddingView = UIView()
         let bottomPaddingView = UIView()

--- a/Mastodon/Scene/Share/View/Content/ContentWarningOverlayView.swift
+++ b/Mastodon/Scene/Share/View/Content/ContentWarningOverlayView.swift
@@ -93,7 +93,7 @@ extension ContentWarningOverlayView {
 
         vibrancyVisualEffectView.translatesAutoresizingMaskIntoConstraints = false
         blurVisualEffectView.contentView.addSubview(vibrancyVisualEffectView)
-        vibrancyVisualEffectView.pinToParent()
+        vibrancyVisualEffectView.pinTo(to: blurVisualEffectView)
 
         vibrancyContentWarningLabel.translatesAutoresizingMaskIntoConstraints = false
         vibrancyVisualEffectView.contentView.addSubview(vibrancyContentWarningLabel)

--- a/Mastodon/Scene/Share/View/Content/DoubleTitleLabelNavigationBarTitleView.swift
+++ b/Mastodon/Scene/Share/View/Content/DoubleTitleLabelNavigationBarTitleView.swift
@@ -47,12 +47,7 @@ extension DoubleTitleLabelNavigationBarTitleView {
         containerView.distribution = .fill
         containerView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(containerView)
-        NSLayoutConstraint.activate([
-            containerView.topAnchor.constraint(equalTo: topAnchor),
-            containerView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            containerView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            containerView.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        containerView.pinToParent()
         
         containerView.addArrangedSubview(titleLabel)
         containerView.addArrangedSubview(subtitleLabel)

--- a/Mastodon/Scene/Share/Webview/WebViewController.swift
+++ b/Mastodon/Scene/Share/Webview/WebViewController.swift
@@ -49,12 +49,7 @@ extension WebViewController {
         
         webView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(webView)
-        NSLayoutConstraint.activate([
-            webView.topAnchor.constraint(equalTo: view.topAnchor),
-            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        webView.pinToParent()
         
         let request = URLRequest(url: viewModel.url)
         webView.load(request)

--- a/Mastodon/Scene/SuggestionAccount/CollectionViewCell/SuggestionAccountCollectionViewCell.swift
+++ b/Mastodon/Scene/SuggestionAccount/CollectionViewCell/SuggestionAccountCollectionViewCell.swift
@@ -53,11 +53,6 @@ extension SuggestionAccountCollectionViewCell {
     private func configure() {
         contentView.addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            imageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-        ])
+        imageView.pinToParent()
     }
 }

--- a/Mastodon/Scene/SuggestionAccount/TableViewCell/SuggestionAccountTableViewCell.swift
+++ b/Mastodon/Scene/SuggestionAccount/TableViewCell/SuggestionAccountTableViewCell.swift
@@ -97,12 +97,7 @@ extension SuggestionAccountTableViewCell {
         containerStackView.isLayoutMarginsRelativeArrangement = true
         containerStackView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(containerStackView)
-        NSLayoutConstraint.activate([
-            containerStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            containerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            containerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            containerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-        ])
+        containerStackView.pinToParent()
         
         avatarButton.translatesAutoresizingMaskIntoConstraints = false
         containerStackView.addArrangedSubview(avatarButton)

--- a/Mastodon/Scene/Thread/ThreadViewController.swift
+++ b/Mastodon/Scene/Thread/ThreadViewController.swift
@@ -87,12 +87,7 @@ extension ThreadViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         tableView.delegate = self
         viewModel.setupDiffableDataSource(

--- a/MastodonSDK/Sources/MastodonExtension/UIView.swift
+++ b/MastodonSDK/Sources/MastodonExtension/UIView.swift
@@ -46,3 +46,20 @@ extension UIView {
         return self
     }
 }
+
+public extension UIView {
+    
+    func pinToParent() {
+        pinTo(to: self.superview)
+    }
+    
+    func pinTo(to view: UIView?) {
+        guard let pinToView = view else { return }
+        NSLayoutConstraint.activate([
+            topAnchor.constraint(equalTo: pinToView.topAnchor),
+            leadingAnchor.constraint(equalTo: pinToView.leadingAnchor),
+            trailingAnchor.constraint(equalTo: pinToView.trailingAnchor),
+            bottomAnchor.constraint(equalTo: pinToView.bottomAnchor),
+        ])
+    }
+}

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/AutoComplete/AutoCompleteViewController.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/AutoComplete/AutoCompleteViewController.swift
@@ -80,12 +80,7 @@ extension AutoCompleteViewController {
         
         tableView.translatesAutoresizingMaskIntoConstraints = false
         containerBackgroundView.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: containerBackgroundView.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: containerBackgroundView.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: containerBackgroundView.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: containerBackgroundView.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         tableView.delegate = self
         viewModel.setupDiffableDataSource(tableView: tableView)

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/AutoComplete/View/AutoCompleteTopChevronView.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/AutoComplete/View/AutoCompleteTopChevronView.swift
@@ -65,12 +65,7 @@ extension AutoCompleteTopChevronView {
         
         shadowView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(shadowView)
-        NSLayoutConstraint.activate([
-            shadowView.topAnchor.constraint(equalTo: topAnchor),
-            shadowView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            shadowView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            shadowView.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        shadowView.pinToParent()
         
         shadowLayer.fillColor = topViewBackgroundColor.cgColor
         shadowView.layer.addSublayer(shadowLayer)

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewController.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewController.swift
@@ -108,12 +108,7 @@ extension ComposeContentViewController {
         // setup tableView
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
+        tableView.pinToParent()
         
         tableView.delegate = self
         viewModel.setupDataSource(tableView: tableView)

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/EmojiPicker/CustomEmojiPickerInputView.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/EmojiPicker/CustomEmojiPickerInputView.swift
@@ -44,12 +44,7 @@ extension CustomEmojiPickerInputView {
 
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(collectionView)
-        NSLayoutConstraint.activate([
-            collectionView.topAnchor.constraint(equalTo: topAnchor),
-            collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            collectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            collectionView.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        collectionView.pinToParent()
         
         activityIndicatorView.hidesWhenStopped = true
         activityIndicatorView.startAnimating()

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/EmojiPicker/CustomEmojiPickerItemCollectionViewCell.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/EmojiPicker/CustomEmojiPickerItemCollectionViewCell.swift
@@ -46,12 +46,7 @@ extension CustomEmojiPickerItemCollectionViewCell {
     private func _init() {
         emojiImageView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(emojiImageView)
-        NSLayoutConstraint.activate([
-            emojiImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            emojiImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            emojiImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            emojiImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-        ])
+        emojiImageView.pinToParent()
         
         isAccessibilityElement = true
         accessibilityTraits = .button

--- a/MastodonSDK/Sources/MastodonUI/SwiftUI/AnimatedImage.swift
+++ b/MastodonSDK/Sources/MastodonUI/SwiftUI/AnimatedImage.swift
@@ -37,12 +37,7 @@ final public class FLAnimatedImageViewProxy: UIView {
 
         imageView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(imageView)
-        NSLayoutConstraint.activate([
-            imageView.topAnchor.constraint(equalTo: topAnchor),
-            imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            imageView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            imageView.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        imageView.pinToParent()
     }
 
     required init?(coder: NSCoder) {

--- a/MastodonSDK/Sources/MastodonUI/View/Button/AvatarButton.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Button/AvatarButton.swift
@@ -32,12 +32,7 @@ open class AvatarButton: UIControl {
         avatarImageView.frame = bounds
         avatarImageView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(avatarImageView)
-        NSLayoutConstraint.activate([
-            avatarImageView.topAnchor.constraint(equalTo: topAnchor),
-            avatarImageView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            avatarImageView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            avatarImageView.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        avatarImageView.pinToParent()
         
         isAccessibilityElement = true
         accessibilityLabel = L10n.Common.Controls.Status.showUserProfile

--- a/MastodonSDK/Sources/MastodonUI/View/Container/MediaGridContainerView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Container/MediaGridContainerView.swift
@@ -136,12 +136,7 @@ extension MediaGridContainerView {
     private func layoutContentWarningOverlay() {
         contentWarningOverlay.translatesAutoresizingMaskIntoConstraints = false
         addSubview(contentWarningOverlay)
-        NSLayoutConstraint.activate([
-            contentWarningOverlay.topAnchor.constraint(equalTo: topAnchor),
-            contentWarningOverlay.leadingAnchor.constraint(equalTo: leadingAnchor),
-            contentWarningOverlay.trailingAnchor.constraint(equalTo: trailingAnchor),
-            contentWarningOverlay.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        contentWarningOverlay.pinToParent()
     }
 }
 
@@ -208,12 +203,7 @@ extension MediaGridContainerView {
             let containerVerticalStackView = createStackView(axis: .vertical)
             containerVerticalStackView.translatesAutoresizingMaskIntoConstraints = false
             view.addSubview(containerVerticalStackView)
-            NSLayoutConstraint.activate([
-                containerVerticalStackView.topAnchor.constraint(equalTo: view.topAnchor),
-                containerVerticalStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                containerVerticalStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                containerVerticalStackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            ])
+            containerVerticalStackView.pinToParent()
             
             let count = mediaViews.count
             switch count {

--- a/MastodonSDK/Sources/MastodonUI/View/Content/FamiliarFollowersDashboardView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/FamiliarFollowersDashboardView.swift
@@ -45,12 +45,7 @@ extension FamiliarFollowersDashboardView {
         
         stackView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(stackView)
-        NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        stackView.pinToParent()
         
         avatarContainerView.translatesAutoresizingMaskIntoConstraints = false
         stackView.addArrangedSubview(avatarContainerView)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -138,12 +138,7 @@ extension MediaView {
     private func layoutImage() {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(imageView)
-        NSLayoutConstraint.activate([
-            imageView.topAnchor.constraint(equalTo: container.topAnchor),
-            imageView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            imageView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            imageView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-        ])
+        imageView.pinToParent()
     }
     
     private func bindImage(configuration: Configuration, info: Configuration.ImageInfo) {        
@@ -168,12 +163,7 @@ extension MediaView {
         // use view controller as View here
         playerViewController.view.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(playerViewController.view)
-        NSLayoutConstraint.activate([
-            playerViewController.view.topAnchor.constraint(equalTo: container.topAnchor),
-            playerViewController.view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            playerViewController.view.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            playerViewController.view.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-        ])
+        playerViewController.view.pinToParent()
         
         setupIndicatorViewHierarchy()
         playerIndicatorLabel.attributedText = NSAttributedString(string: "GIF")
@@ -213,12 +203,7 @@ extension MediaView {
     private func layoutBlurhash() {
         blurhashImageView.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(blurhashImageView)
-        NSLayoutConstraint.activate([
-            blurhashImageView.topAnchor.constraint(equalTo: container.topAnchor),
-            blurhashImageView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            blurhashImageView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            blurhashImageView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-        ])
+        blurhashImageView.pinToParent()
     }
     
     private func bindBlurhash(configuration: Configuration) {
@@ -304,12 +289,7 @@ extension MediaView {
         guard container.superview == nil else { return }
         container.translatesAutoresizingMaskIntoConstraints = false
         addSubview(container)
-        NSLayoutConstraint.activate([
-            container.topAnchor.constraint(equalTo: topAnchor),
-            container.leadingAnchor.constraint(equalTo: leadingAnchor),
-            container.trailingAnchor.constraint(equalTo: trailingAnchor),
-            container.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        container.pinToParent()
     }
 
     private func setupIndicatorViewHierarchy() {
@@ -329,12 +309,7 @@ extension MediaView {
         if vibrancyEffectView.superview == nil {
             vibrancyEffectView.translatesAutoresizingMaskIntoConstraints = false
             blurEffectView.contentView.addSubview(vibrancyEffectView)
-            NSLayoutConstraint.activate([
-                vibrancyEffectView.topAnchor.constraint(equalTo: blurEffectView.contentView.topAnchor),
-                vibrancyEffectView.leadingAnchor.constraint(equalTo: blurEffectView.contentView.leadingAnchor),
-                vibrancyEffectView.trailingAnchor.constraint(equalTo: blurEffectView.contentView.trailingAnchor),
-                vibrancyEffectView.bottomAnchor.constraint(equalTo: blurEffectView.contentView.bottomAnchor),
-            ])
+            vibrancyEffectView.pinToParent()
         }
         
         if playerIndicatorLabel.superview == nil {

--- a/MastodonSDK/Sources/MastodonUI/View/Content/NewsView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/NewsView.swift
@@ -79,12 +79,7 @@ extension NewsView {
         container.spacing = 8
         container.translatesAutoresizingMaskIntoConstraints = false
         addSubview(container)
-        NSLayoutConstraint.activate([
-            container.topAnchor.constraint(equalTo: topAnchor),
-            container.leadingAnchor.constraint(equalTo: leadingAnchor),
-            container.trailingAnchor.constraint(equalTo: trailingAnchor),
-            container.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        container.pinToParent()
         
         // textContainer: V - [ providerContainer | headlineLabel | (spacer) | footnoteLabel ]
         let textContainer = UIStackView()

--- a/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
@@ -338,7 +338,12 @@ extension NotificationView {
         quoteBackgroundView.layoutMargins = UIEdgeInsets(top: 16, left: 0, bottom: 0, right: 0)
         quoteBackgroundView.translatesAutoresizingMaskIntoConstraints = false
         quoteStatusViewContainerView.addSubview(quoteBackgroundView)
-        quoteBackgroundView.pinToParent()
+        NSLayoutConstraint.activate([
+            quoteBackgroundView.topAnchor.constraint(equalTo: quoteStatusViewContainerView.layoutMarginsGuide.topAnchor),
+            quoteBackgroundView.leadingAnchor.constraint(equalTo: quoteStatusViewContainerView.layoutMarginsGuide.leadingAnchor),
+            quoteBackgroundView.trailingAnchor.constraint(equalTo: quoteStatusViewContainerView.layoutMarginsGuide.trailingAnchor),
+            quoteBackgroundView.bottomAnchor.constraint(equalTo: quoteStatusViewContainerView.layoutMarginsGuide.bottomAnchor),
+        ])
         quoteBackgroundView.backgroundColor = .secondarySystemBackground
         quoteBackgroundView.layer.masksToBounds = true
         quoteBackgroundView.layer.cornerCurve = .continuous
@@ -348,7 +353,12 @@ extension NotificationView {
         
         quoteStatusView.translatesAutoresizingMaskIntoConstraints = false
         quoteBackgroundView.addSubview(quoteStatusView)
-        quoteStatusView.pinToParent()
+        NSLayoutConstraint.activate([
+            quoteStatusView.topAnchor.constraint(equalTo: quoteBackgroundView.layoutMarginsGuide.topAnchor),
+            quoteStatusView.leadingAnchor.constraint(equalTo: quoteBackgroundView.layoutMarginsGuide.leadingAnchor),
+            quoteStatusView.trailingAnchor.constraint(equalTo: quoteBackgroundView.layoutMarginsGuide.trailingAnchor),
+            quoteStatusView.bottomAnchor.constraint(equalTo: quoteBackgroundView.layoutMarginsGuide.bottomAnchor),
+        ])
         quoteStatusView.setup(style: .notificationQuote)
         
         statusView.isHidden = true

--- a/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
@@ -292,21 +292,11 @@ extension NotificationView {
         
         acceptFollowRequestButton.translatesAutoresizingMaskIntoConstraints = false
         acceptFollowRequestButtonShadowBackgroundContainer.addSubview(acceptFollowRequestButton)
-        NSLayoutConstraint.activate([
-            acceptFollowRequestButton.topAnchor.constraint(equalTo: acceptFollowRequestButtonShadowBackgroundContainer.topAnchor),
-            acceptFollowRequestButton.leadingAnchor.constraint(equalTo: acceptFollowRequestButtonShadowBackgroundContainer.leadingAnchor),
-            acceptFollowRequestButton.trailingAnchor.constraint(equalTo: acceptFollowRequestButtonShadowBackgroundContainer.trailingAnchor),
-            acceptFollowRequestButton.bottomAnchor.constraint(equalTo: acceptFollowRequestButtonShadowBackgroundContainer.bottomAnchor),
-        ])
+        acceptFollowRequestButton.pinToParent()
         
         rejectFollowRequestButton.translatesAutoresizingMaskIntoConstraints = false
         rejectFollowRequestButtonShadowBackgroundContainer.addSubview(rejectFollowRequestButton)
-        NSLayoutConstraint.activate([
-            rejectFollowRequestButton.topAnchor.constraint(equalTo: rejectFollowRequestButtonShadowBackgroundContainer.topAnchor),
-            rejectFollowRequestButton.leadingAnchor.constraint(equalTo: rejectFollowRequestButtonShadowBackgroundContainer.leadingAnchor),
-            rejectFollowRequestButton.trailingAnchor.constraint(equalTo: rejectFollowRequestButtonShadowBackgroundContainer.trailingAnchor),
-            rejectFollowRequestButton.bottomAnchor.constraint(equalTo: rejectFollowRequestButtonShadowBackgroundContainer.bottomAnchor),
-        ])
+        rejectFollowRequestButton.pinToParent()
         
         followRequestContainerView.axis = .horizontal
         followRequestContainerView.distribution = .fillEqually
@@ -348,12 +338,7 @@ extension NotificationView {
         quoteBackgroundView.layoutMargins = UIEdgeInsets(top: 16, left: 0, bottom: 0, right: 0)
         quoteBackgroundView.translatesAutoresizingMaskIntoConstraints = false
         quoteStatusViewContainerView.addSubview(quoteBackgroundView)
-        NSLayoutConstraint.activate([
-            quoteBackgroundView.topAnchor.constraint(equalTo: quoteStatusViewContainerView.layoutMarginsGuide.topAnchor),
-            quoteBackgroundView.leadingAnchor.constraint(equalTo: quoteStatusViewContainerView.layoutMarginsGuide.leadingAnchor),
-            quoteBackgroundView.trailingAnchor.constraint(equalTo: quoteStatusViewContainerView.layoutMarginsGuide.trailingAnchor),
-            quoteBackgroundView.bottomAnchor.constraint(equalTo: quoteStatusViewContainerView.layoutMarginsGuide.bottomAnchor),
-        ])
+        quoteBackgroundView.pinToParent()
         quoteBackgroundView.backgroundColor = .secondarySystemBackground
         quoteBackgroundView.layer.masksToBounds = true
         quoteBackgroundView.layer.cornerCurve = .continuous
@@ -363,12 +348,7 @@ extension NotificationView {
         
         quoteStatusView.translatesAutoresizingMaskIntoConstraints = false
         quoteBackgroundView.addSubview(quoteStatusView)
-        NSLayoutConstraint.activate([
-            quoteStatusView.topAnchor.constraint(equalTo: quoteBackgroundView.layoutMarginsGuide.topAnchor),
-            quoteStatusView.leadingAnchor.constraint(equalTo: quoteBackgroundView.layoutMarginsGuide.leadingAnchor),
-            quoteStatusView.trailingAnchor.constraint(equalTo: quoteBackgroundView.layoutMarginsGuide.trailingAnchor),
-            quoteStatusView.bottomAnchor.constraint(equalTo: quoteBackgroundView.layoutMarginsGuide.bottomAnchor),
-        ])
+        quoteStatusView.pinToParent()
         quoteStatusView.setup(style: .notificationQuote)
         
         statusView.isHidden = true

--- a/MastodonSDK/Sources/MastodonUI/View/Content/PollOptionView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/PollOptionView.swift
@@ -133,7 +133,7 @@ extension PollOptionView {
         
         plusCircleImageView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(plusCircleImageView)
-        plusCircleImageView.pinToParent()
+        plusCircleImageView.pinTo(to: checkmarkBackgroundView)
         
         optionTextField.translatesAutoresizingMaskIntoConstraints = false
         roundedBackgroundView.addSubview(optionTextField)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/PollOptionView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/PollOptionView.swift
@@ -110,12 +110,7 @@ extension PollOptionView {
         
         voteProgressStripView.translatesAutoresizingMaskIntoConstraints = false
         roundedBackgroundView.addSubview(voteProgressStripView)
-        NSLayoutConstraint.activate([
-            voteProgressStripView.topAnchor.constraint(equalTo: roundedBackgroundView.topAnchor),
-            voteProgressStripView.leadingAnchor.constraint(equalTo: roundedBackgroundView.leadingAnchor),
-            voteProgressStripView.trailingAnchor.constraint(equalTo: roundedBackgroundView.trailingAnchor),
-            voteProgressStripView.bottomAnchor.constraint(equalTo: roundedBackgroundView.bottomAnchor),
-        ])
+        voteProgressStripView.pinToParent()
         
         checkmarkBackgroundView.translatesAutoresizingMaskIntoConstraints = false
         roundedBackgroundView.addSubview(checkmarkBackgroundView)
@@ -138,12 +133,7 @@ extension PollOptionView {
         
         plusCircleImageView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(plusCircleImageView)
-        NSLayoutConstraint.activate([
-            plusCircleImageView.topAnchor.constraint(equalTo: checkmarkBackgroundView.topAnchor),
-            plusCircleImageView.leadingAnchor.constraint(equalTo: checkmarkBackgroundView.leadingAnchor),
-            plusCircleImageView.trailingAnchor.constraint(equalTo: checkmarkBackgroundView.trailingAnchor),
-            plusCircleImageView.bottomAnchor.constraint(equalTo: checkmarkBackgroundView.bottomAnchor),
-        ])
+        plusCircleImageView.pinToParent()
         
         optionTextField.translatesAutoresizingMaskIntoConstraints = false
         roundedBackgroundView.addSubview(optionTextField)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/ProfileCardView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/ProfileCardView.swift
@@ -137,12 +137,7 @@ extension ProfileCardView {
         container.spacing = 8
         container.translatesAutoresizingMaskIntoConstraints = false
         addSubview(container)
-        NSLayoutConstraint.activate([
-            container.topAnchor.constraint(equalTo: topAnchor),
-            container.leadingAnchor.constraint(equalTo: leadingAnchor),
-            container.trailingAnchor.constraint(equalTo: trailingAnchor),
-            container.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        container.pinToParent()
         
         // bannerContainer
         let bannerContainer = UIView()
@@ -237,11 +232,8 @@ extension ProfileCardView {
 
         relationshipActionButton.translatesAutoresizingMaskIntoConstraints = false
         relationshipActionButtonShadowContainer.addSubview(relationshipActionButton)
+        relationshipActionButton.pinToParent()
         NSLayoutConstraint.activate([
-            relationshipActionButton.topAnchor.constraint(equalTo: relationshipActionButtonShadowContainer.topAnchor),
-            relationshipActionButton.leadingAnchor.constraint(equalTo: relationshipActionButtonShadowContainer.leadingAnchor),
-            relationshipActionButton.trailingAnchor.constraint(equalTo: relationshipActionButtonShadowContainer.trailingAnchor),
-            relationshipActionButton.bottomAnchor.constraint(equalTo: relationshipActionButtonShadowContainer.bottomAnchor),
             relationshipActionButtonShadowContainer.widthAnchor.constraint(greaterThanOrEqualToConstant: ProfileCardView.friendshipActionButtonSize.width).priority(.required - 1),
             relationshipActionButtonShadowContainer.heightAnchor.constraint(equalToConstant: ProfileCardView.friendshipActionButtonSize.height).priority(.required - 1),
         ])

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -236,12 +236,7 @@ extension StatusView {
         // container
         containerStackView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(containerStackView)
-        NSLayoutConstraint.activate([
-            containerStackView.topAnchor.constraint(equalTo: topAnchor),
-            containerStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            containerStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            containerStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        containerStackView.pinToParent()
         
         // header
         headerIconImageView.isUserInteractionEnabled = false
@@ -392,12 +387,7 @@ extension StatusView.Style {
 
         statusView.spoilerOverlayView.translatesAutoresizingMaskIntoConstraints = false
         statusView.containerStackView.addSubview(statusView.spoilerOverlayView)
-        NSLayoutConstraint.activate([
-            statusView.contentContainer.topAnchor.constraint(equalTo: statusView.spoilerOverlayView.topAnchor),
-            statusView.contentContainer.leadingAnchor.constraint(equalTo: statusView.spoilerOverlayView.leadingAnchor),
-            statusView.contentContainer.trailingAnchor.constraint(equalTo: statusView.spoilerOverlayView.trailingAnchor),
-            statusView.contentContainer.bottomAnchor.constraint(equalTo: statusView.spoilerOverlayView.bottomAnchor),
-        ])
+        statusView.contentContainer.pinTo(to: statusView.spoilerOverlayView)
 
         // media container: V - [ mediaGridContainerView ]
         statusView.mediaContainerView.translatesAutoresizingMaskIntoConstraints = false
@@ -409,12 +399,7 @@ extension StatusView.Style {
 
         statusView.mediaGridContainerView.translatesAutoresizingMaskIntoConstraints = false
         statusView.mediaContainerView.addSubview(statusView.mediaGridContainerView)
-        NSLayoutConstraint.activate([
-            statusView.mediaGridContainerView.topAnchor.constraint(equalTo: statusView.mediaContainerView.topAnchor),
-            statusView.mediaGridContainerView.leadingAnchor.constraint(equalTo: statusView.mediaContainerView.leadingAnchor),
-            statusView.mediaGridContainerView.trailingAnchor.constraint(equalTo: statusView.mediaContainerView.trailingAnchor),
-            statusView.mediaGridContainerView.bottomAnchor.constraint(equalTo: statusView.mediaContainerView.bottomAnchor),
-        ])
+        statusView.mediaGridContainerView.pinToParent()
 
         // pollContainerView: V - [ pollTableView | pollStatusStackView ]
         statusView.pollAdaptiveMarginContainerView.contentView = statusView.pollContainerView

--- a/MastodonSDK/Sources/MastodonUI/View/Content/UserView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/UserView.swift
@@ -66,12 +66,7 @@ extension UserView {
         // container
         containerStackView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(containerStackView)
-        NSLayoutConstraint.activate([
-            containerStackView.topAnchor.constraint(equalTo: topAnchor),
-            containerStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            containerStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            containerStackView.bottomAnchor.constraint(equalTo: bottomAnchor)
-        ])
+        containerStackView.pinToParent()
         
         avatarButton.translatesAutoresizingMaskIntoConstraints = false
         containerStackView.addArrangedSubview(avatarButton)

--- a/MastodonSDK/Sources/MastodonUI/View/Control/SpoilerOverlayView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Control/SpoilerOverlayView.swift
@@ -48,12 +48,7 @@ extension SpoilerOverlayView {
     private func _init() {
         containerStackView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(containerStackView)
-        NSLayoutConstraint.activate([
-            containerStackView.topAnchor.constraint(equalTo: topAnchor),
-            containerStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            containerStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            containerStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        containerStackView.pinToParent()
         
         let topPaddingView = UIView()
         topPaddingView.translatesAutoresizingMaskIntoConstraints = false

--- a/MastodonSDK/Sources/MastodonUI/View/TableViewCell/PollOptionTableViewCell.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/TableViewCell/PollOptionTableViewCell.swift
@@ -53,12 +53,7 @@ extension PollOptionTableViewCell {
         
         pollOptionView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(pollOptionView)
-        NSLayoutConstraint.activate([
-            pollOptionView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            pollOptionView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            pollOptionView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            pollOptionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-        ])
+        pollOptionView.pinToParent()
         pollOptionView.setup(style: .plain)
     }
     

--- a/MastodonSDK/Sources/MastodonUI/View/TableViewCell/ProfileCardTableViewCell.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/TableViewCell/ProfileCardTableViewCell.swift
@@ -67,12 +67,7 @@ extension ProfileCardTableViewCell {
         
         profileCardView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(profileCardView)
-        NSLayoutConstraint.activate([
-            profileCardView.topAnchor.constraint(equalTo: shadowBackgroundContainer.topAnchor),
-            profileCardView.leadingAnchor.constraint(equalTo: shadowBackgroundContainer.leadingAnchor),
-            profileCardView.trailingAnchor.constraint(equalTo: shadowBackgroundContainer.trailingAnchor),
-            profileCardView.bottomAnchor.constraint(equalTo: shadowBackgroundContainer.bottomAnchor),
-        ])
+        profileCardView.pinTo(to: shadowBackgroundContainer)
         
         profileCardView.delegate = self
         

--- a/MastodonSDK/Sources/MastodonUI/View/TableViewCell/TimelineLoaderTableViewCell.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/TableViewCell/TimelineLoaderTableViewCell.swift
@@ -96,12 +96,7 @@ open class TimelineLoaderTableViewCell: UITableViewCell {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.isUserInteractionEnabled = false
         contentView.addSubview(stackView)
-        NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: loadMoreButton.topAnchor),
-            stackView.leadingAnchor.constraint(equalTo: loadMoreButton.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: loadMoreButton.trailingAnchor),
-            stackView.bottomAnchor.constraint(equalTo: loadMoreButton.bottomAnchor),
-        ])
+        stackView.pinTo(to: loadMoreButton)
         let leftPaddingView = UIView()
         leftPaddingView.translatesAutoresizingMaskIntoConstraints = false
         stackView.addArrangedSubview(leftPaddingView)

--- a/ShareActionExtension/Scene/ShareViewController.swift
+++ b/ShareActionExtension/Scene/ShareViewController.swift
@@ -102,12 +102,7 @@ extension ShareViewController {
             addChild(composeContentViewController)
             composeContentViewController.view.translatesAutoresizingMaskIntoConstraints = false
             view.addSubview(composeContentViewController.view)
-            NSLayoutConstraint.activate([
-                composeContentViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
-                composeContentViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                composeContentViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                composeContentViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            ])
+            composeContentViewController.view.pinToParent()
             composeContentViewController.didMove(toParent: self)
             
             self.composeContentViewModel = composeContentViewModel


### PR DESCRIPTION
[Refactoring Task]
Creating anchors to a specific view (mostly the parent view) is reoccurring code, that can be achieved by an extension of UIView.
It easier to read - in case there is no special constraint necessary.