### PR TITLE
chore: Disable double-tap-to-switch-account

### DIFF
--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -326,7 +326,7 @@ extension MainTabBarController {
         tabBarLongPressGestureRecognizer.addTarget(self, action: #selector(MainTabBarController.tabBarLongPressGestureRecognizerHandler(_:)))
         tabBar.addGestureRecognizer(tabBarLongPressGestureRecognizer)
 
-        // todo: reconsider the "double tap to change account" feature
+        // todo: reconsider the "double tap to change account" feature -> https://github.com/mastodon/mastodon-ios/issues/628
 //        let tabBarDoubleTapGestureRecognizer = UITapGestureRecognizer()
 //        tabBarDoubleTapGestureRecognizer.numberOfTapsRequired = 2
 //        tabBarDoubleTapGestureRecognizer.addTarget(self, action: #selector(MainTabBarController.tabBarDoubleTapGestureRecognizerHandler(_:)))

--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -326,11 +326,12 @@ extension MainTabBarController {
         tabBarLongPressGestureRecognizer.addTarget(self, action: #selector(MainTabBarController.tabBarLongPressGestureRecognizerHandler(_:)))
         tabBar.addGestureRecognizer(tabBarLongPressGestureRecognizer)
 
-        let tabBarDoubleTapGestureRecognizer = UITapGestureRecognizer()
-        tabBarDoubleTapGestureRecognizer.numberOfTapsRequired = 2
-        tabBarDoubleTapGestureRecognizer.addTarget(self, action: #selector(MainTabBarController.tabBarDoubleTapGestureRecognizerHandler(_:)))
-        tabBarDoubleTapGestureRecognizer.delaysTouchesEnded = false
-        tabBar.addGestureRecognizer(tabBarDoubleTapGestureRecognizer)
+        // todo: reconsider the "double tap to change account" feature
+//        let tabBarDoubleTapGestureRecognizer = UITapGestureRecognizer()
+//        tabBarDoubleTapGestureRecognizer.numberOfTapsRequired = 2
+//        tabBarDoubleTapGestureRecognizer.addTarget(self, action: #selector(MainTabBarController.tabBarDoubleTapGestureRecognizerHandler(_:)))
+//        tabBarDoubleTapGestureRecognizer.delaysTouchesEnded = false
+//        tabBar.addGestureRecognizer(tabBarDoubleTapGestureRecognizer)
 
         self.isReadyForWizardAvatarButton = authContext != nil
         

--- a/Mastodon/Scene/Root/Sidebar/SidebarViewController.swift
+++ b/Mastodon/Scene/Root/Sidebar/SidebarViewController.swift
@@ -145,12 +145,13 @@ extension SidebarViewController {
         sidebarLongPressGestureRecognizer.addTarget(self, action: #selector(SidebarViewController.sidebarLongPressGestureRecognizerHandler(_:)))
         collectionView.addGestureRecognizer(sidebarLongPressGestureRecognizer)
         
-        let sidebarDoubleTapGestureRecognizer = UITapGestureRecognizer()
-        sidebarDoubleTapGestureRecognizer.numberOfTapsRequired = 2
-        sidebarDoubleTapGestureRecognizer.addTarget(self, action: #selector(SidebarViewController.sidebarDoubleTapGestureRecognizerHandler(_:)))
-        sidebarDoubleTapGestureRecognizer.delaysTouchesEnded = false
-        sidebarDoubleTapGestureRecognizer.cancelsTouchesInView = true
-        collectionView.addGestureRecognizer(sidebarDoubleTapGestureRecognizer)
+        // todo: reconsider the "double tap to change account" feature
+//        let sidebarDoubleTapGestureRecognizer = UITapGestureRecognizer()
+//        sidebarDoubleTapGestureRecognizer.numberOfTapsRequired = 2
+//        sidebarDoubleTapGestureRecognizer.addTarget(self, action: #selector(SidebarViewController.sidebarDoubleTapGestureRecognizerHandler(_:)))
+//        sidebarDoubleTapGestureRecognizer.delaysTouchesEnded = false
+//        sidebarDoubleTapGestureRecognizer.cancelsTouchesInView = true
+//        collectionView.addGestureRecognizer(sidebarDoubleTapGestureRecognizer)
 
     }
     

--- a/Mastodon/Scene/Root/Sidebar/SidebarViewController.swift
+++ b/Mastodon/Scene/Root/Sidebar/SidebarViewController.swift
@@ -145,7 +145,7 @@ extension SidebarViewController {
         sidebarLongPressGestureRecognizer.addTarget(self, action: #selector(SidebarViewController.sidebarLongPressGestureRecognizerHandler(_:)))
         collectionView.addGestureRecognizer(sidebarLongPressGestureRecognizer)
         
-        // todo: reconsider the "double tap to change account" feature
+        // todo: reconsider the "double tap to change account" feature -> https://github.com/mastodon/mastodon-ios/issues/628
 //        let sidebarDoubleTapGestureRecognizer = UITapGestureRecognizer()
 //        sidebarDoubleTapGestureRecognizer.numberOfTapsRequired = 2
 //        sidebarDoubleTapGestureRecognizer.addTarget(self, action: #selector(SidebarViewController.sidebarDoubleTapGestureRecognizerHandler(_:)))


### PR DESCRIPTION
# Rationale

As the feature has proven to be not fully baked yet we decided to, for `v1.4.7`, disable it.