### PR TITLE
fix: Status notification shows "mentioned you" text

### DIFF
--- a/Mastodon/Extension/String.swift
+++ b/Mastodon/Extension/String.swift
@@ -15,6 +15,8 @@ extension String {
     mutating func capitalizeFirstLetter() {
         self = self.capitalizingFirstLetter()
     }
+    
+    static let empty = ""
 }
 
 extension String {

--- a/Mastodon/Scene/Share/View/Content/NotificationView+Configuration.swift
+++ b/Mastodon/Scene/Share/View/Content/NotificationView+Configuration.swift
@@ -154,7 +154,7 @@ extension NotificationView {
                 )
             case .status:
                 self.viewModel.notificationIndicatorText = createMetaContent(
-                    text: L10n.Scene.Notification.NotificationDescription.mentionedYou,
+                    text: .empty,
                     emojis: emojis.asDictionary
                 )
             case ._other:


### PR DESCRIPTION
# Rationale

Previously a status mention showed "mentioned you" in the Notifications area

# Demo

| Before | After |
|---|---|
| <img width="396" alt="Bildschirm­foto 2022-11-18 um 10 52 59" src="https://user-images.githubusercontent.com/126418/202674122-cefc1fbd-f97c-47cb-b92a-b07cd1f04f65.png"> | <img width="401" alt="Bildschirm­foto 2022-11-18 um 10 53 57" src="https://user-images.githubusercontent.com/126418/202674116-d891d938-b4b2-4864-aa19-f9cd1fbb9b33.png"> | 
