### PR TITLE
Bump the timeout interval for all requests to 60s

### DIFF
--- a/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API.swift
+++ b/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API.swift
@@ -11,7 +11,7 @@ import enum NIOHTTP1.HTTPResponseStatus
 
 extension Mastodon.API {
         
-    static let timeoutInterval: TimeInterval = 10
+    static let timeoutInterval: TimeInterval = 60
     
     static let httpHeaderDateFormatter: ISO8601DateFormatter = {
         var formatter = ISO8601DateFormatter()


### PR DESCRIPTION
Targeting this against the release branch so that it can be included in the upcoming release. Hopefully Mastodon (especially .social) will recover soon and will be more scalable in the face of sudden user growth in the future, but in the meantime the app is unusable with the current timeout. And the change is fairly simple — “what could possibly go wrong?”