### PR TITLE
Always allow to continue when reporting a post if at least one is selected

### DIFF
--- a/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
+++ b/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
@@ -58,7 +58,6 @@ class ReportStatusViewController: UIViewController, NeedsDependency, ReportViewC
     let navigationActionView: NavigationActionView = {
         let navigationActionView = NavigationActionView()
         navigationActionView.backgroundColor = Asset.Scene.Onboarding.background.color
-        navigationActionView.backButton.setTitle(L10n.Common.Controls.Actions.skip, for: .normal)
         navigationActionView.hidesBackButton = true
         return navigationActionView
     }()

--- a/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
+++ b/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
@@ -58,6 +58,7 @@ class ReportStatusViewController: UIViewController, NeedsDependency, ReportViewC
     let navigationActionView: NavigationActionView = {
         let navigationActionView = NavigationActionView()
         navigationActionView.backgroundColor = Asset.Scene.Onboarding.background.color
+        navigationActionView.backButton.setTitle(L10n.Common.Controls.Actions.skip, for: .normal)
         navigationActionView.hidesBackButton = true
         return navigationActionView
     }()

--- a/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
+++ b/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
@@ -59,7 +59,6 @@ class ReportStatusViewController: UIViewController, NeedsDependency, ReportViewC
         let navigationActionView = NavigationActionView()
         navigationActionView.backgroundColor = Asset.Scene.Onboarding.background.color
         navigationActionView.backButton.setTitle(L10n.Common.Controls.Actions.skip, for: .normal)
-        navigationActionView.hidesBackButton = true
         return navigationActionView
     }()
     
@@ -123,6 +122,10 @@ extension ReportStatusViewController {
             .receive(on: DispatchQueue.main)
             .assign(to: \.isEnabled, on: navigationActionView.nextButton)
             .store(in: &disposeBag)
+        
+        if !viewModel.selectStatuses.isEmpty {
+            navigationActionView.hidesBackButton = true
+        }
         
         navigationActionView.backButton.addTarget(self, action: #selector(ReportStatusViewController.skipButtonDidPressed(_:)), for: .touchUpInside)
         navigationActionView.nextButton.addTarget(self, action: #selector(ReportStatusViewController.nextButtonDidPressed(_:)), for: .touchUpInside)        

--- a/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
+++ b/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
@@ -59,6 +59,7 @@ class ReportStatusViewController: UIViewController, NeedsDependency, ReportViewC
         let navigationActionView = NavigationActionView()
         navigationActionView.backgroundColor = Asset.Scene.Onboarding.background.color
         navigationActionView.backButton.setTitle(L10n.Common.Controls.Actions.skip, for: .normal)
+        navigationActionView.hidesBackButton = true
         return navigationActionView
     }()
     

--- a/Mastodon/Scene/Report/ReportStatus/ReportStatusViewModel.swift
+++ b/Mastodon/Scene/Report/ReportStatus/ReportStatusViewModel.swift
@@ -71,9 +71,7 @@ class ReportStatusViewModel {
         }
 
         $selectStatuses
-            .map { statuses -> Bool in
-                return status == nil ? !statuses.isEmpty : statuses.count > 1
-            }
+            .map { !$0.isEmpty }
             .assign(to: &$isNextButtonEnabled)
     }
 


### PR DESCRIPTION
# Rationale

Currently the "Report Post" functionality can be a bit misleading, as the next button is only enabled if an additional post is selected.

When selecting a user to block, not a post, then the flow will be the same and still show the Skip button (as no post has been selected previously).

Sorry for the person and their post depicted in the screenshot, this only serves as an example and has not been reported.

# Demo

| Before | After |
|---|---|
| ![RocketSim_Screenshot_iPhone_14_Pro_2022-11-21_11 28 30](https://user-images.githubusercontent.com/126418/203027939-bbad2b7c-907c-4ea1-9278-bc67f5baf876.png)  | ![RocketSim_Recording_iPhone_14_Pro_2022-11-21_11 26 22](https://user-images.githubusercontent.com/126418/203027790-5d276582-c00d-4be1-bfb9-450bfbc0f67f.gif)|
