### PR TITLE
Fix no downscaling for raw image from camera issue

### DIFF
--- a/Mastodon/Scene/Compose/ComposeViewController.swift
+++ b/Mastodon/Scene/Compose/ComposeViewController.swift
@@ -209,6 +209,7 @@ extension ComposeViewController {
                     api: viewModel.context.apiService,
                     authContext: viewModel.authContext,
                     input: .image(image),
+                    sizeLimit: composeContentViewModel.sizeLimit,
                     delegate: composeContentViewModel
                 )
             }

--- a/MastodonSDK/Sources/MastodonUI/Extension/UIImage.swift
+++ b/MastodonSDK/Sources/MastodonUI/Extension/UIImage.swift
@@ -16,3 +16,14 @@ extension UIImage {
     }
     
 }
+
+extension UIImage {
+    public func normalized() -> UIImage? {
+        if imageOrientation == .up { return self }
+        UIGraphicsBeginImageContext(size)
+        draw(in: CGRect(origin: CGPoint.zero, size: size))
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image
+    }
+ }

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentViewModel+Compress.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentViewModel+Compress.swift
@@ -97,7 +97,7 @@ extension AttachmentViewModel {
 extension AttachmentViewModel {
     @AttachmentViewModelActor
     func compressImage(data: Data, sizeLimit: SizeLimit) throws -> Output {
-        let maxPayloadSizeInBytes = sizeLimit.image ?? 10 * 1024 * 1024
+        let maxPayloadSizeInBytes = max((sizeLimit.image ?? 10 * 1024 * 1024), 1 * 1024 * 1024)
 
         guard let image = KFCrossPlatformImage(data: data)?.kf.normalized,
               var imageData = image.kf.pngRepresentation()

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentViewModel+Load.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentViewModel+Load.swift
@@ -16,7 +16,7 @@ extension AttachmentViewModel {
     func load(input: Input) async throws -> Output {
         switch input {
         case .image(let image):
-            guard let data = image.pngData() else {
+            guard let data = image.normalized()?.pngData() else {
                 throw AttachmentError.invalidAttachmentType
             }
             return .image(data, imageKind: .png)

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewController.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewController.swift
@@ -435,6 +435,7 @@ extension ComposeContentViewController: PHPickerViewControllerDelegate {
                 api: viewModel.context.apiService,
                 authContext: viewModel.authContext,
                 input: .pickerResult(result),
+                sizeLimit: viewModel.sizeLimit,
                 delegate: viewModel
             )
         }
@@ -453,6 +454,7 @@ extension ComposeContentViewController: UIImagePickerControllerDelegate & UINavi
             api: viewModel.context.apiService,
             authContext: viewModel.authContext,
             input: .image(image),
+            sizeLimit: viewModel.sizeLimit,
             delegate: viewModel
         )
         viewModel.attachmentViewModels += [attachmentViewModel]
@@ -473,6 +475,7 @@ extension ComposeContentViewController: UIDocumentPickerDelegate {
             api: viewModel.context.apiService,
             authContext: viewModel.authContext,
             input: .url(url),
+            sizeLimit: viewModel.sizeLimit,
             delegate: viewModel
         )
         viewModel.attachmentViewModels += [attachmentViewModel]

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
@@ -88,7 +88,7 @@ public final class ComposeContentViewModel: NSObject, ObservableObject {
     // attachment
     @Published public var attachmentViewModels: [AttachmentViewModel] = []
     @Published public var maxMediaAttachmentLimit = 4
-    // @Published public internal(set) var isMediaValid = true
+    @Published public internal(set) var maxImageMediaSizeLimitInByte = 10 * 1024 * 1024     // 10 MiB
     
     // poll
     @Published public var isPollActive = false
@@ -126,6 +126,14 @@ public final class ComposeContentViewModel: NSObject, ObservableObject {
     @Published var isPollButtonEnabled = false
     
     @Published public private(set) var shouldDismiss = true
+    
+    // size limit
+    public var sizeLimit: AttachmentViewModel.SizeLimit {
+        AttachmentViewModel.SizeLimit(
+            image: maxImageMediaSizeLimitInByte,
+            video: nil
+        )
+    }
 
     public init(
         context: AppContext,
@@ -251,6 +259,10 @@ public final class ComposeContentViewModel: NSObject, ObservableObject {
             // set poll option limit
             if let maxOptions = configuration.polls?.maxOptions {
                 maxPollOptionLimit = maxOptions
+            }
+            // set photo attachment limit
+            if let imageSizeLimit = configuration.mediaAttachments?.imageSizeLimit {
+                maxImageMediaSizeLimitInByte = imageSizeLimit
             }
             // TODO: more limit
         }

--- a/ShareActionExtension/Scene/ShareViewController.swift
+++ b/ShareActionExtension/Scene/ShareViewController.swift
@@ -276,6 +276,7 @@ extension ShareViewController {
                 api: context.apiService,
                 authContext: authContext,
                 input: .itemProvider(movieProvider),
+                sizeLimit: .init(image: nil, video: nil),
                 delegate: composeContentViewModel
             )
             composeContentViewModel.attachmentViewModels.append(attachmentViewModel)
@@ -285,6 +286,7 @@ extension ShareViewController {
                     api: context.apiService,
                     authContext: authContext,
                     input: .itemProvider(provider),
+                    sizeLimit: .init(image: nil, video: nil),
                     delegate: composeContentViewModel
                 )
             }


### PR DESCRIPTION
resolve #665 

The app doesn't compress images from the camera. So the attachment may always too large to upload.

This patch compresses the photo to the server image size limit (fallback to 10 MiB limit if no limitation from the server). The image input will be handled this workflow:

1. normalized png data
2. upload when smaller then size limit
3. compress to JPEG with q=0.8 (loop=1)
4. compress to JPEG with q=0.8, size_scale=0.8 (loop > 1)