### PR TITLE
Fix share extension reentry crash issue

### DIFF
--- a/MastodonSDK/Sources/MastodonCore/AppContext.swift
+++ b/MastodonSDK/Sources/MastodonCore/AppContext.swift
@@ -115,6 +115,10 @@ public class AppContext: ObservableObject {
             .store(in: &disposeBag)
     }
     
+    deinit {
+        os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
+    }
+    
 }
 
 extension AppContext {

--- a/ShareActionExtension/Scene/ShareViewController.swift
+++ b/ShareActionExtension/Scene/ShareViewController.swift
@@ -21,7 +21,7 @@ final class ShareViewController: UIViewController {
     
     var disposeBag = Set<AnyCancellable>()
     
-    let context = AppContext()
+    let context = AppContext.shared
     private(set) lazy var viewModel = ShareViewModel(context: context)
     
     let publishButton: UIButton = {
@@ -63,6 +63,10 @@ final class ShareViewController: UIViewController {
         label.text = "No Available Account" // TODO: i18n
         return label
     }()
+    
+    deinit {
+        os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
+    }
 
 }
 
@@ -155,7 +159,7 @@ extension ShareViewController {
                 _ = try await statusPublisher.publish(api: context.apiService, authContext: authContext)
                 
                 self.publishButton.setTitle(L10n.Common.Controls.Actions.done, for: .normal)
-                try await  Task.sleep(nanoseconds: 1 * .second)
+                try await Task.sleep(nanoseconds: 1 * .second)
                 
                 self.extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)
 
@@ -324,4 +328,8 @@ extension ShareViewController {
         case userCancelShare
         case missingAuthentication
     }
+}
+
+extension AppContext {
+    static let shared = AppContext()
 }


### PR DESCRIPTION
The CoreDataStack instance somehow leaked when the share extension exited. So if extension reentry before killed by the system. The duplicated init CoreDataStack raises an exception and crashes the extension. 

Using a singleton AppContext to avoid the CoreDataStack leaking to workaround this problem.

#### Before
https://user-images.githubusercontent.com/7940186/203484270-c582e4cd-b573-41f2-b3cd-d4dfe1b1c795.mp4

#### After
https://user-images.githubusercontent.com/7940186/203484274-13652c9a-8eae-4963-93c3-6f5c0e8737e9.mp4