### PR TITLE
Fix profile page scroll to top cannot trigger issue

### DIFF
--- a/Mastodon/Scene/Profile/ProfileViewController.swift
+++ b/Mastodon/Scene/Profile/ProfileViewController.swift
@@ -885,7 +885,7 @@ extension ProfileViewController: MastodonMenuDelegate {
 // MARK: - ScrollViewContainer
 extension ProfileViewController: ScrollViewContainer {
     var scrollView: UIScrollView {
-        return tabBarPagerController.containerScrollView
+        return tabBarPagerController.relayScrollView
     }
 }
 


### PR DESCRIPTION
There is a single tap gesture to trigger scroll-to-top action for scroll view. But somehow it's not work in iOS 16. 

The underlying scroll logic is driven by `TabBarPager` which is a shared framework from `TwidereProject`. There are two scrollViews to control the position of the parallax header and pages. Use the `relayScrollView` to perform scroll to top to fix this problem. (But `containerScrollView` also worked before iOS 16).

#### Before (v1.4.7)
https://user-images.githubusercontent.com/7940186/204056623-62244a94-d967-4998-a2b7-4929a01ec2d6.mp4

#### After (should be the same in v1.4.5)
https://user-images.githubusercontent.com/7940186/204057003-dfd12b50-7147-4ee3-9217-e8d7575c45dd.mp4

