### PR TITLE
Space buttons instead of stretching

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
@@ -105,7 +105,7 @@ extension ActionToolbarContainer {
             shareButton.setImage(ActionToolbarContainer.shareImage, for: .normal)
             
             container.axis = .horizontal
-            container.distribution = .fill
+            container.distribution = .equalSpacing
             
             replyButton.translatesAutoresizingMaskIntoConstraints = false
             reblogButton.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
The tap targets for buttons are currently misleading, and I'll tap the space in between to go to the details and end up performing an unintended action. This is how Twitter works, so users migrating will probably expect this too.