### PR TITLE
Add support for server-side user preferences

### DIFF
--- a/Documentation/How-it-works.md
+++ b/Documentation/How-it-works.md
@@ -40,9 +40,9 @@ There is a self-hosted Swift Package that contains the common libraries to build
 #### CoreDataStack
 App uses Core Data as the backend to persist all entitles from the server. So the app has the capability to keep the timeline and notifications. Another reason for using a database is it makes the app could respond to entity changes between different sources. For example, a user could skim in the home timeline and then interact with the same post on other pages with favorite or reblog action. Core Data will handle the property modifications and notify the home timeline to update the view.
 
-To simplify the database operations. There is only one persistent store for all accounts. We use `domain` to identify entity for different servers (a.k.a instance). Do not mix the `domain` with the Mastodon remote server name. For example. The domain is `mastodon.online` whereever the post (e.g. post come from `mstdn.jp`) and friends from for the account sign in `mastodon.online`. Also, do not only rely on `id` because it has conflict potential between different `domain`. The unique predicate is `domain` + `id`.
+To simplify the database operations. There is only one persistent store for all accounts. We use `domain` to identify entity for different servers (a.k.a instance). Do not mix the `domain` with the Mastodon remote server name. For example. The domain is `mastodon.online` wherever the post (e.g. post come from `mstdn.jp`) and friends from for the account sign in `mastodon.online`. Also, do not only rely on `id` because it has conflict potential between different `domain`. The unique predicate is `domain` + `id`.
 
-The app use "One stack, two context" setup. There is one main managed object context for UI displaying and another background managed context for entities creating and updating. We assert the background context performs in a queue. Also, the app could accept mulitple background context model. Then the flag `-com.apple.CoreData.ConcurrencyDebug 1` will be usful.
+The app use "One stack, two context" setup. There is one main managed object context for UI displaying and another background managed context for entities creating and updating. We assert the background context performs in a queue. Also, the app could accept multiple background context model. Then the flag `-com.apple.CoreData.ConcurrencyDebug 1` will be useful.
 
 ###### How to create a new Entity
 First, select the `CoreData.xcdatamodeld` file and in menu `Editor > Add Model Version…` to create a new version. Make sure active the new version in the inspect panel. e.g. `Model Version. Current > "Core Data 5"`
@@ -58,7 +58,23 @@ We using the Core Data lightweight migration. Please check the rules detail [her
 
 Tip: 
 
-Please check the `Soucery` and use that generates getter and setter for properties and relationships. It's could save you time. To take the benefit from the dynamic property. We can declare a raw value property and then use compute property to construct the struct we want (e.g. `Feed.acct`). Or control the primitive by hand and declare the mirror type for this value (e.g `Status.attachments`).
+Please check the `Sourcery` and use that generates getter and setter for properties and relationships. It's could save you time. To take the benefit from the dynamic property. We can declare a raw value property and then use compute property to construct the struct we want (e.g. `Feed.acct`). Or control the primitive by hand and declare the mirror type for this value (e.g `Status.attachments`).
+
+Note: Sourcery requires that you manually type the out conformances for the templates you want to use. Once you build, the `sourcery:inline:*` sections will be filled in for you.
+
+```swift
+// MARK: - AutoGenerateProperty
+extension Preference: AutoGenerateProperty {
+    // sourcery:inline:Preference.AutoGenerateProperty
+    // sourcery:end
+}
+
+// MARK: - AutoUpdatableObject
+extension Preference: AutoUpdatableObject {
+    // sourcery:inline:Preference.AutoUpdatableObject
+    // sourcery:end
+}
+```
 
 ###### How to persist the Entity
 Please check the `Persistence+Status.swift`. We follow the pattern: migrate the old one if exists. Otherwise, create a new one. (Maybe some improvements could be adopted?)

--- a/Mastodon/Diffable/Status/StatusSection.swift
+++ b/Mastodon/Diffable/Status/StatusSection.swift
@@ -33,6 +33,7 @@ extension StatusSection {
         weak var timelineMiddleLoaderTableViewCellDelegate: TimelineMiddleLoaderTableViewCellDelegate?
         let filterContext: Mastodon.Entity.Filter.Context?
         let activeFilters: Published<[Mastodon.Entity.Filter]>.Publisher?
+        let preferences: CurrentValueSubject<Mastodon.Entity.Preferences, Never>
     }
 
     static func diffableDataSource(
@@ -281,6 +282,7 @@ extension StatusSection {
         
         cell.statusView.viewModel.context = configuration.context
         cell.statusView.viewModel.authContext = configuration.authContext
+        cell.statusView.viewModel.currentPreferences = configuration.preferences
         
         cell.configure(
             tableView: tableView,
@@ -309,7 +311,8 @@ extension StatusSection {
         
         cell.statusView.viewModel.context = configuration.context
         cell.statusView.viewModel.authContext = configuration.authContext
-        
+        cell.statusView.viewModel.currentPreferences = configuration.preferences
+
         cell.configure(
             tableView: tableView,
             viewModel: viewModel,

--- a/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewModel+Diffable.swift
+++ b/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewModel+Diffable.swift
@@ -23,7 +23,8 @@ extension DiscoveryCommunityViewModel {
                 statusTableViewCellDelegate: statusTableViewCellDelegate,
                 timelineMiddleLoaderTableViewCellDelegate: nil,
                 filterContext: .none,
-                activeFilters: nil
+                activeFilters: nil,
+                preferences: context.preferencesService.currentPreferences
             )
         )
         

--- a/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewModel+Diffable.swift
+++ b/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewModel+Diffable.swift
@@ -23,7 +23,8 @@ extension DiscoveryPostsViewModel {
                 statusTableViewCellDelegate: statusTableViewCellDelegate,
                 timelineMiddleLoaderTableViewCellDelegate: nil,
                 filterContext: .none,
-                activeFilters: nil
+                activeFilters: nil,
+                preferences: context.preferencesService.currentPreferences
             )
         )
         

--- a/Mastodon/Scene/HashtagTimeline/HashtagTimelineViewModel+Diffable.swift
+++ b/Mastodon/Scene/HashtagTimeline/HashtagTimelineViewModel+Diffable.swift
@@ -25,7 +25,8 @@ extension HashtagTimelineViewModel {
                 statusTableViewCellDelegate: statusTableViewCellDelegate,
                 timelineMiddleLoaderTableViewCellDelegate: nil,
                 filterContext: .none,
-                activeFilters: nil
+                activeFilters: nil,
+                preferences: context.preferencesService.currentPreferences
             )
         )
 

--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel+Diffable.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel+Diffable.swift
@@ -27,7 +27,8 @@ extension HomeTimelineViewModel {
                 statusTableViewCellDelegate: statusTableViewCellDelegate,
                 timelineMiddleLoaderTableViewCellDelegate: timelineMiddleLoaderTableViewCellDelegate,
                 filterContext: .home,
-                activeFilters: context.statusFilterService.$activeFilters
+                activeFilters: context.statusFilterService.$activeFilters,
+                preferences: context.preferencesService.currentPreferences
             )
         )
 

--- a/Mastodon/Scene/Onboarding/Share/AuthenticationViewModel.swift
+++ b/Mastodon/Scene/Onboarding/Share/AuthenticationViewModel.swift
@@ -215,7 +215,8 @@ extension AuthenticationViewModel {
                 appAccessToken: userToken.accessToken,  // TODO: swap app token
                 userAccessToken: userToken.accessToken,
                 clientID: info.clientID,
-                clientSecret: info.clientSecret
+                clientSecret: info.clientSecret,
+                preferences: nil
             )
             return managedObjectContext.performChanges {
                 _ = APIService.CoreData.createOrMergeMastodonAuthentication(

--- a/Mastodon/Scene/Profile/Bookmark/BookmarkViewModel+Diffable.swift
+++ b/Mastodon/Scene/Profile/Bookmark/BookmarkViewModel+Diffable.swift
@@ -22,7 +22,8 @@ extension BookmarkViewModel {
                 statusTableViewCellDelegate: statusTableViewCellDelegate,
                 timelineMiddleLoaderTableViewCellDelegate: nil,
                 filterContext: .none,
-                activeFilters: nil
+                activeFilters: nil,
+                preferences: context.preferencesService.currentPreferences
             )
         )
         // set empty section to make update animation top-to-bottom style

--- a/Mastodon/Scene/Profile/Favorite/FavoriteViewModel+Diffable.swift
+++ b/Mastodon/Scene/Profile/Favorite/FavoriteViewModel+Diffable.swift
@@ -22,7 +22,8 @@ extension FavoriteViewModel {
                 statusTableViewCellDelegate: statusTableViewCellDelegate,
                 timelineMiddleLoaderTableViewCellDelegate: nil,
                 filterContext: .none,
-                activeFilters: nil
+                activeFilters: nil,
+                preferences: context.preferencesService.currentPreferences
             )
         )
         // set empty section to make update animation top-to-bottom style

--- a/Mastodon/Scene/Profile/Timeline/UserTimelineViewModel+Diffable.swift
+++ b/Mastodon/Scene/Profile/Timeline/UserTimelineViewModel+Diffable.swift
@@ -23,7 +23,8 @@ extension UserTimelineViewModel {
                 statusTableViewCellDelegate: statusTableViewCellDelegate,
                 timelineMiddleLoaderTableViewCellDelegate: nil,
                 filterContext: .none,
-                activeFilters: nil
+                activeFilters: nil,
+                preferences: context.preferencesService.currentPreferences
             )
         )
 

--- a/Mastodon/Scene/Thread/ThreadViewModel+Diffable.swift
+++ b/Mastodon/Scene/Thread/ThreadViewModel+Diffable.swift
@@ -29,7 +29,8 @@ extension ThreadViewModel {
                 statusTableViewCellDelegate: statusTableViewCellDelegate,
                 timelineMiddleLoaderTableViewCellDelegate: nil,
                 filterContext: .thread,
-                activeFilters: context.statusFilterService.$activeFilters
+                activeFilters: context.statusFilterService.$activeFilters,
+                preferences: context.preferencesService.currentPreferences
             )
         )
         

--- a/MastodonSDK/Sources/CoreDataStack/CoreData.xcdatamodeld/CoreData 4.xcdatamodel/contents
+++ b/MastodonSDK/Sources/CoreDataStack/CoreData.xcdatamodeld/CoreData 4.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21509" systemVersion="21G217" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G115" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Application" representedClassName="CoreDataStack.Application" syncable="YES">
         <attribute name="identifier" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" attributeType="String"/>
@@ -54,7 +54,6 @@
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="domain" attributeType="String"/>
         <attribute name="identifier" attributeType="UUID" usesScalarValueType="NO"/>
-        <attribute name="preferencesRaw" optional="YES" attributeType="Binary"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="userAccessToken" attributeType="String"/>
         <attribute name="userID" attributeType="String"/>

--- a/MastodonSDK/Sources/CoreDataStack/CoreData.xcdatamodeld/CoreData 4.xcdatamodel/contents
+++ b/MastodonSDK/Sources/CoreDataStack/CoreData.xcdatamodeld/CoreData 4.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G115" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21509" systemVersion="21G217" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Application" representedClassName="CoreDataStack.Application" syncable="YES">
         <attribute name="identifier" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" attributeType="String"/>
@@ -54,6 +54,7 @@
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="domain" attributeType="String"/>
         <attribute name="identifier" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="preferencesRaw" optional="YES" attributeType="Binary"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="userAccessToken" attributeType="String"/>
         <attribute name="userID" attributeType="String"/>

--- a/MastodonSDK/Sources/CoreDataStack/CoreData.xcdatamodeld/CoreData 7.xcdatamodel/contents
+++ b/MastodonSDK/Sources/CoreDataStack/CoreData.xcdatamodeld/CoreData 7.xcdatamodel/contents
@@ -73,6 +73,7 @@
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="domain" attributeType="String"/>
         <attribute name="identifier" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="preferencesRaw" optional="YES" attributeType="Binary"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="userAccessToken" attributeType="String"/>
         <attribute name="userID" attributeType="String"/>

--- a/MastodonSDK/Sources/CoreDataStack/CoreData.xcdatamodeld/CoreData 7.xcdatamodel/contents
+++ b/MastodonSDK/Sources/CoreDataStack/CoreData.xcdatamodeld/CoreData 7.xcdatamodel/contents
@@ -73,7 +73,6 @@
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="domain" attributeType="String"/>
         <attribute name="identifier" attributeType="UUID" usesScalarValueType="NO"/>
-        <attribute name="preferencesRaw" optional="YES" attributeType="Binary"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="userAccessToken" attributeType="String"/>
         <attribute name="userID" attributeType="String"/>

--- a/MastodonSDK/Sources/CoreDataStack/CoreData.xcdatamodeld/CoreData 8.xcdatamodel/contents
+++ b/MastodonSDK/Sources/CoreDataStack/CoreData.xcdatamodeld/CoreData 8.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22D68" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22C65" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Application" representedClassName="CoreDataStack.Application" syncable="YES">
         <attribute name="identifier" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" attributeType="String"/>
@@ -73,6 +73,7 @@
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="domain" attributeType="String"/>
         <attribute name="identifier" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="preferencesRaw" optional="YES" attributeType="Binary"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="userAccessToken" attributeType="String"/>
         <attribute name="userID" attributeType="String"/>

--- a/MastodonSDK/Sources/CoreDataStack/Entity/Mastodon/MastodonAuthentication.swift
+++ b/MastodonSDK/Sources/CoreDataStack/Entity/Mastodon/MastodonAuthentication.swift
@@ -26,7 +26,9 @@ final public class MastodonAuthentication: NSManagedObject {
     @NSManaged public private(set) var createdAt: Date
     @NSManaged public private(set) var updatedAt: Date
     @NSManaged public private(set) var activedAt: Date
-    
+
+    @NSManaged public private(set) var preferencesRaw: Data?
+
     // one-to-one relationship
     @NSManaged public private(set) var user: MastodonUser
     
@@ -105,6 +107,12 @@ extension MastodonAuthentication {
             self.instance = instance
         }
     }
+
+    public func update(preferencesRaw: Data?) {
+        if self.preferencesRaw != preferencesRaw {
+            self.preferencesRaw = preferencesRaw
+        }
+    }
     
     public func didUpdate(at networkDate: Date) {
         self.updatedAt = networkDate
@@ -122,6 +130,7 @@ extension MastodonAuthentication {
         public let userAccessToken: String
         public let clientID: String
         public let clientSecret: String
+        public let preferencesRaw: Data?
     
         public init(
             domain: String,
@@ -130,7 +139,8 @@ extension MastodonAuthentication {
             appAccessToken: String,
             userAccessToken: String,
             clientID: String,
-            clientSecret: String
+            clientSecret: String,
+            preferencesRaw: Data?
         ) {
             self.domain = domain
             self.userID = userID
@@ -139,6 +149,7 @@ extension MastodonAuthentication {
             self.userAccessToken = userAccessToken
             self.clientID = clientID
             self.clientSecret = clientSecret
+            self.preferencesRaw = preferencesRaw
         }
         
     }

--- a/MastodonSDK/Sources/MastodonCore/AppContext.swift
+++ b/MastodonSDK/Sources/MastodonCore/AppContext.swift
@@ -23,6 +23,7 @@ public class AppContext: ObservableObject {
     
     public let apiService: APIService
     public let authenticationService: AuthenticationService
+    public let preferencesService: PreferencesService
     public let emojiService: EmojiService
     // public let statusPublishService = StatusPublishService()
     public let publisherService: PublisherService
@@ -63,6 +64,11 @@ public class AppContext: ObservableObject {
             apiService: _apiService
         )
         authenticationService = _authenticationService
+
+        preferencesService = PreferencesService(
+            apiService: apiService,
+            authenticationService: authenticationService
+        )
         
         emojiService = EmojiService(
             apiService: apiService

--- a/MastodonSDK/Sources/MastodonCore/Extension/CoreDataStack/MastodonAuthentication.swift
+++ b/MastodonSDK/Sources/MastodonCore/Extension/CoreDataStack/MastodonAuthentication.swift
@@ -1,0 +1,57 @@
+//
+//  MastodonAuthentication.swift
+//  
+//
+//  Created by Jed Fox on 2022-11-28.
+//
+
+import Foundation
+import CoreDataStack
+import MastodonSDK
+
+private func decodePreferences(_ data: Data?) -> Mastodon.Entity.Preferences? {
+    guard let data else { return nil }
+    return try? JSONDecoder().decode(Mastodon.Entity.Preferences.self, from: data)
+}
+private func encodePreferences(_ preferences: Mastodon.Entity.Preferences?) -> Data? {
+    guard let preferences else { return nil }
+    return try? JSONEncoder().encode(preferences)
+}
+
+extension MastodonAuthentication {
+    public var preferences: Mastodon.Entity.Preferences? {
+        decodePreferences(preferencesRaw)
+    }
+
+    public func update(preferences: Mastodon.Entity.Preferences?) {
+        update(preferencesRaw: encodePreferences(preferences))
+    }
+}
+
+extension MastodonAuthentication.Property {
+    public var preferences: Mastodon.Entity.Preferences? {
+        decodePreferences(preferencesRaw)
+    }
+
+    public init(
+        domain: String,
+        userID: String,
+        username: String,
+        appAccessToken: String,
+        userAccessToken: String,
+        clientID: String,
+        clientSecret: String,
+        preferences: Mastodon.Entity.Preferences?
+    ) {
+        self.init(
+            domain: domain,
+            userID: userID,
+            username: username,
+            appAccessToken: appAccessToken,
+            userAccessToken: userAccessToken,
+            clientID: clientID,
+            clientSecret: clientSecret,
+            preferencesRaw: encodePreferences(preferences)
+        )
+    }
+}

--- a/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Preferences.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Preferences.swift
@@ -1,0 +1,25 @@
+//
+//  APIService+Preferences.swift
+//  Mastodon
+//
+//  Created by Jed Fox on 2022-11-28.
+//
+
+import Foundation
+import Combine
+import CoreData
+import CoreDataStack
+import CommonOSLog
+import MastodonSDK
+
+extension APIService {
+
+    public func preferences(
+        authenticationBox: MastodonAuthenticationBox
+    ) -> AnyPublisher<Mastodon.Response.Content<Mastodon.Entity.Preferences>, Error> {
+        let domain = authenticationBox.domain
+        let authorization = authenticationBox.userAuthorization
+        return Mastodon.API.Preferences.preferences(session: session, domain: domain, authorization: authorization)
+    }
+
+}

--- a/MastodonSDK/Sources/MastodonCore/Service/PreferencesService.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/PreferencesService.swift
@@ -20,7 +20,7 @@ public final class PreferencesService {
     weak var authenticationService: AuthenticationService?
 
     // output
-    public let currentPreferences = CurrentValueSubject<Mastodon.Entity.Preferences?, Never>(nil)
+    public let currentPreferences = CurrentValueSubject<Mastodon.Entity.Preferences, Never>(.default)
 
     init(
         apiService: APIService,
@@ -63,7 +63,7 @@ public final class PreferencesService {
             .sink { [weak self] authenticationRecord in
                 guard let self = self, let apiService = self.apiService else { return }
                 self.currentPreferences.send(
-                    authenticationRecord.object(in: apiService.backgroundManagedObjectContext)?.preferences
+                    authenticationRecord.object(in: apiService.backgroundManagedObjectContext)?.preferences ?? .default
                 )
             }
             .store(in: &disposeBag)

--- a/MastodonSDK/Sources/MastodonCore/Service/PreferencesService.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/PreferencesService.swift
@@ -1,0 +1,72 @@
+//
+//  PreferencesService.swift
+//  
+//
+//  Created by Jed Fox on 2022-11-28.
+//
+
+import Combine
+import CoreDataStack
+import MastodonSDK
+
+public final class PreferencesService {
+
+    var disposeBag = Set<AnyCancellable>()
+
+    private var currentSettingUpdateSubscription: AnyCancellable?
+
+    // input
+    weak var apiService: APIService?
+    weak var authenticationService: AuthenticationService?
+
+    // output
+    public let currentPreferences = CurrentValueSubject<Mastodon.Entity.Preferences?, Never>(nil)
+
+    init(
+        apiService: APIService,
+        authenticationService: AuthenticationService
+    ) {
+        self.apiService = apiService
+        self.authenticationService = authenticationService
+
+        // bind current setting
+        Publishers.CombineLatest(
+            authenticationService.$mastodonAuthenticationBoxes,
+            authenticationService.updateActiveUserAccountPublisher
+        )
+        .compactMap { [weak self] (mastodonAuthenticationBoxes, _) -> AnyPublisher<(Mastodon.Response.Content<Mastodon.Entity.Preferences>, ManagedObjectRecord<MastodonAuthentication>, APIService), Error>? in
+            guard let self = self, let apiService = self.apiService else { return nil }
+            guard let activeMastodonAuthenticationBox = mastodonAuthenticationBoxes.first else { return nil }
+            return apiService.preferences(authenticationBox: activeMastodonAuthenticationBox)
+                .combineLatest(
+                    Just(activeMastodonAuthenticationBox.authenticationRecord).setFailureType(to: Error.self),
+                    Just(apiService).setFailureType(to: Error.self)
+                )
+                .eraseToAnyPublisher()
+        }
+        .flatMap { $0 }
+        .asyncMap { [weak self] prefs, authenticationRecord, apiService in
+            guard let self = self, let apiService = self.apiService else { return }
+            await MainActor.run {
+                self.currentPreferences.send(prefs.value)
+            }
+            try await apiService.backgroundManagedObjectContext.perform {
+                let authentication = authenticationRecord.object(in: apiService.backgroundManagedObjectContext)
+                authentication?.update(preferences: prefs.value)
+            }
+        }
+        .sink { _ in } receiveValue: { _ in }
+        .store(in: &disposeBag)
+
+        authenticationService.$mastodonAuthenticationBoxes
+            .compactMap { $0.first?.authenticationRecord }
+            .sink { [weak self] authenticationRecord in
+                guard let self = self, let apiService = self.apiService else { return }
+                self.currentPreferences.send(
+                    authenticationRecord.object(in: apiService.backgroundManagedObjectContext)?.preferences
+                )
+            }
+            .store(in: &disposeBag)
+    }
+
+}

--- a/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+Preferences.swift
+++ b/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+Preferences.swift
@@ -1,0 +1,51 @@
+//
+//  Mastodon+API+Preferences.swift
+//  
+//
+//  Created by Jed Fox on 2022-11-28.
+//
+
+
+import Foundation
+import Combine
+
+extension Mastodon.API.Preferences {
+
+    static func preferencesEndpointURL(domain: String) -> URL {
+        return Mastodon.API.endpointURL(domain: domain).appendingPathComponent("preferences")
+    }
+
+    /// Preferred common behaviors to be shared across clients
+    ///
+    /// - Since: 2.8.0
+    /// - Version: 4.0.2
+    /// # Last Update
+    ///   2022/11/28
+    /// # Reference
+    ///   [Document](https://docs.joinmastodon.org/methods/preferences/)
+    /// - Parameters:
+    ///   - session: `URLSession`
+    ///   - domain: Mastodon instance domain. e.g. "example.com"
+    ///   - authorization: App token
+    /// - Returns: `AnyPublisher` contains `Preferences` nested in the response
+    public static func preferences(
+        session: URLSession,
+        domain: String,
+        authorization: Mastodon.API.OAuth.Authorization
+    ) -> AnyPublisher<Mastodon.Response.Content<Mastodon.Entity.Preferences>, Error>  {
+        let request = Mastodon.API.get(
+            url: preferencesEndpointURL(domain: domain),
+            query: nil,
+            authorization: authorization
+        )
+        return session.dataTaskPublisher(for: request)
+            .tryMap { data, response in
+                let value: Mastodon.Entity.Preferences
+
+                value = try Mastodon.API.decode(type: Mastodon.Entity.Preferences.self, from: data, response: response)
+                return Mastodon.Response.Content(value: value, response: response)
+            }
+            .eraseToAnyPublisher()
+    }
+
+}

--- a/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API.swift
+++ b/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API.swift
@@ -120,6 +120,7 @@ extension Mastodon.API {
     public enum Subscriptions { }
     public enum Reports { }
     public enum DomainBlock { }
+    public enum Preferences { }
 }
 
 extension Mastodon.API.V2 {

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Preferences.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Preferences.swift
@@ -58,8 +58,8 @@ extension Mastodon.Entity.Preferences {
         public init?(rawValue: String) {
             switch rawValue {
             case "default":                 self = .default
-            case "showAll":                 self = .showAll
-            case "hideAll":                 self = .hideAll
+            case "show_all":                self = .showAll
+            case "hide_all":                self = .hideAll
             default:                        self = ._other(rawValue)
             }
         }
@@ -67,8 +67,8 @@ extension Mastodon.Entity.Preferences {
         public var rawValue: String {
             switch self {
             case .default:                      return "default"
-            case .showAll:                      return "showAll"
-            case .hideAll:                      return "hideAll"
+            case .showAll:                      return "show_all"
+            case .hideAll:                      return "hide_all"
             case ._other(let value):            return value
             }
         }

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Preferences.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Preferences.swift
@@ -22,6 +22,14 @@ extension Mastodon.Entity {
         public let postingDefaultLanguage: String?      // (ISO 639-1 language two-letter code)
         public let readingExpandMedia: ExpandMedia
         public let readingExpandSpoilers: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case postingDefaultVisibility = "posting:default:visibility"
+            case postingDefaultSensitive = "posting:default:sensitive"
+            case postingDefaultLanguage = "posting:default:language"
+            case readingExpandMedia = "reading:expand:media"
+            case readingExpandSpoilers = "reading:expand:spoilers"
+        }
     }
 }
 

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Preferences.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Preferences.swift
@@ -40,7 +40,7 @@ extension Mastodon.Entity.Preferences {
 }
 
 extension Mastodon.Entity.Preferences {
-    public enum ExpandMedia: RawRepresentable, Codable {
+    public enum ExpandMedia: RawRepresentable, Codable, Equatable {
         case `default`
         case showAll
         case hideAll

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Preferences.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Preferences.swift
@@ -26,6 +26,16 @@ extension Mastodon.Entity {
 }
 
 extension Mastodon.Entity.Preferences {
+    public static let `default` = Mastodon.Entity.Preferences(
+        postingDefaultVisibility: .public,
+        postingDefaultSensitive: false,
+        postingDefaultLanguage: "en",
+        readingExpandMedia: .default,
+        readingExpandSpoilers: false
+    )
+}
+
+extension Mastodon.Entity.Preferences {
     public typealias Visibility = Mastodon.Entity.Source.Privacy
 }
 

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Preferences.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Preferences.swift
@@ -22,6 +22,7 @@ extension Mastodon.Entity {
         public let postingDefaultLanguage: String?      // (ISO 639-1 language two-letter code)
         public let readingExpandMedia: ExpandMedia
         public let readingExpandSpoilers: Bool
+        public let readingAutoplayGIFs: Bool
 
         enum CodingKeys: String, CodingKey {
             case postingDefaultVisibility = "posting:default:visibility"
@@ -29,6 +30,7 @@ extension Mastodon.Entity {
             case postingDefaultLanguage = "posting:default:language"
             case readingExpandMedia = "reading:expand:media"
             case readingExpandSpoilers = "reading:expand:spoilers"
+            case readingAutoplayGIFs = "reading:autoplay:gifs"
         }
     }
 }
@@ -39,8 +41,26 @@ extension Mastodon.Entity.Preferences {
         postingDefaultSensitive: false,
         postingDefaultLanguage: "en",
         readingExpandMedia: .default,
-        readingExpandSpoilers: false
+        readingExpandSpoilers: false,
+        readingAutoplayGIFs: true
     )
+}
+
+extension Mastodon.Entity.Preferences {
+    // necessary to allow newly added preferences to be decoded if present
+    // and take on their default value if missing
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.postingDefaultVisibility = try container.decode(Visibility.self, forKey: .postingDefaultVisibility)
+        self.postingDefaultSensitive = try container.decode(Bool.self, forKey: .postingDefaultSensitive)
+        self.postingDefaultLanguage = try container.decodeIfPresent(String.self, forKey: .postingDefaultLanguage)
+        self.readingExpandMedia = try container.decode(ExpandMedia.self, forKey: .readingExpandMedia)
+        self.readingExpandSpoilers = try container.decode(Bool.self, forKey: .readingExpandSpoilers)
+        
+        // use the default value for these preferences if not present
+        self.readingAutoplayGIFs = try container.decodeIfPresent(Bool.self, forKey: .readingAutoplayGIFs) ?? Self.default.readingAutoplayGIFs
+    }
 }
 
 extension Mastodon.Entity.Preferences {

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Preferences.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Preferences.swift
@@ -39,7 +39,7 @@ extension Mastodon.Entity.Preferences {
     public static let `default` = Mastodon.Entity.Preferences(
         postingDefaultVisibility: .public,
         postingDefaultSensitive: false,
-        postingDefaultLanguage: "en",
+        postingDefaultLanguage: nil,
         readingExpandMedia: .default,
         readingExpandSpoilers: false,
         readingAutoplayGIFs: true

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Source.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Source.swift
@@ -40,32 +40,5 @@ extension Mastodon.Entity {
 }
 
 extension Mastodon.Entity.Source {
-    public enum Privacy: RawRepresentable, Codable, Sendable {
-        case `public`
-        case unlisted
-        case `private`
-        case direct
-        
-        case _other(String)
-        
-        public init?(rawValue: String) {
-            switch rawValue {
-            case "public":                  self = .public
-            case "unlisted":                self = .unlisted
-            case "private":                 self = .private
-            case "direct":                  self = .direct
-            default:                        self = ._other(rawValue)
-            }
-        }
-        
-        public var rawValue: String {
-            switch self {
-            case .public:                       return "public"
-            case .unlisted:                     return "unlisted"
-            case .private:                      return "private"
-            case .direct:                       return "direct"
-            case ._other(let value):            return value
-            }
-        }
-    }
+    public typealias Privacy = Mastodon.Entity.Status.Visibility
 }

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewController.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewController.swift
@@ -384,6 +384,7 @@ extension ComposeContentViewController {
             .store(in: &disposeBag)
 
         viewModel.$recentLanguages.assign(to: &composeContentToolbarViewModel.$recentLanguages)
+        viewModel.$defaultLanguage.assign(to: &composeContentToolbarViewModel.$defaultLanguage)
         
         // bind back to source due to visibility not update via delegate
         composeContentToolbarViewModel.$visibility

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
@@ -156,8 +156,9 @@ public final class ComposeContentViewModel: NSObject, ObservableObject {
         self.authContext = authContext
         self.destination = destination
         self.composeContext = composeContext
+        let prefs = context.preferencesService.currentPreferences.value
         self.visibility = {
-            var visibility = context.preferencesService.currentPreferences.value.postingDefaultVisibility
+            var visibility = prefs.postingDefaultVisibility
             // set visibility for reply post
             if case .reply(let record) = destination {
                 context.managedObjectContext.performAndWait {
@@ -208,7 +209,7 @@ public final class ComposeContentViewModel: NSObject, ObservableObject {
         
         let recentLanguages = context.settingService.currentSetting.value?.recentLanguages ?? []
         self.recentLanguages = recentLanguages
-        self.language = recentLanguages.first ?? Locale.current.languageCode ?? "en"
+        self.language = prefs.postingDefaultLanguage ?? recentLanguages.first ?? Locale.current.languageCode ?? "en"
         super.init()
         // end init
         

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
@@ -121,6 +121,7 @@ public final class ComposeContentViewModel: NSObject, ObservableObject {
 
     // language
     @Published public var language: String
+    @Published public var defaultLanguage: String?
     @Published public private(set) var recentLanguages: [String]
 
     // UI & UX
@@ -209,6 +210,7 @@ public final class ComposeContentViewModel: NSObject, ObservableObject {
         
         let recentLanguages = context.settingService.currentSetting.value?.recentLanguages ?? []
         self.recentLanguages = recentLanguages
+        self.defaultLanguage = prefs.postingDefaultLanguage
         self.language = prefs.postingDefaultLanguage ?? recentLanguages.first ?? Locale.current.languageCode ?? "en"
         super.init()
         // end init

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
@@ -159,10 +159,14 @@ public final class ComposeContentViewModel: NSObject, ObservableObject {
         self.visibility = {
             // default private when user locked
             var visibility: Mastodon.Entity.Status.Visibility = {
-                guard let author = authContext.mastodonAuthenticationBox.authenticationRecord.object(in: context.managedObjectContext)?.user else {
-                    return .public
+                if let prefs = context.preferencesService.currentPreferences.value {
+                    return prefs.postingDefaultVisibility
                 }
-                return author.locked ? .private : .public
+                if let author = authContext.mastodonAuthenticationBox.authenticationRecord.object(in: context.managedObjectContext)?.user,
+                   author.locked {
+                    return .private
+                }
+                return .public
             }()
             // set visibility for reply post
             if case .reply(let record) = destination {

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
@@ -157,17 +157,7 @@ public final class ComposeContentViewModel: NSObject, ObservableObject {
         self.destination = destination
         self.composeContext = composeContext
         self.visibility = {
-            // default private when user locked
-            var visibility: Mastodon.Entity.Status.Visibility = {
-                if let prefs = context.preferencesService.currentPreferences.value {
-                    return prefs.postingDefaultVisibility
-                }
-                if let author = authContext.mastodonAuthenticationBox.authenticationRecord.object(in: context.managedObjectContext)?.user,
-                   author.locked {
-                    return .private
-                }
-                return .public
-            }()
+            var visibility = context.preferencesService.currentPreferences.value.postingDefaultVisibility
             // set visibility for reply post
             if case .reply(let record) = destination {
                 context.managedObjectContext.performAndWait {

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView+ViewModel.swift
@@ -35,6 +35,7 @@ extension ComposeContentToolbarView {
         @Published var language = Locale.current.languageCode ?? "en"
         @Published var recentLanguages: [String] = []
         @Published var defaultLanguage: String?
+        @Published var didChangeLanguage = false
 
         @Published public var maxTextInputLimit = 500
         @Published public var contentWeightedLength = 0

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView+ViewModel.swift
@@ -34,6 +34,7 @@ extension ComposeContentToolbarView {
         
         @Published var language = Locale.current.languageCode ?? "en"
         @Published var recentLanguages: [String] = []
+        @Published var defaultLanguage: String?
 
         @Published public var maxTextInputLimit = 500
         @Published public var contentWeightedLength = 0

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView.swift
@@ -86,8 +86,6 @@ struct ComposeContentToolbarView: View {
                                 Menu {
                                     Section {} // workaround a bug where the “Suggested” section doesn’t appear
 
-                                    let onSelect = { viewModel.didChangeLanguage = true }
-
                                     if let defaultLanguage = viewModel.defaultLanguage {
                                         LanguageToggle(viewModel: viewModel, code: defaultLanguage)
                                     }

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView.swift
@@ -86,26 +86,42 @@ struct ComposeContentToolbarView: View {
                             case .language:
                                 Menu {
                                     Section {} // workaround a bug where the “Suggested” section doesn’t appear
-                                    if !viewModel.suggestedLanguages.isEmpty {
+
+                                    if let defaultLanguage = viewModel.defaultLanguage {
+                                        Toggle(isOn: languageBinding(for: defaultLanguage)) {
+                                            Text(Language(id: defaultLanguage)?.label ?? AttributedString("\(viewModel.language)"))
+                                        }
+                                    }
+
+                                    let suggested = viewModel.suggestedLanguages
+                                        .filter { $0 != viewModel.defaultLanguage }
+                                        .compactMap(Language.init(id:))
+                                    if !suggested.isEmpty {
                                         Section(L10n.Scene.Compose.Language.suggested) {
-                                            ForEach(viewModel.suggestedLanguages.compactMap(Language.init(id:))) { lang in
+                                            ForEach(suggested) { lang in
                                                 Toggle(isOn: languageBinding(for: lang.id)) {
                                                     Text(lang.label)
                                                 }
                                             }
                                         }
                                     }
-                                    let recent = viewModel.recentLanguages.filter { !viewModel.suggestedLanguages.contains($0) }
+
+                                    let recent = viewModel.recentLanguages
+                                        .filter { $0 != viewModel.defaultLanguage }
+                                        .compactMap(Language.init(id:))
+                                        .filter { !suggested.contains($0) }
                                     if !recent.isEmpty {
                                         Section(L10n.Scene.Compose.Language.recent) {
-                                            ForEach(recent.compactMap(Language.init(id:))) { lang in
+                                            ForEach(recent) { lang in
                                                 Toggle(isOn: languageBinding(for: lang.id)) {
                                                     Text(lang.label)
                                                 }
                                             }
                                         }
                                     }
-                                    if !(recent + viewModel.suggestedLanguages).contains(viewModel.language) {
+
+                                    if viewModel.language != viewModel.defaultLanguage,
+                                       !(recent + suggested).map(\.id).contains(viewModel.language) {
                                         Toggle(isOn: languageBinding(for: viewModel.language)) {
                                             Text(Language(id: viewModel.language)?.label ?? AttributedString("\(viewModel.language)"))
                                         }
@@ -121,7 +137,7 @@ struct ComposeContentToolbarView: View {
                                             return .system(size: 11, weight: .semibold)
                                         }
                                     }()
-                                    
+
                                     Text(viewModel.language)
                                         .font(font)
                                         .textCase(.uppercase)

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView.swift
@@ -85,39 +85,7 @@ struct ComposeContentToolbarView: View {
                             case .language:
                                 Menu {
                                     Section {} // workaround a bug where the “Suggested” section doesn’t appear
-
-                                    if let defaultLanguage = viewModel.defaultLanguage {
-                                        LanguageToggle(viewModel: viewModel, code: defaultLanguage)
-                                    }
-
-                                    let suggested = viewModel.suggestedLanguages
-                                        .filter { $0 != viewModel.defaultLanguage }
-                                        .compactMap(Language.init(id:))
-                                    if !suggested.isEmpty {
-                                        Section(L10n.Scene.Compose.Language.suggested) {
-                                            ForEach(suggested) { language in
-                                                LanguageToggle(viewModel: viewModel, language: language)
-                                            }
-                                        }
-                                    }
-
-                                    let recent = viewModel.recentLanguages
-                                        .filter { $0 != viewModel.defaultLanguage }
-                                        .compactMap(Language.init(id:))
-                                        .filter { !suggested.contains($0) }
-                                    if !recent.isEmpty {
-                                        Section(L10n.Scene.Compose.Language.recent) {
-                                            ForEach(recent) { language in
-                                                LanguageToggle(viewModel: viewModel, language: language)
-                                            }
-                                        }
-                                    }
-
-                                    if viewModel.language != viewModel.defaultLanguage,
-                                       !(recent + suggested).map(\.id).contains(viewModel.language) {
-                                        LanguageToggle(viewModel: viewModel, code: viewModel.language)
-                                    }
-
+                                    LanguagePickerMenu(viewModel: viewModel)
                                     Button(L10n.Scene.Compose.Language.other) {
                                         showingLanguagePicker = true
                                     }
@@ -219,6 +187,44 @@ extension ComposeContentToolbarView {
         Image(uiImage: image)
             .foregroundColor(Color(Asset.Scene.Compose.buttonTint.color))
             .frame(width: 24, height: 24, alignment: .center)
+    }
+    
+    private struct LanguagePickerMenu: View {
+        @ObservedObject var viewModel: ViewModel
+
+        var body: some View {
+            if let defaultLanguage = viewModel.defaultLanguage {
+                LanguageToggle(viewModel: viewModel, code: defaultLanguage)
+            }
+            
+            let suggested = viewModel.suggestedLanguages
+                .filter { $0 != viewModel.defaultLanguage }
+                .compactMap(Language.init(id:))
+            if !suggested.isEmpty {
+                Section(L10n.Scene.Compose.Language.suggested) {
+                    ForEach(suggested) { language in
+                        LanguageToggle(viewModel: viewModel, language: language)
+                    }
+                }
+            }
+            
+            let recent = viewModel.recentLanguages
+                .filter { $0 != viewModel.defaultLanguage }
+                .compactMap(Language.init(id:))
+                .filter { !suggested.contains($0) }
+            if !recent.isEmpty {
+                Section(L10n.Scene.Compose.Language.recent) {
+                    ForEach(recent) { language in
+                        LanguageToggle(viewModel: viewModel, language: language)
+                    }
+                }
+            }
+            
+            if viewModel.language != viewModel.defaultLanguage,
+               !(recent + suggested).map(\.id).contains(viewModel.language) {
+                LanguageToggle(viewModel: viewModel, code: viewModel.language)
+            }
+        }
     }
     
     private struct LanguageToggle: View {

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView.swift
@@ -191,39 +191,65 @@ extension ComposeContentToolbarView {
     
     private struct LanguagePickerMenu: View {
         @ObservedObject var viewModel: ViewModel
-
-        var body: some View {
-            if let defaultLanguage = viewModel.defaultLanguage {
-                LanguageToggle(viewModel: viewModel, code: defaultLanguage)
-            }
-            
-            let suggested = viewModel.suggestedLanguages
+        
+        var suggested: [Language] {
+            viewModel.suggestedLanguages
                 .filter { $0 != viewModel.defaultLanguage }
                 .compactMap(Language.init(id:))
-            if !suggested.isEmpty {
-                Section(L10n.Scene.Compose.Language.suggested) {
-                    ForEach(suggested) { language in
-                        LanguageToggle(viewModel: viewModel, language: language)
-                    }
-                }
-            }
-            
-            let recent = viewModel.recentLanguages
+        }
+        
+        var recent: [Language] {
+            viewModel.recentLanguages
                 .filter { $0 != viewModel.defaultLanguage }
                 .compactMap(Language.init(id:))
                 .filter { !suggested.contains($0) }
-            if !recent.isEmpty {
-                Section(L10n.Scene.Compose.Language.recent) {
-                    ForEach(recent) { language in
-                        LanguageToggle(viewModel: viewModel, language: language)
-                    }
+        }
+
+        @ViewBuilder
+        var defaultItem: some View {
+            if let defaultLanguage = viewModel.defaultLanguage {
+                LanguageToggle(viewModel: viewModel, code: defaultLanguage)
+            }
+        }
+
+        @ViewBuilder
+        var suggestedItems: some View {
+            Section(L10n.Scene.Compose.Language.suggested) {
+                ForEach(suggested) { language in
+                    LanguageToggle(viewModel: viewModel, language: language)
                 }
             }
-            
+        }
+
+        @ViewBuilder
+        var recentItems: some View {
+            Section(L10n.Scene.Compose.Language.recent) {
+                ForEach(recent) { language in
+                    LanguageToggle(viewModel: viewModel, language: language)
+                }
+            }
+        }
+        
+        @ViewBuilder
+        var currentItem: some View {
             if viewModel.language != viewModel.defaultLanguage,
                !(recent + suggested).map(\.id).contains(viewModel.language) {
                 LanguageToggle(viewModel: viewModel, code: viewModel.language)
             }
+        }
+
+        var body: some View {
+            defaultItem
+
+            if !suggested.isEmpty {
+                suggestedItems
+            }
+
+            if !recent.isEmpty {
+                recentItems
+            }
+
+            currentItem
         }
     }
     

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/Language.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/Language.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 // Consider replacing this with Locale.Language when dropping iOS 15
-struct Language: Identifiable {
+struct Language: Hashable, Identifiable {
     let endonym: String
     let exonym: String
     let id: String

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -31,6 +31,61 @@ extension StatusView {
         public var authContext: AuthContext?
         public var originalStatus: Status?
 
+        private var prefsDisposeBag = Set<AnyCancellable>()
+        public var currentPreferences: CurrentValueSubject<Mastodon.Entity.Preferences, Never>? {
+            didSet {
+                guard let currentPreferences else {
+                    prefsDisposeBag.removeAll()
+                    return
+                }
+
+                // isReveal
+                Publishers.CombineLatest4(
+                    $isContentSensitive,
+                    $isMediaSensitive,
+                    $isSensitiveToggled,
+                    currentPreferences
+                )
+                .sink { [weak self] isContentSensitive, isMediaSensitive, isSensitiveToggled, prefs in
+                    guard let self = self else { return }
+                    if prefs.readingExpandSpoilers {
+                        self.isContentReveal = true
+                    } else {
+                        self.isContentReveal = isContentSensitive ? isSensitiveToggled : true
+                    }
+                    switch prefs.readingExpandMedia {
+                    case .default, ._other:
+                        self.isMediaReveal = isMediaSensitive ? isSensitiveToggled : true
+                    case .showAll:
+                        self.isMediaReveal = true
+                    case .hideAll:
+                        self.isMediaReveal = isSensitiveToggled
+                    }
+                }
+                .store(in: &prefsDisposeBag)
+
+                currentPreferences
+                    .combineLatest($isMediaSensitive, $isContentSensitive, $mediaViewConfigurations)
+                    .map { prefs, isMediaSensitive, isContentSensitive, mediaViewConfigurations in
+                        if !prefs.readingExpandSpoilers && isContentSensitive {
+                            return true
+                        }
+                        switch prefs.readingExpandMedia {
+                        case .showAll:
+                            return false
+                        case .hideAll:
+                            return !mediaViewConfigurations.isEmpty
+                        case .default, ._other:
+                            return isMediaSensitive
+                        }
+                    }
+                    .sink { [weak self] show in
+                        self?.showSensitiveToggleButton = show
+                    }
+                    .store(in: &prefsDisposeBag)
+            }
+        }
+
         // Header
         @Published public var header: Header = .none
         
@@ -58,6 +113,7 @@ extension StatusView {
         
         // Spoiler
         @Published public var spoilerContent: MetaContent?
+        @Published private var showSensitiveToggleButton: Bool = false
         
         // Status
         @Published public var content: MetaContent?
@@ -179,18 +235,6 @@ extension StatusView {
             $spoilerContent
                 .map { $0 != nil }
                 .assign(to: &$isContentSensitive)
-            // isReveal
-            Publishers.CombineLatest3(
-                $isContentSensitive,
-                $isMediaSensitive,
-                $isSensitiveToggled
-            )
-            .sink { [weak self] isContentSensitive, isMediaSensitive, isSensitiveToggled in
-                guard let self = self else { return }
-                self.isContentReveal = isContentSensitive ? isSensitiveToggled : true
-                self.isMediaReveal = isMediaSensitive ? isSensitiveToggled : true
-            }
-            .store(in: &disposeBag)
         }
     }
 }
@@ -359,13 +403,10 @@ extension StatusView.ViewModel {
         }
         .store(in: &disposeBag)
 
-        $isMediaSensitive
-            .sink { isSensitive in
-                guard isSensitive else { return }
-                statusView.setContentSensitiveeToggleButtonDisplay()
-            }
+        $showSensitiveToggleButton
+            .sink { statusView.setContentSensitiveeToggleButtonDisplay(isDisplay: $0) }
             .store(in: &disposeBag)
-        
+
         $isSensitiveToggled
             .sink { isSensitiveToggled in
                 // The button indicator go-to state for button action direction


### PR DESCRIPTION
Fixes #331.
Preferences currently returned by Mastodon (v4.1.0):

- `posting:default:visibility`: configures the default visibility value for new posts (except that replies to private/DM posts will inherit that visibility). Maybe fixes #472, fixes #750.
- `posting:default:sensitive`: _not supported_. The compose UI does not allow configuring sensitive status for media separately from adding a content warning.
- `posting:default:language`: controls the default language used when composing a new post. Also, this language will always be available as the first element of the language menu.
- `reading:expand:media`: controls when media is hidden and controls visibility of the button icon as needed (e.g. it will always show up on posts with media if you set media to always be hidden by default). Fixes #297.
- `reading:expand:spoilers`: if `true`, content warnings will never be shown. (note: if `reading:expand:media` is not set to `show_all`, people won’t be able to see the content warning before viewing media. Should this be changed?). Fixes #511.
- `reading:autoplay:gifs`: _not supported_. Will implement after #815 is merged.

Preferences are re-fetched every time you switch accounts and every time the app is brought into the foreground. Unsure if this request frequency should be reduced. Thoughts? The API endpoint doesn’t seem terribly heavy on the backend, but I could imagine a bunch of folks switching back and forth from the app quickly causing a bunch of server overload. It is nice that changes to preferences are quickly picked up though!