### PR TITLE
fix: Text in compose post is not selectable, focussable, pastable

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentView.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentView.swift
@@ -30,6 +30,7 @@ public struct AttachmentView: View {
                     Image(uiImage: image)
                         .resizable()
                         .aspectRatio(contentMode: .fill)
+                        .allowsHitTesting(false)
                 }
             )
             .overlay(


### PR DESCRIPTION
# Rationale

When adding a **portrait format** image attachment, the text input in the compose view cannot be interacted with anymore. This is due to the image overlaying the input (invisibly). Due to the `clipShape` modifier we're applying, this is not visible but still the image view is capturing touches, making it impossible to interact with the text input, this is true for bot the in-app compose as well as the share extension as they both share the same underlying components.

When removing the clipping you can see the image cover the text input.

![IMG_1512](https://user-images.githubusercontent.com/126418/204510887-d5844d32-4675-47f7-9f52-6edf10b81077.PNG)

This PR dibbles hit testing on the image, so it will forward touches to its parent(s). As there is no direct interaction with the image anyways I think this is a reasonable solution.

Fixes #695 

