### PR TITLE
Rename second tab to “Search and Explore”

### DIFF
--- a/Localization/StringsConvertor/input/Base.lproj/app.json
+++ b/Localization/StringsConvertor/input/Base.lproj/app.json
@@ -95,7 +95,7 @@
             },
             "tabs": {
                 "home": "Home",
-                "search": "Search",
+                "search_and_explore": "Search and Explore",
                 "notifications": "Notifications",
                 "profile": "Profile"
             },

--- a/Localization/app.json
+++ b/Localization/app.json
@@ -95,7 +95,7 @@
             },
             "tabs": {
                 "home": "Home",
-                "search": "Search",
+                "search_and_explore": "Search and Explore",
                 "notifications": "Notifications",
                 "profile": "Profile"
             },

--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -61,7 +61,7 @@ class MainTabBarController: UITabBarController {
         var title: String {
             switch self {
             case .home:             return L10n.Common.Controls.Tabs.home
-            case .search:           return L10n.Common.Controls.Tabs.search
+            case .search:           return L10n.Common.Controls.Tabs.searchAndExplore
             case .compose:          return L10n.Common.Controls.Actions.compose
             case .notifications:    return L10n.Common.Controls.Tabs.notifications
             case .me:               return L10n.Common.Controls.Tabs.profile

--- a/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
+++ b/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
@@ -370,8 +370,8 @@ public enum L10n {
         public static let notifications = L10n.tr("Localizable", "Common.Controls.Tabs.Notifications", fallback: "Notifications")
         /// Profile
         public static let profile = L10n.tr("Localizable", "Common.Controls.Tabs.Profile", fallback: "Profile")
-        /// Search
-        public static let search = L10n.tr("Localizable", "Common.Controls.Tabs.Search", fallback: "Search")
+        /// Search and Explore
+        public static let searchAndExplore = L10n.tr("Localizable", "Common.Controls.Tabs.SearchAndExplore", fallback: "Search and Explore")
       }
       public enum Timeline {
         /// Filtered

--- a/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
+++ b/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
@@ -133,7 +133,7 @@ Please check your internet connection.";
 "Common.Controls.Tabs.Home" = "Home";
 "Common.Controls.Tabs.Notifications" = "Notifications";
 "Common.Controls.Tabs.Profile" = "Profile";
-"Common.Controls.Tabs.Search" = "Search";
+"Common.Controls.Tabs.SearchAndExplore" = "Search and Explore";
 "Common.Controls.Timeline.Filtered" = "Filtered";
 "Common.Controls.Timeline.Header.BlockedWarning" = "You can’t view this user’s profile
 until they unblock you.";


### PR DESCRIPTION
I [got some feedback](https://iaccessibility.social/@douglawlor/109433017703283439) that the local feed (and the other things in the Search) tab were hard to discover because the Search tab doesn’t say anything about showing additional content unless you select it. This PR retitles it to “Search and Explore” when using VoiceOver (which matches Twitter’s naming).