### PR TITLE
Workaround paste crash on iOS 14.x issue

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/Vendor/MetaTextView+PasteExtensions.swift
+++ b/MastodonSDK/Sources/MastodonUI/Vendor/MetaTextView+PasteExtensions.swift
@@ -13,17 +13,21 @@ extension MetaTextView {
     public override func paste(_ sender: Any?) {
         super.paste(sender)
         
-        var nextResponder = self.next;
-        
-        // Force the event to bubble through ALL responders
-        // This is a workaround as somewhere down the chain the paste event gets eaten
-        while (nextResponder != nil) {
-            if let nextResponder = nextResponder {
-                if (nextResponder.responds(to: #selector(UIResponderStandardEditActions.paste(_:)))) {
-                    nextResponder.perform(#selector(UIResponderStandardEditActions.paste(_:)), with: sender)
+        // fix #660
+        // https://github.com/mastodon/mastodon-ios/issues/660
+        if #available(iOS 15.0, *) {
+            var nextResponder = self.next;
+            
+            // Force the event to bubble through ALL responders
+            // This is a workaround as somewhere down the chain the paste event gets eaten
+            while (nextResponder != nil) {
+                if let nextResponder = nextResponder {
+                    if (nextResponder.responds(to: #selector(UIResponderStandardEditActions.paste(_:)))) {
+                        nextResponder.perform(#selector(UIResponderStandardEditActions.paste(_:)), with: sender)
+                    }
                 }
+                nextResponder = nextResponder?.next;
             }
-            nextResponder = nextResponder?.next;
-        }
+        }   // end if
     }
 }


### PR DESCRIPTION
Resolve #660 

Paste anything in post compose scene on iOS 14.5+ will crash the app. However, it's normal on iOS 15.0+ and iOS 16.0+. It looks like the paste image feature intro in #486 is somehow not working on iOS 14.x. 

Just disable it for iOS 14.x to work around the crash problem.

#### Reproduce the issue on iPad mini 5 with iOS 14.8.

<img width="300" alt="image" src="https://user-images.githubusercontent.com/7940186/204993320-94450293-f484-4004-8513-9bb59a89e552.png">
