### PR TITLE
fix: Tidy up accessibility labels in bio fields

### DIFF
--- a/Mastodon/Scene/Profile/About/Cell/ProfileFieldCollectionViewCell.swift
+++ b/Mastodon/Scene/Profile/About/Cell/ProfileFieldCollectionViewCell.swift
@@ -68,6 +68,11 @@ extension ProfileFieldCollectionViewCell {
             checkmark.addInteraction(editMenuInteraction)
         }
         
+        // Setup Accessibility
+        checkmark.isAccessibilityElement = true
+        checkmark.accessibilityTraits = .none
+        keyMetaLabel.accessibilityTraits = .none
+
         // containerStackView: V - [ metaContainer | plainContainer ]
         let containerStackView = UIStackView()
         containerStackView.axis = .vertical


### PR DESCRIPTION
Enables reading out the label for the checkmark, and avoids describing the title text as a 'button'.