### PR TITLE
Add Debug Option For Displaying Touches

### DIFF
--- a/Mastodon/Extension/UIApplication.swift
+++ b/Mastodon/Extension/UIApplication.swift
@@ -22,5 +22,13 @@ extension UIApplication {
 
         return version == build ? "v\(version)" : "v\(version) (\(build))"
     }
+    
+    func getKeyWindow() -> UIWindow? {
+        return UIApplication
+            .shared
+            .connectedScenes
+            .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+            .first { $0.isKeyWindow }
+    }
 
 }

--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewController+DebugAction.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewController+DebugAction.swift
@@ -122,6 +122,10 @@ extension HomeTimelineViewController {
             identifier: nil,
             options: [],
             children: [
+                UIAction(title: "Toggle Visible Touches", image: UIImage(systemName: "hand.tap"), attributes: []) { [weak self] action in
+                    guard let window = UIApplication.shared.keyWindow as? TouchesVisibleWindow else { return }
+                    window.touchesVisible = !window.touchesVisible
+                },
                 UIAction(title: "Toggle EmptyView", image: UIImage(systemName: "clear"), attributes: []) { [weak self] action in
                     guard let self = self else { return }
                     if self.emptyView.superview != nil {

--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewController+DebugAction.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewController+DebugAction.swift
@@ -122,8 +122,8 @@ extension HomeTimelineViewController {
             identifier: nil,
             options: [],
             children: [
-                UIAction(title: "Toggle Visible Touches", image: UIImage(systemName: "hand.tap"), attributes: []) { [weak self] action in
-                    guard let window = UIApplication.shared.keyWindow as? TouchesVisibleWindow else { return }
+                UIAction(title: "Toggle Visible Touches", image: UIImage(systemName: "hand.tap"), attributes: []) { _ in
+                    guard let window = UIApplication.shared.getKeyWindow() as? TouchesVisibleWindow else { return }
                     window.touchesVisible = !window.touchesVisible
                 },
                 UIAction(title: "Toggle EmptyView", image: UIImage(systemName: "clear"), attributes: []) { [weak self] action in

--- a/Mastodon/Supporting Files/SceneDelegate.swift
+++ b/Mastodon/Supporting Files/SceneDelegate.swift
@@ -11,6 +11,7 @@ import Combine
 import CoreDataStack
 import MastodonCore
 import MastodonExtension
+import MastodonUI
 
 #if PROFILE
 import FPSIndicator
@@ -35,8 +36,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = scene as? UIWindowScene else { return }
         
+        #if DEBUG
+        let window = TouchesVisibleWindow(windowScene: windowScene)
+        self.window = window
+        #else
         let window = UIWindow(windowScene: windowScene)
         self.window = window
+        #endif
 
         // set tint color
         window.tintColor = UIColor.label

--- a/MastodonSDK/Sources/MastodonUI/View/Window/TouchesVisibleWindow.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Window/TouchesVisibleWindow.swift
@@ -9,12 +9,10 @@
 
 import UIKit
 
+/// View that represents a single touch from the user.
 fileprivate final class TouchView: UIView {
     
-    fileprivate lazy var blurView: UIVisualEffectView = {
-        let blurEffect = UIBlurEffect(style: .systemUltraThinMaterialLight)
-        return UIVisualEffectView(effect: blurEffect)
-    }()
+    private let blurView: UIVisualEffectView
     
     override var frame: CGRect {
         didSet {
@@ -23,6 +21,9 @@ fileprivate final class TouchView: UIView {
     }
     
     override init(frame: CGRect) {
+        let blurEffect = UIBlurEffect(style: .systemUltraThinMaterialLight)
+        blurView = UIVisualEffectView(effect: blurEffect)
+        
         super.init(frame: frame)
         
         backgroundColor = .clear
@@ -47,6 +48,7 @@ fileprivate final class TouchView: UIView {
 }
 
 
+/// `UIWindow` subclass that renders visual representations of the user's touches.
 public final class TouchesVisibleWindow: UIWindow {
     
     public var touchesVisible = false {
@@ -57,9 +59,9 @@ public final class TouchesVisibleWindow: UIWindow {
         }
     }
     
-    fileprivate var touchViews: [UITouch : TouchView] = [:]
+    private var touchViews: [UITouch : TouchView] = [:]
     
-    fileprivate func newTouchView() -> TouchView {
+    private func newTouchView() -> TouchView {
         let touchSize = 44.0
         return TouchView(frame: CGRect(
             origin: .zero,
@@ -70,7 +72,7 @@ public final class TouchesVisibleWindow: UIWindow {
         ))
     }
     
-    fileprivate func cleanupTouch(_ touch: UITouch) {
+    private func cleanupTouch(_ touch: UITouch) {
         guard let touchView = touchViews[touch] else {
             return
         }
@@ -79,7 +81,7 @@ public final class TouchesVisibleWindow: UIWindow {
         touchViews.removeValue(forKey: touch)
     }
     
-    fileprivate func cleanUpAllTouches() {
+    private func cleanUpAllTouches() {
         for (_, touchView) in touchViews {
             touchView.removeFromSuperview()
         }
@@ -88,42 +90,39 @@ public final class TouchesVisibleWindow: UIWindow {
     }
     
     public override func sendEvent(_ event: UIEvent) {
-        if !touchesVisible {
-            super.sendEvent(event)
-            return
-        }
-        
-        let touches = event.allTouches
-        
-        guard
-            let touches = touches,
-            touches.count > 0
-        else {
-            cleanUpAllTouches()
-            super.sendEvent(event)
-            return
-        }
-        
-        for touch in touches {
-            let touchLocation = touch.location(in: self)
-            switch touch.phase {
-            case .began:
-                let touchView = newTouchView()
-                touchView.center = touchLocation
-                addSubview(touchView)
-                touchViews[touch] = touchView
-                
-            case .moved:
-                guard let touchView = touchViews[touch] else {
-                    return
+        if touchesVisible {
+            let touches = event.allTouches
+            
+            guard
+                let touches = touches,
+                touches.count > 0
+            else {
+                cleanUpAllTouches()
+                super.sendEvent(event)
+                return
+            }
+            
+            for touch in touches {
+                let touchLocation = touch.location(in: self)
+                switch touch.phase {
+                case .began:
+                    let touchView = newTouchView()
+                    touchView.center = touchLocation
+                    addSubview(touchView)
+                    touchViews[touch] = touchView
+                    
+                case .moved:
+                    guard let touchView = touchViews[touch] else {
+                        return
+                    }
+                    touchView.center = touchLocation
+                    
+                case .ended, .cancelled:
+                    cleanupTouch(touch)
+                    
+                default:
+                    break
                 }
-                touchView.center = touchLocation
-                
-            case .ended, .cancelled:
-                cleanupTouch(touch)
-                
-            default:
-                break
             }
         }
         

--- a/MastodonSDK/Sources/MastodonUI/View/Window/TouchesVisibleWindow.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Window/TouchesVisibleWindow.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  TouchesVisibleWindow.swift
 //  
 //
 //  Created by Chase Carroll on 12/5/22.

--- a/MastodonSDK/Sources/MastodonUI/View/Window/TouchesVisibleWindow.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Window/TouchesVisibleWindow.swift
@@ -49,7 +49,7 @@ fileprivate final class TouchView: UIView {
 
 public final class TouchesVisibleWindow: UIWindow {
     
-    var touchesVisible = false {
+    public var touchesVisible = false {
         didSet {
             if !touchesVisible {
                 cleanUpAllTouches()

--- a/MastodonSDK/Sources/MastodonUI/View/Window/TouchesVisibleWindow.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Window/TouchesVisibleWindow.swift
@@ -1,0 +1,134 @@
+//
+//  File.swift
+//  
+//
+//  Created by Chase Carroll on 12/5/22.
+//
+
+#if DEBUG
+
+import UIKit
+
+fileprivate final class TouchView: UIView {
+    
+    fileprivate lazy var blurView: UIVisualEffectView = {
+        let blurEffect = UIBlurEffect(style: .systemUltraThinMaterialLight)
+        return UIVisualEffectView(effect: blurEffect)
+    }()
+    
+    override var frame: CGRect {
+        didSet {
+            layer.cornerRadius = frame.height / 2.0
+        }
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        backgroundColor = .clear
+        layer.masksToBounds = true
+        layer.cornerCurve = .circular
+        layer.borderColor = UIColor.white.cgColor
+        layer.borderWidth = 2.0
+        
+        addSubview(blurView)
+    }
+    
+    @available(iOS, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        blurView.frame = bounds
+    }
+    
+}
+
+
+public final class TouchesVisibleWindow: UIWindow {
+    
+    var touchesVisible = false {
+        didSet {
+            if !touchesVisible {
+                cleanUpAllTouches()
+            }
+        }
+    }
+    
+    fileprivate var touchViews: [UITouch : TouchView] = [:]
+    
+    fileprivate func newTouchView() -> TouchView {
+        let touchSize = 44.0
+        return TouchView(frame: CGRect(
+            origin: .zero,
+            size: CGSize(
+                width: touchSize,
+                height: touchSize
+            )
+        ))
+    }
+    
+    fileprivate func cleanupTouch(_ touch: UITouch) {
+        guard let touchView = touchViews[touch] else {
+            return
+        }
+        
+        touchView.removeFromSuperview()
+        touchViews.removeValue(forKey: touch)
+    }
+    
+    fileprivate func cleanUpAllTouches() {
+        for (_, touchView) in touchViews {
+            touchView.removeFromSuperview()
+        }
+        
+        touchViews.removeAll()
+    }
+    
+    public override func sendEvent(_ event: UIEvent) {
+        if !touchesVisible {
+            super.sendEvent(event)
+            return
+        }
+        
+        let touches = event.allTouches
+        
+        guard
+            let touches = touches,
+            touches.count > 0
+        else {
+            cleanUpAllTouches()
+            super.sendEvent(event)
+            return
+        }
+        
+        for touch in touches {
+            let touchLocation = touch.location(in: self)
+            switch touch.phase {
+            case .began:
+                let touchView = newTouchView()
+                touchView.center = touchLocation
+                addSubview(touchView)
+                touchViews[touch] = touchView
+                
+            case .moved:
+                guard let touchView = touchViews[touch] else {
+                    return
+                }
+                touchView.center = touchLocation
+                
+            case .ended, .cancelled:
+                cleanupTouch(touch)
+                
+            default:
+                break
+            }
+        }
+        
+        super.sendEvent(event)
+    }
+}
+
+#endif

--- a/MastodonSDK/Sources/MastodonUI/View/Window/TouchesVisibleWindow.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Window/TouchesVisibleWindow.swift
@@ -115,10 +115,9 @@ public final class TouchesVisibleWindow: UIWindow {
                     touchViews[touch] = touchView
                     
                 case .moved:
-                    guard let touchView = touchViews[touch] else {
-                        return
+                    if let touchView = touchViews[touch] {
+                        touchView.center = touchLocation
                     }
-                    touchView.center = touchLocation
                     
                 case .ended, .cancelled:
                     cleanupTouch(touch)

--- a/MastodonSDK/Sources/MastodonUI/View/Window/TouchesVisibleWindow.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Window/TouchesVisibleWindow.swift
@@ -10,9 +10,9 @@
 import UIKit
 
 /// View that represents a single touch from the user.
-fileprivate final class TouchView: UIView {
+private final class TouchView: UIView {
     
-    private let blurView: UIVisualEffectView
+    private let blurView = UIVisualEffectView(effect: nil)
     
     override var frame: CGRect {
         didSet {
@@ -21,9 +21,6 @@ fileprivate final class TouchView: UIView {
     }
     
     override init(frame: CGRect) {
-        let blurEffect = UIBlurEffect(style: .systemUltraThinMaterialLight)
-        blurView = UIVisualEffectView(effect: blurEffect)
-        
         super.init(frame: frame)
         
         backgroundColor = .clear
@@ -32,6 +29,10 @@ fileprivate final class TouchView: UIView {
         layer.borderColor = UIColor.white.cgColor
         layer.borderWidth = 2.0
         
+        let blurEffect = traitCollection.userInterfaceStyle == .light ?
+            UIBlurEffect(style: .systemUltraThinMaterialDark) :
+            UIBlurEffect(style: .systemUltraThinMaterialLight)
+        blurView.effect = blurEffect
         addSubview(blurView)
     }
     

--- a/MastodonSDK/Sources/MastodonUI/View/Window/TouchesVisibleWindow.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Window/TouchesVisibleWindow.swift
@@ -23,13 +23,15 @@ private final class TouchView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
+        let isLightMode = traitCollection.userInterfaceStyle == .light
+        
         backgroundColor = .clear
         layer.masksToBounds = true
         layer.cornerCurve = .circular
-        layer.borderColor = UIColor.white.cgColor
+        layer.borderColor = isLightMode ? UIColor.gray.cgColor : UIColor.white.cgColor
         layer.borderWidth = 2.0
         
-        let blurEffect = traitCollection.userInterfaceStyle == .light ?
+        let blurEffect = isLightMode ?
             UIBlurEffect(style: .systemUltraThinMaterialDark) :
             UIBlurEffect(style: .systemUltraThinMaterialLight)
         blurView.effect = blurEffect


### PR DESCRIPTION
When reporting a bug or pitching a new feature, it can be very helpful to see just how the user is interacting with the UI. This PR adds the functionality to do just that by providing a new option in the debug menu to toggle on/off the visibility of touches.

### Example
https://user-images.githubusercontent.com/5335670/206009337-01fc352f-2266-49cd-9348-ff8ee3250694.mp4