### PR TITLE
Fix Issue Media Preview Jumping on Interactive Dismissal

### DIFF
--- a/Mastodon/Scene/Transition/MediaPreview/MediaHostToMediaPreviewViewControllerAnimatedTransitioning.swift
+++ b/Mastodon/Scene/Transition/MediaPreview/MediaHostToMediaPreviewViewControllerAnimatedTransitioning.swift
@@ -534,7 +534,7 @@ extension MediaHostToMediaPreviewViewControllerAnimatedTransitioning {
         let scaleTransform = CGAffineTransform(scaleX: (itemWidth / size.width), y: (itemHeight / size.height))
         let scaledOffset = transitionItem.touchOffset.apply(transform: scaleTransform)
 
-        let center = transitionView.convert(transitionView.center, to: nil)
+        let center = transitionView.convert(CGPoint(x: transitionView.bounds.midX, y: transitionView.bounds.midY), to: nil)
         snapshot.center = (center + (translation + (transitionItem.touchOffset - scaledOffset))).point
         snapshot.bounds = CGRect(origin: CGPoint.zero, size: CGSize(width: itemWidth, height: itemHeight))
         transitionItem.touchOffset = scaledOffset


### PR DESCRIPTION
At the beginning of an interactive dismissal of a media preview, the position of the media always seems to jump its position slightly downward. This is caused by an incorrect `CGPoint` conversion at the very beginning of the transition. This PR fixes that issue, and creates a seamless swipe with the media.

_Please forgive the choppiness of these screen recordings. They were captured from the simulator._

### Before
https://user-images.githubusercontent.com/5335670/206724224-c4a1094a-9c84-4190-9831-f3e025940511.mp4

### After
https://user-images.githubusercontent.com/5335670/206724326-13bd85a1-dc99-43f2-8c72-7f721a450e47.mp4