### PR TITLE
Use relative date formatting for long post timestamps

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -543,13 +543,14 @@ extension StatusView.ViewModel {
                 let formatter = DateFormatter()
                 
                 // make adaptive UI
-                if UIView.isZoomedMode || metricButtonTitleLength > 20 {
+                if UIView.isZoomedMode || metricButtonTitleLength > 30 {
                     formatter.dateStyle = .short
                     formatter.timeStyle = .short
                 } else {
                     formatter.dateStyle = .medium
                     formatter.timeStyle = .short
                 }
+                formatter.doesRelativeDateFormatting = true
                 return formatter.string(from: timestamp)
             }()
             
@@ -648,6 +649,7 @@ extension StatusView.ViewModel {
 
         let longTimestampFormatter = DateFormatter()
         longTimestampFormatter.dateStyle = .medium
+        longTimestampFormatter.doesRelativeDateFormatting = true
         longTimestampFormatter.timeStyle = .short
         let longTimestampLabel = Publishers.CombineLatest(
             $timestampText,


### PR DESCRIPTION
This fixes #759.

That said, I don’t really like this area of the code. The `UIView.isZoomedMode || metricButtonTitleLength > [magic number]` check is weird to me and it would be great to rewrite it in SwiftUI to use the `ViewThatFits` view in iOS 16, or an equivalent UIKit construct that allows us to change the text of the label as the available space changes.

It’s also weird that the long and short forms of the date string are “Today at XX:XX” and “Today, XX:XX” in English (and there’s no good way to check for this case since the set of days for which relative formatting is applied depends on the locale)

Also not sure if I like this better than the current behavior but wanted to try it out