### PR TITLE
Fix VoiceOver trap in thread titles

### DIFF
--- a/Mastodon/Scene/Share/View/Content/DoubleTitleLabelNavigationBarTitleView.swift
+++ b/Mastodon/Scene/Share/View/Content/DoubleTitleLabelNavigationBarTitleView.swift
@@ -51,16 +51,20 @@ extension DoubleTitleLabelNavigationBarTitleView {
         
         containerView.addArrangedSubview(titleLabel)
         containerView.addArrangedSubview(subtitleLabel)
+
+        isAccessibilityElement = true
     }
 
     func update(title: String, subtitle: String?) {
         titleLabel.configure(content: PlaintextMetaContent(string: title))
         update(subtitle: subtitle)
+        accessibilityLabel = subtitle.map { "\(title), \($0)" } ?? title
     }
     
     func update(titleMetaContent: MetaContent, subtitle: String?) {
         titleLabel.configure(content: titleMetaContent)
         update(subtitle: subtitle)
+        accessibilityLabel = subtitle.map { "\(titleMetaContent.string), \($0)" } ?? titleMetaContent.string
     }
 
     func update(subtitle: String?) {


### PR DESCRIPTION
Fixes #542! I’m not sure why this fixes the issue but it does. Now the `DoubleTitleLabelNavigationBarTitleView` sets itself as an accessibility element with no children, and sets its label to `title, subtitle`. Navigation through the title area now works properly!