### PR TITLE
Add a drag interaction and link preview to post links and cards

### DIFF
--- a/Mastodon/Activity/SafariActivity.swift
+++ b/Mastodon/Activity/SafariActivity.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import SafariServices
 import MastodonAsset
 import MastodonLocalization
 

--- a/Mastodon/Coordinator/SceneCoordinator.swift
+++ b/Mastodon/Coordinator/SceneCoordinator.swift
@@ -275,8 +275,8 @@ extension SceneCoordinator {
 
     @MainActor
     @discardableResult
-    func present(scene: Scene, from sender: UIViewController? = nil, transition: Transition) -> UIViewController? {
-        guard let viewController = get(scene: scene) else {
+    func present(scene: Scene, from sender: UIViewController?, to prebuiltViewController: UIViewController? = nil, transition: Transition) -> UIViewController? {
+        guard let viewController = prebuiltViewController ?? viewController(forScene: scene) else {
             return nil
         }
         guard var presentingViewController = sender ?? sceneDelegate.window?.rootViewController?.topMost else {
@@ -384,9 +384,9 @@ extension SceneCoordinator {
     }
 }
 
-private extension SceneCoordinator {
+extension SceneCoordinator {
     
-    func get(scene: Scene) -> UIViewController? {
+    func viewController(forScene scene: Scene) -> UIViewController? {
         let viewController: UIViewController?
         
         switch scene {

--- a/Mastodon/Protocol/Provider/DataSourceFacade+Status.swift
+++ b/Mastodon/Protocol/Provider/DataSourceFacade+Status.swift
@@ -388,7 +388,7 @@ extension DataSourceFacade {
                 authContext: dependency.authContext,
                 composeContext: .editStatus(status: status, statusSource: statusSource),
                 destination: .topLevel)
-            _ = dependency.coordinator.present(scene: .editStatus(viewModel: editStatusViewModel), transition: .modal(animated: true))
+            _ = dependency.coordinator.present(scene: .editStatus(viewModel: editStatusViewModel), from: dependency, transition: .modal(animated: true))
         }
     }   // end func
 }

--- a/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
+++ b/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
@@ -132,30 +132,6 @@ extension StatusTableViewCellDelegate where Self: DataSourceProvider & AuthConte
     func tableViewCell(
         _ cell: UITableViewCell,
         statusView: StatusView,
-        didTapCardWithURL url: URL
-    ) {
-        Task {
-            let source = DataSourceItem.Source(tableViewCell: cell, indexPath: nil)
-            guard let item = await item(from: source) else {
-                assertionFailure()
-                return
-            }
-            guard case let .status(status) = item else {
-                assertionFailure("only works for status data provider")
-                return
-            }
-
-            await DataSourceFacade.responseToURLAction(
-                provider: self,
-                status: status,
-                url: url
-            )
-        }
-    }
-
-    func tableViewCell(
-        _ cell: UITableViewCell,
-        statusView: StatusView,
         cardControl: StatusCardControl,
         didTapURL url: URL
     ) {

--- a/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
+++ b/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
@@ -157,13 +157,8 @@ extension StatusTableViewCellDelegate where Self: DataSourceProvider & AuthConte
     func tableViewCell(
         _ cell: UITableViewCell,
         statusView: StatusView,
-        cardControlMenu statusCardControl: StatusCardControl
+        menuFor url: URL
     ) -> [LabeledAction]? {
-        guard let card = statusView.viewModel.card,
-              let url = card.url else {
-            return nil
-        }
-
         return [
             LabeledAction(
                 title: L10n.Common.Controls.Actions.copy,
@@ -177,22 +172,26 @@ extension StatusTableViewCellDelegate where Self: DataSourceProvider & AuthConte
                 asset: Asset.Arrow.squareAndArrowUp
             ) {
                 DispatchQueue.main.async {
-                    let activityViewController = UIActivityViewController(
-                        activityItems: [
-                            URLActivityItemWithMetadata(url: url) { metadata in
-                                metadata.title = card.title
-
-                                if let image = card.imageURL {
-                                    metadata.iconProvider = ImageProvider(url: image, filter: nil).itemProvider
-                                }
+                    let item: Any
+                    if let card = statusView.viewModel.card, url == card.url {
+                        item = URLActivityItemWithMetadata(url: url) { metadata in
+                            metadata.title = card.title
+                            
+                            if let image = card.imageURL {
+                                metadata.iconProvider = ImageProvider(url: image, filter: nil).itemProvider
                             }
-                        ],
+                        }
+                    } else {
+                        item = url
+                    }
+                    let activityViewController = UIActivityViewController(
+                        activityItems: [item],
                         applicationActivities: []
                     )
                     self.coordinator.present(
                         scene: .activityViewController(
                             activityViewController: activityViewController,
-                            sourceView: statusCardControl, barButtonItem: nil
+                            sourceView: statusView, barButtonItem: nil
                         ),
                         from: self,
                         transition: .activityViewControllerPresent(animated: true)

--- a/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
+++ b/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
@@ -157,7 +157,7 @@ extension StatusTableViewCellDelegate where Self: DataSourceProvider & AuthConte
     func tableViewCell(
         _ cell: UITableViewCell,
         statusView: StatusView,
-        previewFor url: URL
+        previewForURL url: URL
     ) -> UIViewController? {
         coordinator.viewController(forScene: .safari(url: url))
     }
@@ -166,7 +166,7 @@ extension StatusTableViewCellDelegate where Self: DataSourceProvider & AuthConte
     func tableViewCell(
         _ cell: UITableViewCell,
         statusView: StatusView,
-        menuFor url: URL
+        menuForURL url: URL
     ) -> [LabeledAction]? {
         return [
             LabeledAction(

--- a/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
+++ b/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
@@ -153,6 +153,15 @@ extension StatusTableViewCellDelegate where Self: DataSourceProvider & AuthConte
             )
         }
     }
+    
+    func tableViewCell(
+        _ cell: UITableViewCell,
+        statusView: StatusView,
+        previewFor url: URL
+    ) -> UIViewController? {
+        coordinator.viewController(forScene: .safari(url: url))
+    }
+
 
     func tableViewCell(
         _ cell: UITableViewCell,
@@ -218,6 +227,18 @@ extension StatusTableViewCellDelegate where Self: DataSourceProvider & AuthConte
                 }
             }
         ]
+    }
+    
+    @MainActor
+    func tableViewCell(
+        _ cell: UITableViewCell,
+        statusView: StatusView,
+        commitPreview preview: MetaPreview
+    ) {
+        switch preview {
+        case .url(let url, let vc):
+            coordinator.present(scene: .safari(url: url), from: self, to: vc, transition: .safariPresent(animated: true))
+        }
     }
 
 }

--- a/Mastodon/Scene/Onboarding/ServerRules/MastodonServerRulesViewController.swift
+++ b/Mastodon/Scene/Onboarding/ServerRules/MastodonServerRulesViewController.swift
@@ -9,7 +9,6 @@ import os.log
 import UIKit
 import Combine
 import MastodonSDK
-import SafariServices
 import MetaTextKit
 import MastodonAsset
 import MastodonCore

--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -410,7 +410,7 @@ extension MainTabBarController {
             composeContext: .composeStatus,
             destination: .topLevel
         )
-        _ = coordinator.present(scene: .compose(viewModel: composeViewModel), transition: .modal(animated: true, completion: nil))
+        _ = coordinator.present(scene: .compose(viewModel: composeViewModel), from: self, transition: .modal(animated: true, completion: nil))
     }
     
     private func touchedTab(by sender: UIGestureRecognizer) -> Tab? {

--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -9,7 +9,6 @@ import os.log
 import UIKit
 import Combine
 import CoreDataStack
-import SafariServices
 import MastodonAsset
 import MastodonCore
 import MastodonLocalization

--- a/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCellDelegate.swift
+++ b/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCellDelegate.swift
@@ -27,7 +27,6 @@ protocol StatusTableViewCellDelegate: AnyObject, AutoGenerateProtocolDelegate {
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, authorAvatarButtonDidPressed button: AvatarButton)
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, contentSensitiveeToggleButtonDidPressed button: UIButton)
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, metaText: MetaText, didSelectMeta meta: Meta)
-    func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, didTapCardWithURL url: URL)
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, mediaGridContainerView: MediaGridContainerView, mediaView: MediaView, didSelectMediaViewAt index: Int)
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, pollTableView tableView: UITableView, didSelectRowAt indexPath: IndexPath)
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, pollVoteButtonPressed button: UIButton)
@@ -63,10 +62,6 @@ extension StatusViewDelegate where Self: StatusViewContainerTableViewCell {
 
     func statusView(_ statusView: StatusView, metaText: MetaText, didSelectMeta meta: Meta) {
         delegate?.tableViewCell(self, statusView: statusView, metaText: metaText, didSelectMeta: meta)
-    }
-
-    func statusView(_ statusView: StatusView, didTapCardWithURL url: URL) {
-        delegate?.tableViewCell(self, statusView: statusView, didTapCardWithURL: url)
     }
 
     func statusView(_ statusView: StatusView, mediaGridContainerView: MediaGridContainerView, mediaView: MediaView, didSelectMediaViewAt index: Int) {

--- a/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCellDelegate.swift
+++ b/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCellDelegate.swift
@@ -38,7 +38,7 @@ protocol StatusTableViewCellDelegate: AnyObject, AutoGenerateProtocolDelegate {
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, statusMetricView: StatusMetricView, favoriteButtonDidPressed button: UIButton)
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, statusMetricView: StatusMetricView, showEditHistory button: UIButton)
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, cardControl: StatusCardControl, didTapURL url: URL)
-    func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, cardControlMenu: StatusCardControl) -> [LabeledAction]?
+    func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, menuFor url: URL) -> [LabeledAction]?
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, accessibilityActivate: Void)
     // sourcery:end
 }
@@ -108,8 +108,8 @@ extension StatusViewDelegate where Self: StatusViewContainerTableViewCell {
         delegate?.tableViewCell(self, statusView: statusView, cardControl: cardControl, didTapURL: url)
     }
 
-    func statusView(_ statusView: StatusView, cardControlMenu: StatusCardControl) -> [LabeledAction]? {
-        return delegate?.tableViewCell(self, statusView: statusView, cardControlMenu: cardControlMenu)
+    func statusView(_ statusView: StatusView, menuFor url: URL) -> [LabeledAction]? {
+        return delegate?.tableViewCell(self, statusView: statusView, menuFor: url)
     }
 
     func statusView(_ statusView: StatusView, accessibilityActivate: Void) {

--- a/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCellDelegate.swift
+++ b/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCellDelegate.swift
@@ -38,8 +38,8 @@ protocol StatusTableViewCellDelegate: AnyObject, AutoGenerateProtocolDelegate {
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, statusMetricView: StatusMetricView, favoriteButtonDidPressed button: UIButton)
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, statusMetricView: StatusMetricView, showEditHistory button: UIButton)
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, cardControl: StatusCardControl, didTapURL url: URL)
-    func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, previewFor url: URL) -> UIViewController?
-    func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, menuFor url: URL) -> [LabeledAction]?
+    func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, previewForURL url: URL) -> UIViewController?
+    func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, menuForURL url: URL) -> [LabeledAction]?
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, commitPreview preview: MetaPreview)
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, accessibilityActivate: Void)
     // sourcery:end
@@ -110,12 +110,12 @@ extension StatusViewDelegate where Self: StatusViewContainerTableViewCell {
         delegate?.tableViewCell(self, statusView: statusView, cardControl: cardControl, didTapURL: url)
     }
 
-    func statusView(_ statusView: StatusView, previewFor url: URL) -> UIViewController? {
-        return delegate?.tableViewCell(self, statusView: statusView, previewFor: url)
+    func statusView(_ statusView: StatusView, previewForURL url: URL) -> UIViewController? {
+        return delegate?.tableViewCell(self, statusView: statusView, previewForURL: url)
     }
 
-    func statusView(_ statusView: StatusView, menuFor url: URL) -> [LabeledAction]? {
-        return delegate?.tableViewCell(self, statusView: statusView, menuFor: url)
+    func statusView(_ statusView: StatusView, menuForURL url: URL) -> [LabeledAction]? {
+        return delegate?.tableViewCell(self, statusView: statusView, menuForURL: url)
     }
 
     func statusView(_ statusView: StatusView, commitPreview preview: MetaPreview) {

--- a/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCellDelegate.swift
+++ b/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCellDelegate.swift
@@ -38,7 +38,9 @@ protocol StatusTableViewCellDelegate: AnyObject, AutoGenerateProtocolDelegate {
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, statusMetricView: StatusMetricView, favoriteButtonDidPressed button: UIButton)
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, statusMetricView: StatusMetricView, showEditHistory button: UIButton)
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, cardControl: StatusCardControl, didTapURL url: URL)
+    func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, previewFor url: URL) -> UIViewController?
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, menuFor url: URL) -> [LabeledAction]?
+    func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, commitPreview preview: MetaPreview)
     func tableViewCell(_ cell: UITableViewCell, statusView: StatusView, accessibilityActivate: Void)
     // sourcery:end
 }
@@ -108,8 +110,16 @@ extension StatusViewDelegate where Self: StatusViewContainerTableViewCell {
         delegate?.tableViewCell(self, statusView: statusView, cardControl: cardControl, didTapURL: url)
     }
 
+    func statusView(_ statusView: StatusView, previewFor url: URL) -> UIViewController? {
+        return delegate?.tableViewCell(self, statusView: statusView, previewFor: url)
+    }
+
     func statusView(_ statusView: StatusView, menuFor url: URL) -> [LabeledAction]? {
         return delegate?.tableViewCell(self, statusView: statusView, menuFor: url)
+    }
+
+    func statusView(_ statusView: StatusView, commitPreview preview: MetaPreview) {
+        delegate?.tableViewCell(self, statusView: statusView, commitPreview: preview)
     }
 
     func statusView(_ statusView: StatusView, accessibilityActivate: Void) {

--- a/MastodonSDK/Sources/MastodonUI/Extension/UITextView.swift
+++ b/MastodonSDK/Sources/MastodonUI/Extension/UITextView.swift
@@ -1,0 +1,51 @@
+//
+//  UITextView.swift
+//  
+//
+//  Created by Jed Fox on 2022-12-15.
+//
+
+import UIKit
+import Meta
+import MastodonCore
+
+extension UITextView {
+    public func meta(at location: CGPoint) -> (meta: Meta, range: NSRange)? {
+        let glyphIndex = layoutManager.glyphIndex(for: location, in: textContainer)
+        let bounds = layoutManager.boundingRect(forGlyphRange: NSMakeRange(glyphIndex, 1), in: textContainer)
+        let index = layoutManager.characterIndexForGlyph(at: glyphIndex)
+
+        guard bounds.contains(location), index < textStorage.length else { return nil }
+
+        var effectiveRange = NSRange()
+        let key = NSAttributedString.Key("MetaAttributeKey.meta")
+        if let meta = textStorage.attribute(key, at: index, longestEffectiveRange: &effectiveRange, in: NSRange(..<textStorage.length)) as? Meta {
+            return (meta, effectiveRange)
+        }
+
+        return nil
+    }
+
+    public func snapshot(of range: NSRange, backgroundColor: UIColor) -> (snapshot: UIView, textLineRects: [NSValue], center: CGPoint)? {
+        var rects = [CGRect]()
+        var combinedRect = CGRect.null
+        let combinedPath = UIBezierPath()
+        layoutManager.enumerateEnclosingRects(forGlyphRange: range, withinSelectedGlyphRange: NSMakeRange(NSNotFound, 0), in: textContainer) { rect, _ in
+            rects.append(rect)
+            combinedRect = combinedRect.union(rect)
+            combinedPath.append(UIBezierPath(rect: rect))
+        }
+        if let snapshot = snapshotView(afterScreenUpdates: false) {
+            let mask = CAShapeLayer()
+            mask.path = combinedPath.cgPath
+            snapshot.layer.mask = mask
+            snapshot.backgroundColor = backgroundColor
+            return (
+                snapshot,
+                rects.map(NSValue.init),
+                CGPoint(x: combinedRect.midX, y: combinedRect.midY)
+            )
+        }
+        return nil
+    }
+}

--- a/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
@@ -606,7 +606,7 @@ extension NotificationView: StatusViewDelegate {
         assertionFailure()
     }
 
-    public func statusView(_ statusView: StatusView, cardControlMenu: StatusCardControl) -> [LabeledAction]? {
+    public func statusView(_ statusView: StatusView, menuFor url: URL) -> [LabeledAction]? {
         assertionFailure()
         return nil
     }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
@@ -496,10 +496,6 @@ extension NotificationView {
 
 // MARK: - StatusViewDelegate
 extension NotificationView: StatusViewDelegate {
-    public func statusView(_ statusView: StatusView, didTapCardWithURL url: URL) {
-        assertionFailure()
-    }
-
     public func statusView(_ statusView: StatusView, headerDidPressed header: UIView) {
         // do nothing
     }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
@@ -606,11 +606,11 @@ extension NotificationView: StatusViewDelegate {
         assertionFailure()
     }
 
-    public func statusView(_ statusView: StatusView, previewFor url: URL) -> UIViewController? {
+    public func statusView(_ statusView: StatusView, previewForURL url: URL) -> UIViewController? {
         return nil
     }
     
-    public func statusView(_ statusView: StatusView, menuFor url: URL) -> [LabeledAction]? {
+    public func statusView(_ statusView: StatusView, menuForURL url: URL) -> [LabeledAction]? {
         return nil
     }
     

--- a/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
@@ -606,9 +606,19 @@ extension NotificationView: StatusViewDelegate {
         assertionFailure()
     }
 
-    public func statusView(_ statusView: StatusView, menuFor url: URL) -> [LabeledAction]? {
+    public func statusView(_ statusView: StatusView, previewFor url: URL) -> UIViewController? {
         assertionFailure()
         return nil
+    }
+    
+    public func statusView(_ statusView: StatusView, menuFor url: URL) -> [LabeledAction]? {
+        // XXX
+        assertionFailure()
+        return nil
+    }
+    
+    public func statusView(_ statusView: StatusView, commitPreview preview: MetaPreview) {
+        assertionFailure()
     }
 
 }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView.swift
@@ -607,18 +607,14 @@ extension NotificationView: StatusViewDelegate {
     }
 
     public func statusView(_ statusView: StatusView, previewFor url: URL) -> UIViewController? {
-        assertionFailure()
         return nil
     }
     
     public func statusView(_ statusView: StatusView, menuFor url: URL) -> [LabeledAction]? {
-        // XXX
-        assertionFailure()
         return nil
     }
     
     public func statusView(_ statusView: StatusView, commitPreview preview: MetaPreview) {
-        assertionFailure()
     }
 
 }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
@@ -13,7 +13,6 @@ import MastodonLocalization
 import CoreDataStack
 import UIKit
 import WebKit
-import SafariServices
 
 public protocol StatusCardControlDelegate: AnyObject {
     func statusCardControl(_ statusCardControl: StatusCardControl, didTapURL url: URL)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
@@ -45,6 +45,7 @@ public final class StatusCardControl: UIControl {
             self?.showWebView()
         })
     }()
+    private var url: URL?
     private var html = ""
 
     private static let cardContentPool = WKProcessPool()
@@ -129,6 +130,7 @@ public final class StatusCardControl: UIControl {
         ])
 
         addInteraction(UIContextMenuInteraction(delegate: self))
+        addInteraction(UIDragInteraction(delegate: self))
         isAccessibilityElement = true
         accessibilityTraits.insert(.link)
     }
@@ -138,6 +140,7 @@ public final class StatusCardControl: UIControl {
     }
 
     public func configure(card: Card) {
+        self.url = card.url
         if let host = card.url?.host {
             accessibilityLabel = "\(card.title) \(host)"
         } else {
@@ -314,6 +317,14 @@ extension StatusCardControl {
 
     public override func contextMenuInteraction(_ interaction: UIContextMenuInteraction, previewForDismissingMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
         UITargetedPreview(view: self)
+    }
+}
+
+// MARK: UIDragInteractionDelegate
+extension StatusCardControl: UIDragInteractionDelegate {
+    public func dragInteraction(_ interaction: UIDragInteraction, itemsForBeginning session: UIDragSession) -> [UIDragItem] {
+        guard let url else { return [] }
+        return [UIDragItem(itemProvider: NSItemProvider(object: url as NSURL))]
     }
 }
 

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
@@ -326,8 +326,13 @@ extension StatusCardControl {
 // MARK: UIDragInteractionDelegate
 extension StatusCardControl: UIDragInteractionDelegate {
     public func dragInteraction(_ interaction: UIDragInteraction, itemsForBeginning session: UIDragSession) -> [UIDragItem] {
+        dragInteraction(interaction, itemsForAddingTo: session, withTouchAt: session.location(in: self))
+    }
+
+    public func dragInteraction(_ interaction: UIDragInteraction, itemsForAddingTo session: UIDragSession, withTouchAt point: CGPoint) -> [UIDragItem] {
         guard let url else { return [] }
-        return [UIDragItem(itemProvider: NSItemProvider(object: url as NSURL))]
+        let item = UIDragItem(itemProvider: NSItemProvider(object: url as NSURL))
+        return [item]
     }
 }
 

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
@@ -312,6 +312,8 @@ extension StatusCardControl: WKNavigationDelegate, WKUIDelegate {
 
 // MARK: UIContextMenuInteractionDelegate
 extension StatusCardControl {
+    /// This class is needed because `UIControl` marks `contextMenuInteraction(_:willPerformPreviewActionForMenuWith:animator:)`
+    /// as unavailable for some reason, so we can’t use the `StatusCardControl` itself as the delegate.
     fileprivate class ContextMenuDelegate: NSObject, UIContextMenuInteractionDelegate {
         unowned let parent: StatusCardControl
         

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
@@ -332,6 +332,9 @@ extension StatusCardControl: UIDragInteractionDelegate {
     public func dragInteraction(_ interaction: UIDragInteraction, itemsForAddingTo session: UIDragSession, withTouchAt point: CGPoint) -> [UIDragItem] {
         guard let url else { return [] }
         let item = UIDragItem(itemProvider: NSItemProvider(object: url as NSURL))
+        item.previewProvider = {
+            UIDragPreview(for: url, title: self.titleLabel.text)
+        }
         return [item]
     }
 }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
@@ -13,6 +13,7 @@ import MastodonLocalization
 import CoreDataStack
 import UIKit
 import WebKit
+import SafariServices
 
 public protocol StatusCardControlDelegate: AnyObject {
     func statusCardControl(_ statusCardControl: StatusCardControl, didTapURL url: URL)
@@ -307,7 +308,9 @@ extension StatusCardControl: WKNavigationDelegate, WKUIDelegate {
 // MARK: UIContextMenuInteractionDelegate
 extension StatusCardControl {
     public override func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
-        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { _ in
+        return UIContextMenuConfiguration(identifier: nil) {
+            self.url.map { SFSafariViewController(url: $0) }
+        } actionProvider: { elements in
             if let elements = self.delegate?.statusCardControlMenu(self)?.map(\.menuElement) {
                 return UIMenu(children: elements)
             }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -8,7 +8,6 @@
 import os.log
 import UIKit
 import Combine
-import SafariServices
 import MetaTextKit
 import Meta
 import MastodonAsset

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -40,8 +40,8 @@ public protocol StatusViewDelegate: AnyObject {
     func statusView(_ statusView: StatusView, statusMetricView: StatusMetricView, favoriteButtonDidPressed button: UIButton)
     func statusView(_ statusView: StatusView, statusMetricView: StatusMetricView, showEditHistory button: UIButton)
     func statusView(_ statusView: StatusView, cardControl: StatusCardControl, didTapURL url: URL)
-    func statusView(_ statusView: StatusView, previewFor url: URL) -> UIViewController?
-    func statusView(_ statusView: StatusView, menuFor url: URL) -> [LabeledAction]?
+    func statusView(_ statusView: StatusView, previewForURL url: URL) -> UIViewController?
+    func statusView(_ statusView: StatusView, menuForURL url: URL) -> [LabeledAction]?
     func statusView(_ statusView: StatusView, commitPreview preview: MetaPreview)
     
     // a11y
@@ -799,10 +799,10 @@ extension StatusView: UIContextMenuInteractionDelegate {
         else { return nil }
         let config = MetaContextMenuConfiguration(
             previewProvider: {
-                self.delegate?.statusView(self, previewFor: url)
+                self.delegate?.statusView(self, previewForURL: url)
             },
             actionProvider: { _ in
-                if let elements = self.delegate?.statusView(self, menuFor: url)?.map(\.menuElement) {
+                if let elements = self.delegate?.statusView(self, menuForURL: url)?.map(\.menuElement) {
                     return UIMenu(children: elements)
                 }
                 return nil
@@ -921,7 +921,7 @@ extension StatusView: StatusCardControlDelegate {
 
     public func statusCardControlMenu(_ statusCardControl: StatusCardControl) -> [LabeledAction]? {
         if let url = viewModel.card?.url {
-            return delegate?.statusView(self, menuFor: url)
+            return delegate?.statusView(self, menuForURL: url)
         } else {
             return nil
         }
@@ -932,7 +932,7 @@ extension StatusView: StatusCardControlDelegate {
     }
     
     public func statusCardControl(_ statusCardControl: StatusCardControl, previewViewControllerFor url: URL) -> UIViewController? {
-        delegate?.statusView(self, previewFor: url)
+        delegate?.statusView(self, previewForURL: url)
     }
 }
 

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -35,8 +35,8 @@ public protocol StatusViewDelegate: AnyObject {
     func statusView(_ statusView: StatusView, statusMetricView: StatusMetricView, favoriteButtonDidPressed button: UIButton)
     func statusView(_ statusView: StatusView, statusMetricView: StatusMetricView, showEditHistory button: UIButton)
     func statusView(_ statusView: StatusView, cardControl: StatusCardControl, didTapURL url: URL)
-    func statusView(_ statusView: StatusView, cardControlMenu: StatusCardControl) -> [LabeledAction]?
-    
+    func statusView(_ statusView: StatusView, menuFor url: URL) -> [LabeledAction]?
+
     // a11y
     func statusView(_ statusView: StatusView, accessibilityActivate: Void)
 }
@@ -795,9 +795,10 @@ extension StatusView: UIContextMenuInteractionDelegate {
                 SFSafariViewController(url: url)
             },
             actionProvider: { _ in
-                UIMenu(children: [
-                    UIAction(title: url.absoluteString, handler: { _ in })
-                ])
+                if let elements = self.delegate?.statusView(self, menuFor: url)?.map(\.menuElement) {
+                    return UIMenu(children: elements)
+                }
+                return nil
             }
         )
         config.meta = meta
@@ -890,7 +891,11 @@ extension StatusView: StatusCardControlDelegate {
     }
 
     public func statusCardControlMenu(_ statusCardControl: StatusCardControl) -> [LabeledAction]? {
-        delegate?.statusView(self, cardControlMenu: statusCardControl)
+        if let url = viewModel.card?.url {
+            return delegate?.statusView(self, menuFor: url)
+        } else {
+            return nil
+        }
     }
 }
 

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -747,31 +747,31 @@ private class MetaContextMenuConfiguration: UIContextMenuConfiguration {
 extension StatusView: UIContextMenuInteractionDelegate {
     public func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
         let location = contentMetaText.textView.convert(location, from: interaction.view!)
-        if let (meta, effectiveRange) = contentMetaText.textView.meta(at: location),
-           case .url(_, _, let url, _) = meta,
-            let url = URL(string: url) {
-            let config = MetaContextMenuConfiguration(
-                previewProvider: {
-                    SFSafariViewController(url: url)
-                },
-                actionProvider: { _ in
-                    UIMenu(children: [
-                        UIAction(title: url.absoluteString, handler: { _ in })
-                    ])
-                }
-            )
-            config.meta = meta
-            config.range = effectiveRange
-            if let (snapshot, textLineRects, center) = contentMetaText.textView.snapshot(of: effectiveRange, backgroundColor: ThemeService.shared.currentTheme.value.systemBackgroundColor) {
-                config.preview = UITargetedPreview(
-                    view: snapshot,
-                    parameters: UIPreviewParameters(textLineRects: textLineRects),
-                    target: UIPreviewTarget(container: contentMetaText.textView, center: center)
-                )
+        guard
+            let (meta, effectiveRange) = contentMetaText.textView.meta(at: location),
+            case .url(_, _, let url, _) = meta,
+            let url = URL(string: url)
+        else { return nil }
+        let config = MetaContextMenuConfiguration(
+            previewProvider: {
+                SFSafariViewController(url: url)
+            },
+            actionProvider: { _ in
+                UIMenu(children: [
+                    UIAction(title: url.absoluteString, handler: { _ in })
+                ])
             }
-            return config
+        )
+        config.meta = meta
+        config.range = effectiveRange
+        if let (snapshot, textLineRects, center) = contentMetaText.textView.snapshot(of: effectiveRange, backgroundColor: ThemeService.shared.currentTheme.value.systemBackgroundColor) {
+            config.preview = UITargetedPreview(
+                view: snapshot,
+                parameters: UIPreviewParameters(textLineRects: textLineRects),
+                target: UIPreviewTarget(container: contentMetaText.textView, center: center)
+            )
         }
-        return nil
+        return config
     }
 
     public func contextMenuInteraction(_ interaction: UIContextMenuInteraction, previewForHighlightingMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -745,9 +745,13 @@ extension StatusView: MetaTextViewDelegate {
 // MARK: - UIDragInteractionDelegate
 extension StatusView: UIDragInteractionDelegate {
     public func dragInteraction(_ interaction: UIDragInteraction, itemsForBeginning session: UIDragSession) -> [UIDragItem] {
+        dragInteraction(interaction, itemsForAddingTo: session, withTouchAt: session.location(in: interaction.view!))
+    }
+
+    public func dragInteraction(_ interaction: UIDragInteraction, itemsForAddingTo session: UIDragSession, withTouchAt point: CGPoint) -> [UIDragItem] {
         guard
-            let (meta, effectiveRange) = contentMetaText.textView.meta(at: session.location(in: contentMetaText.textView)),
-            case let .url(text, trimmed, url, _) = meta,
+            let (meta, effectiveRange) = contentMetaText.textView.meta(at: contentMetaText.textView.convert(point, from: interaction.view!)),
+            case let .url(_, trimmed, url, _) = meta,
             let url = URL(string: url)
         else { return [] }
         let item = UIDragItem(itemProvider: NSItemProvider(object: url as NSURL))
@@ -757,7 +761,7 @@ extension StatusView: UIDragInteractionDelegate {
     }
 
     public func dragInteraction(_ interaction: UIDragInteraction, previewForLifting item: UIDragItem, session: UIDragSession) -> UITargetedDragPreview? {
-        guard let (url, effectiveRange) = item.localObject as? (URL, NSRange) else {
+        guard let (_, effectiveRange) = item.localObject as? (URL, NSRange) else {
             assertionFailure()
             return nil
         }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -775,8 +775,12 @@ extension StatusView: UIContextMenuInteractionDelegate {
             combinedRect = combinedRect.union(rect)
             combinedPath.append(UIBezierPath(rect: rect))
         }
+        guard let snapshot = contentMetaText.textView.snapshotView(afterScreenUpdates: false) else { return nil }
+        let mask = CAShapeLayer()
+        mask.path = combinedPath.cgPath
+        snapshot.layer.mask = mask
         return UITargetedPreview(
-            view: contentMetaText.textView.snapshotView(afterScreenUpdates: false)!,
+            view: snapshot,
             parameters: UIPreviewParameters(textLineRects: rects.map(NSValue.init)),
             target: UIPreviewTarget(container: contentMetaText.textView, center: CGPoint(x: combinedRect.midX, y: combinedRect.midY))
         )

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -24,7 +24,6 @@ public protocol StatusViewDelegate: AnyObject {
     func statusView(_ statusView: StatusView, authorAvatarButtonDidPressed button: AvatarButton)
     func statusView(_ statusView: StatusView, contentSensitiveeToggleButtonDidPressed button: UIButton)
     func statusView(_ statusView: StatusView, metaText: MetaText, didSelectMeta meta: Meta)
-    func statusView(_ statusView: StatusView, didTapCardWithURL url: URL)
     func statusView(_ statusView: StatusView, mediaGridContainerView: MediaGridContainerView, mediaView: MediaView, didSelectMediaViewAt index: Int)
     func statusView(_ statusView: StatusView, pollTableView tableView: UITableView, didSelectRowAt indexPath: IndexPath)
     func statusView(_ statusView: StatusView, pollVoteButtonPressed button: UIButton)
@@ -419,7 +418,7 @@ extension StatusView {
     @objc private func statusCardControlPressed(_ sender: StatusCardControl) {
         logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public)")
         guard let url = viewModel.card?.url else { return }
-        delegate?.statusView(self, didTapCardWithURL: url)
+        delegate?.statusView(self, cardControl: sender, didTapURL: url)
     }
     
 }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -778,6 +778,7 @@ extension StatusView: UIContextMenuInteractionDelegate {
                     let mask = CAShapeLayer()
                     mask.path = combinedPath.cgPath
                     snapshot.layer.mask = mask
+                    snapshot.backgroundColor = ThemeService.shared.currentTheme.value.systemBackgroundColor
                     config.preview = UITargetedPreview(
                         view: snapshot,
                         parameters: UIPreviewParameters(textLineRects: rects.map(NSValue.init)),

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -746,7 +746,10 @@ private class MetaContextMenuConfiguration: UIContextMenuConfiguration {
 }
 extension StatusView: UIContextMenuInteractionDelegate {
     public func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
+        let location = contentMetaText.textView.convert(location, from: interaction.view!)
         let glyphIndex = contentMetaText.layoutManager.glyphIndex(for: location, in: contentMetaText.textView.textContainer)
+        let bounds = contentMetaText.layoutManager.boundingRect(forGlyphRange: NSMakeRange(glyphIndex, 1), in: contentMetaText.textView.textContainer)
+        guard bounds.contains(location) else { return nil }
         let index = contentMetaText.layoutManager.characterIndexForGlyph(at: glyphIndex)
         if index < contentMetaText.textStorage.length {
             var effectiveRange: NSRange = NSRange()

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -757,13 +757,13 @@ extension StatusView: UIDragInteractionDelegate {
             let url = URL(string: url)
         else { return [] }
         let item = UIDragItem(itemProvider: NSItemProvider(object: url as NSURL))
-        item.localObject = (url, effectiveRange)
+        item.localObject = effectiveRange
         item.previewProvider = { UIDragPreview(for: url, title: trimmed) }
         return [item]
     }
 
     public func dragInteraction(_ interaction: UIDragInteraction, previewForLifting item: UIDragItem, session: UIDragSession) -> UITargetedDragPreview? {
-        guard let (_, effectiveRange) = item.localObject as? (URL, NSRange) else {
+        guard let effectiveRange = item.localObject as? NSRange else {
             assertionFailure()
             return nil
         }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -349,10 +349,7 @@ public final class StatusView: UIView {
 
 extension StatusView {
     private func _init() {
-        let dragInteraction = UIDragInteraction(delegate: self)
-        dragInteraction.allowsSimultaneousRecognitionDuringLift = true
-        dragInteraction.isEnabled = true
-        addInteraction(dragInteraction)
+        addInteraction(UIDragInteraction(delegate: self))
         addInteraction(UIContextMenuInteraction(delegate: self))
 
         // container

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -753,12 +753,17 @@ extension StatusView: UIContextMenuInteractionDelegate {
             let key = NSAttributedString.Key("MetaAttributeKey.meta")
             guard let meta = contentMetaText.textStorage.attribute(key, at: index, longestEffectiveRange: &effectiveRange, in: NSRange(..<contentMetaText.textStorage.length)) as? Meta
             else { return nil }
-            if case .url(_, _, let url, _) = meta {
-                let config = MetaContextMenuConfiguration(actionProvider: { _ in
-                    UIMenu(children: [
-                        UIAction(title: url, handler: { _ in })
-                    ])
-                })
+            if case .url(_, _, let url, _) = meta, let url = URL(string: url) {
+                let config = MetaContextMenuConfiguration(
+                    previewProvider: {
+                        SFSafariViewController(url: url)
+                    },
+                    actionProvider: { _ in
+                        UIMenu(children: [
+                            UIAction(title: url.absoluteString, handler: { _ in })
+                        ])
+                    }
+                )
                 config.meta = meta
                 config.range = effectiveRange
                 var rects = [CGRect]()


### PR DESCRIPTION
- Fixes #652
- Fixes #725
- add a drag interaction to post links and the card so you can drop the URL elsewhere (like into a new post window or something)
- add a context menu to links in posts with the same actions as on the card
- Configure an `SFSafariViewController` to enable link previews when long pressing links/cards
  - this works exactly like in Mail/Safari/other apps, including support for toggling the preview on and off!
  - (implemented) ~it would be ideal if there were some way to pass the `SFSafariViewController` instance up to the scene coordinator so that if the user commits the long press interaction the page can be shown immediately without having to reload it (and also ideally it would be a synchronous method call so that the animated presentation could be adjusted to occur in sync with the commit animation).~

code changes:
- unify `statusView:didTapCardWithURL:` and `statusView:cardControl:didTapURL:` since they do the same thing
- `SceneCoordinator` now allows you to fetch a view controller for a proposed scene separately from doing the transition, this allows for peek+pop to be added elsewhere (posts? other meta entities? user cards?)
- `UITextView` now has support for finding the `Meta` object corresponding to a point and snapshotting a text range (for use in the highlight preview)
- The code is extensible to other meta types (like hashtags and mentions), I may implement these in future PRs if I have time.

~This is still WIP because I would like to configure:~
- [x] a drag interaction on links too
- [x] some sort of code sharing arrangement since currently the code for the context menu stuff is a little duplicative (it’s better now but there could be improvements?)
- [x] some more code sharing to make it easier to enable previews/context menus/drag interactions for hashtags and mentions in the future (specifically in the code that creates the targeted preview for the drag/context menu interactions)