### PR TITLE
IOS-32: Fix paragraph margins in compose

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/SwiftUI/MetaTextViewRepresentable.swift
+++ b/MastodonSDK/Sources/MastodonUI/SwiftUI/MetaTextViewRepresentable.swift
@@ -50,6 +50,8 @@ public struct MetaTextViewRepresentable: UIViewRepresentable {
             .foregroundColor: Asset.Colors.brand.color,
         ]
                 
+        metaText.paragraphStyle = NSMutableParagraphStyle()
+        
         configurationHandler(metaText)
             
         metaText.configure(content: PlaintextMetaContent(string: string))


### PR DESCRIPTION
# Rationale

Apply default `NSParagraphStyle` to compose view controller's `MetaText` to avoid excessive spacing between lines and paragraphs.

| Before | After |
|---|---|
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-16 at 10 25 39](https://user-images.githubusercontent.com/126418/208067446-8d373196-ef8f-4b06-8246-dae3132b3208.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-16 at 10 26 54](https://user-images.githubusercontent.com/126418/208067517-fc84952c-7908-4d2f-bb8e-0095f8b5ad22.png)|
