### PR TITLE
Improve status menu UX, fix accessibility bug

### DIFF
--- a/Localization/StringsConvertor/input/Base.lproj/app.json
+++ b/Localization/StringsConvertor/input/Base.lproj/app.json
@@ -98,6 +98,7 @@
                 "unblock_domain": "Unblock %s",
                 "settings": "Settings",
                 "delete": "Delete",
+                "manage_author": "Manage Author…",
                 "translate_post": {
                     "title": "Translate from %s",
                     "unknown_language": "Unknown"

--- a/Localization/app.json
+++ b/Localization/app.json
@@ -98,6 +98,7 @@
                 "unblock_domain": "Unblock %s",
                 "settings": "Settings",
                 "delete": "Delete",
+                "manage_author": "Manage Author…",
                 "translate_post": {
                     "title": "Translate from %s",
                     "unknown_language": "Unknown"

--- a/Mastodon.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mastodon.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
         "state": {
           "branch": null,
-          "revision": "8dd85aee02e39dd280c75eef88ffdb86eed4b07b",
-          "version": "5.6.2"
+          "revision": "354dda32d89fc8cd4f5c46487f64957d355f53d8",
+          "version": "5.6.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/Flipboard/FLAnimatedImage.git",
         "state": {
           "branch": null,
-          "revision": "d4f07b6f164d53c1212c3e54d6460738b1981e9f",
-          "version": "1.0.17"
+          "revision": "e7f9fd4681ae41bf6f3056db08af4f401d61da52",
+          "version": "1.0.16"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/kean/Nuke.git",
         "state": {
           "branch": null,
-          "revision": "a002b7fd786f2df2ed4333fe73a9727499fd9d97",
-          "version": "10.11.2"
+          "revision": "0ea7545b5c918285aacc044dc75048625c8257cc",
+          "version": "10.8.0"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/uias/Pageboy",
         "state": {
           "branch": null,
-          "revision": "af8fa81788b893205e1ff42ddd88c5b0b315d7c5",
-          "version": "3.7.0"
+          "revision": "34ecb6e7c4e0e07494960ab2f7cc9a02293915a6",
+          "version": "3.6.2"
         }
       },
       {
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/SDWebImage/SDWebImage.git",
         "state": {
           "branch": null,
-          "revision": "3312bf5e67b52fbce7c3caf431b0cda721a9f7bb",
-          "version": "5.14.2"
+          "revision": "2e63d0061da449ad0ed130768d05dceb1496de44",
+          "version": "5.12.5"
         }
       },
       {
@@ -186,8 +186,8 @@
         "repositoryURL": "https://github.com/scinfu/SwiftSoup.git",
         "state": {
           "branch": null,
-          "revision": "6778575285177365cbad3e5b8a72f2a20583cfec",
-          "version": "2.4.3"
+          "revision": "41e7c263fb8c277e980ebcb9b0b5f6031d3d4886",
+          "version": "2.4.2"
         }
       },
       {

--- a/Mastodon/Protocol/Provider/DataSourceFacade+Status.swift
+++ b/Mastodon/Protocol/Provider/DataSourceFacade+Status.swift
@@ -361,7 +361,6 @@ extension DataSourceFacade {
             let cancelAction = UIAlertAction(title: L10n.Common.Controls.Actions.cancel, style: .cancel)
             alertController.addAction(cancelAction)
             dependency.present(alertController, animated: true)
-            
         case .translateStatus:
             guard let status = menuContext.status else { return }
             do {
@@ -375,7 +374,6 @@ extension DataSourceFacade {
                 dependency.present(alertController, animated: true)
             }
         case .editStatus:
-
             guard let status = menuContext.status?.object(in: dependency.context.managedObjectContext) else { return }
 
             let statusSource = try await dependency.context.apiService.getStatusSource(
@@ -389,6 +387,17 @@ extension DataSourceFacade {
                 composeContext: .editStatus(status: status, statusSource: statusSource),
                 destination: .topLevel)
             _ = dependency.coordinator.present(scene: .editStatus(viewModel: editStatusViewModel), transition: .modal(animated: true))
+        case let .showActionSheet(title, actions):
+            let actionSheet = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
+            actions.forEach { actionSheet.addAction($0) }
+            actionSheet.addAction(UIAlertAction(title: L10n.Common.Controls.Actions.cancel, style: .cancel))
+            actionSheet.popoverPresentationController?.sourceView = menuContext.button
+            actionSheet.popoverPresentationController?.barButtonItem = menuContext.barButtonItem
+            dependency.coordinator.present(
+                scene: .alertController(alertController: actionSheet),
+                from: dependency,
+                transition: .alertController(animated: true)
+            )
         }
     }   // end func
 }

--- a/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
+++ b/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
@@ -136,6 +136,8 @@ public enum L10n {
         public static let editPost = L10n.tr("Localizable", "Common.Controls.Actions.EditPost", fallback: "Edit")
         /// Find people to follow
         public static let findPeople = L10n.tr("Localizable", "Common.Controls.Actions.FindPeople", fallback: "Find people to follow")
+        /// Manage Author…
+        public static let manageAuthor = L10n.tr("Localizable", "Common.Controls.Actions.ManageAuthor", fallback: "Manage Author…")
         /// Manually search instead
         public static let manuallySearch = L10n.tr("Localizable", "Common.Controls.Actions.ManuallySearch", fallback: "Manually search instead")
         /// Next

--- a/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
+++ b/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
@@ -41,6 +41,7 @@ Please check your internet connection.";
 "Common.Controls.Actions.Done" = "Done";
 "Common.Controls.Actions.Edit" = "Edit";
 "Common.Controls.Actions.FindPeople" = "Find people to follow";
+"Common.Controls.Actions.ManageAuthor" = "Manage Author…";
 "Common.Controls.Actions.ManuallySearch" = "Manually search instead";
 "Common.Controls.Actions.Next" = "Next";
 "Common.Controls.Actions.Ok" = "OK";

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusAuthorView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusAuthorView.swift
@@ -157,20 +157,21 @@ extension StatusAuthorView {
     }
 
     public func setupAuthorMenu(menuContext: AuthorMenuContext) -> (UIMenu, [UIAccessibilityCustomAction]) {
-        var actions = [MastodonMenu.Action]()
+        var statusActions = [MastodonMenu.Action]()
+        var userActions = [MastodonMenu.Action]()
 
         if menuContext.isMyself {
-            actions.append(.editStatus)
+            statusActions.append(.editStatus)
         }
 
         if !menuContext.isMyself {
             if let statusLanguage = menuContext.statusLanguage, menuContext.isTranslationEnabled, !menuContext.isTranslated {
-                actions.append(
+                statusActions.append(
                     .translateStatus(.init(language: statusLanguage))
                 )
             }
             
-            actions.append(contentsOf: [
+            userActions.append(contentsOf: [
                 .muteUser(.init(
                     name: menuContext.name,
                     isMuting: menuContext.isMuting
@@ -185,7 +186,7 @@ extension StatusAuthorView {
             ])
         }
         
-        actions.append(contentsOf: [
+        statusActions.append(contentsOf: [
             .bookmarkStatus(
                 .init(isBookmarking: menuContext.isBookmarking)
             ),
@@ -193,17 +194,23 @@ extension StatusAuthorView {
         ])
 
         if menuContext.isMyself {
-            actions.append(.deleteStatus)
+            statusActions.append(.deleteStatus)
         }
 
 
-        let menu = MastodonMenu.setupMenu(
-            actions: actions,
-            delegate: self.statusView!
-        )
+        let menu = UIMenu(children: [
+            MastodonMenu.setupMenu(
+                actions: statusActions,
+                delegate: self.statusView!
+            ),
+            userActions.isEmpty ? nil : MastodonMenu.setupMenu(
+                actions: userActions,
+                delegate: self.statusView!
+            ),
+        ].compactMap { $0 })
 
         let accessibilityActions = MastodonMenu.setupAccessibilityActions(
-            actions: actions,
+            actions: statusActions + userActions,
             delegate: self.statusView!
         )
 

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusAuthorView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusAuthorView.swift
@@ -209,8 +209,21 @@ extension StatusAuthorView {
             ),
         ].compactMap { $0 })
 
+        let seeMoreActions: [MastodonMenu.Action]
+        if userActions.isEmpty {
+            seeMoreActions = []
+        } else {
+            seeMoreActions = [.showActionSheet(
+                title: L10n.Common.Controls.Actions.manageAuthor,
+                actions: MastodonMenu.setupAlertActions(
+                    actions: userActions,
+                    delegate: self.statusView!
+                )
+            )]
+        }
+
         let accessibilityActions = MastodonMenu.setupAccessibilityActions(
-            actions: statusActions + userActions,
+            actions: statusActions + seeMoreActions,
             delegate: self.statusView!
         )
 

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -709,6 +709,9 @@ extension StatusView.ViewModel {
             )
             let (menu, actions) = authorView.setupAuthorMenu(menuContext: menuContext)
             authorView.menuButton.menu = menu
+            if #available(iOS 16.0, *) {
+                authorView.menuButton.preferredMenuElementOrder = .priority
+            }
             authorView.authorActions = actions
             authorView.menuButton.showsMenuAsPrimaryAction = true
         }

--- a/MastodonSDK/Sources/MastodonUI/View/Menu/LabeledAction.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Menu/LabeledAction.swift
@@ -43,12 +43,18 @@ public struct LabeledAction {
             return true
         }
     }
+
+    public var alertAction: UIAlertAction {
+        UIAlertAction(title: title, style: attributes.contains(.destructive) ? .destructive : .default) { _ in
+            handler()
+        }
+    }
 }
 
 extension LabeledAction {
     public init(
         title: String,
-        asset: ImageAsset? = nil,
+        asset: ImageAsset?,
         attributes: UIMenuElement.Attributes = [],
         state: UIMenuElement.State = .off,
         handler: @escaping () -> Void

--- a/MastodonSDK/Sources/MastodonUI/View/Menu/MastodonMenu.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Menu/MastodonMenu.swift
@@ -30,7 +30,7 @@ public enum MastodonMenu {
             }
             children.append(element)
         }
-        return UIMenu(children: children)
+        return UIMenu(options: .displayInline, children: children)
     }
 
     public static func setupAccessibilityActions(

--- a/MastodonSDK/Sources/MastodonUI/View/Menu/MastodonMenu.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Menu/MastodonMenu.swift
@@ -44,6 +44,19 @@ public enum MastodonMenu {
         }
         return accessibilityActions
     }
+
+    public static func setupAlertActions(
+        actions: [Action],
+        delegate: MastodonMenuDelegate
+    ) -> [UIAlertAction] {
+        var alertActions: [UIAlertAction] = []
+        for action in actions {
+            let element = action.build(delegate: delegate)
+            alertActions.append(element.alertAction)
+        }
+        return alertActions
+
+    }
 }
 
 extension MastodonMenu {
@@ -58,7 +71,8 @@ extension MastodonMenu {
         case shareStatus
         case deleteStatus
         case editStatus
-        
+        case showActionSheet(title: String, actions: [UIAlertAction])
+
         func build(delegate: MastodonMenuDelegate) -> LabeledAction {
             switch self {
             case .hideReblogs(let context):
@@ -172,6 +186,12 @@ extension MastodonMenu {
                 }
 
                 return editStatusAction
+            case let .showActionSheet(title, _):
+                let showMoreAction = LabeledAction(title: title) { [weak delegate] in
+                    guard let delegate = delegate else { return }
+                    delegate.menuAction(self)
+                }
+                return showMoreAction
             }   // end switch
         }   // end func build
     }   // end enum Action


### PR DESCRIPTION
Since there have been more and more items added to the status menu recently, I’m proposing two changes to improve UX here.

First, I've added a separator between the post-specific actions (translate/bookmark/share/delete) and the user-specific ones (mute/block/report). When looking at your own post, the divider is hidden (since the user-specific actions are not available).

Secondly, for folks who use accessibility tools, the mute/block/report actions are moved to a “submenu” accessed by selecting the “Manage Author…” custom action (please help me come up with a better title for this) which opens an action sheet with those actions.

<img src=https://user-images.githubusercontent.com/25517624/208502847-ed08c4b9-0e11-4d93-9b75-3c5b632ccc58.png width=390><img src=https://user-images.githubusercontent.com/25517624/208503157-555db62e-5d37-4e2d-84b3-8927621105cb.png width=390>

<img src=https://user-images.githubusercontent.com/25517624/208504315-96633c4a-8283-4607-bbf7-4488db90a6fd.png width=390>
