### PR TITLE
Improve status accessibility

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -52,7 +52,10 @@ public final class StatusView: UIView {
     public weak var delegate: StatusViewDelegate?
     
     public private(set) var style: Style?
-    
+
+    // accessibility actions
+    var toolbarActions = [UIAccessibilityCustomAction]()
+
     public private(set) lazy var viewModel: ViewModel = {
         let viewModel = ViewModel()
         viewModel.bind(statusView: self)
@@ -613,6 +616,7 @@ extension StatusView {
     public override var accessibilityCustomActions: [UIAccessibilityCustomAction]? {
         get {
             (contentMetaText.textView.accessibilityCustomActions ?? [])
+            + toolbarActions
             + (authorView.accessibilityCustomActions ?? [])
         }
         set { }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -611,7 +611,10 @@ extension StatusView {
 
 extension StatusView {
     public override var accessibilityCustomActions: [UIAccessibilityCustomAction]? {
-        get { contentMetaText.textView.accessibilityCustomActions }
+        get {
+            (contentMetaText.textView.accessibilityCustomActions ?? [])
+            + (authorView.accessibilityCustomActions ?? [])
+        }
         set { }
     }
 }


### PR DESCRIPTION
See #378 and #309, Fixes #733!

Status views in threads/on the timeline now have actions for reply/reblog/favorite, and also adopt the actions from the post action menu.