### PR TITLE
Move `MastodonSDK` to dynamic framework

### DIFF
--- a/Mastodon.xcodeproj/project.pbxproj
+++ b/Mastodon.xcodeproj/project.pbxproj
@@ -3938,6 +3938,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "Mastodon/Resources/Preview\\ Assets.xcassets";
 				DEVELOPMENT_TEAM = 5Z4GVSS33P;
+				EXCLUDED_SOURCE_FILE_NAMES = "Mastodon/Resources/Preview\\ Assets.xcassets";
 				INFOPLIST_FILE = Mastodon/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Mastodon.xcodeproj/project.pbxproj
+++ b/Mastodon.xcodeproj/project.pbxproj
@@ -75,11 +75,11 @@
 		2DAC9E46262FC9FD0062E1A6 /* SuggestionAccountTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAC9E45262FC9FD0062E1A6 /* SuggestionAccountTableViewCell.swift */; };
 		2DCB73FD2615C13900EC03D4 /* SearchRecommendCollectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB73FC2615C13900EC03D4 /* SearchRecommendCollectionHeader.swift */; };
 		2DE0FACE2615F7AD00CDF649 /* RecommendAccountSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE0FACD2615F7AD00CDF649 /* RecommendAccountSection.swift */; };
-		357FEE8729522CA50021C9DC /* MastodonSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 357FEE8629522CA50021C9DC /* MastodonSDK */; };
-		357FEE8829522CA50021C9DC /* MastodonSDK in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 357FEE8629522CA50021C9DC /* MastodonSDK */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		357FEE8A29522CB60021C9DC /* MastodonSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 357FEE8929522CB60021C9DC /* MastodonSDK */; };
-		357FEE8E29522CC00021C9DC /* MastodonSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 357FEE8D29522CC00021C9DC /* MastodonSDK */; };
-		357FEE9229522CE60021C9DC /* MastodonSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 357FEE9129522CE60021C9DC /* MastodonSDK */; };
+		357FEEAF29523D470021C9DC /* MastodonSDKDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 357FEEAE29523D470021C9DC /* MastodonSDKDynamic */; };
+		357FEEB029523D470021C9DC /* MastodonSDKDynamic in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 357FEEAE29523D470021C9DC /* MastodonSDKDynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		357FEEB229523D510021C9DC /* MastodonSDKDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 357FEEB129523D510021C9DC /* MastodonSDKDynamic */; };
+		357FEEB629523D5C0021C9DC /* MastodonSDKDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 357FEEB529523D5C0021C9DC /* MastodonSDKDynamic */; };
+		357FEEBA29523D660021C9DC /* MastodonSDKDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 357FEEB929523D660021C9DC /* MastodonSDKDynamic */; };
 		5B24BBDA262DB14800A9381B /* ReportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B24BBD7262DB14800A9381B /* ReportViewModel.swift */; };
 		5B24BBDB262DB14800A9381B /* ReportStatusViewModel+Diffable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B24BBD8262DB14800A9381B /* ReportStatusViewModel+Diffable.swift */; };
 		5B90C45E262599800002E742 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B90C456262599800002E742 /* SettingsViewModel.swift */; };
@@ -493,7 +493,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				357FEE8829522CA50021C9DC /* MastodonSDK in Embed Frameworks */,
+				357FEEB029523D470021C9DC /* MastodonSDKDynamic in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1087,7 +1087,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				357FEE8729522CA50021C9DC /* MastodonSDK in Frameworks */,
+				357FEEAF29523D470021C9DC /* MastodonSDKDynamic in Frameworks */,
 				DBF96326262EC0A6001D8D25 /* AuthenticationServices.framework in Frameworks */,
 				87FFDA5D898A5C42ADCB35E7 /* Pods_Mastodon.framework in Frameworks */,
 			);
@@ -1114,7 +1114,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				357FEE9229522CE60021C9DC /* MastodonSDK in Frameworks */,
+				357FEEBA29523D660021C9DC /* MastodonSDKDynamic in Frameworks */,
 				DB8FABC726AEC7B2008E5AF4 /* Intents.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1123,7 +1123,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				357FEE8E29522CC00021C9DC /* MastodonSDK in Frameworks */,
+				357FEEB629523D5C0021C9DC /* MastodonSDKDynamic in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1131,7 +1131,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				357FEE8A29522CB60021C9DC /* MastodonSDK in Frameworks */,
+				357FEEB229523D510021C9DC /* MastodonSDKDynamic in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2757,7 +2757,7 @@
 			);
 			name = Mastodon;
 			packageProductDependencies = (
-				357FEE8629522CA50021C9DC /* MastodonSDK */,
+				357FEEAE29523D470021C9DC /* MastodonSDKDynamic */,
 			);
 			productName = Mastodon;
 			productReference = DB427DD225BAA00100D1B89D /* Mastodon.app */;
@@ -2816,7 +2816,7 @@
 			);
 			name = MastodonIntent;
 			packageProductDependencies = (
-				357FEE9129522CE60021C9DC /* MastodonSDK */,
+				357FEEB929523D660021C9DC /* MastodonSDKDynamic */,
 			);
 			productName = MastodonIntent;
 			productReference = DB8FABC626AEC7B2008E5AF4 /* MastodonIntent.appex */;
@@ -2836,7 +2836,7 @@
 			);
 			name = ShareActionExtension;
 			packageProductDependencies = (
-				357FEE8D29522CC00021C9DC /* MastodonSDK */,
+				357FEEB529523D5C0021C9DC /* MastodonSDKDynamic */,
 			);
 			productName = ShareActionExtension;
 			productReference = DBC6461226A170AB00B0E31B /* ShareActionExtension.appex */;
@@ -2856,7 +2856,7 @@
 			);
 			name = NotificationService;
 			packageProductDependencies = (
-				357FEE8929522CB60021C9DC /* MastodonSDK */,
+				357FEEB129523D510021C9DC /* MastodonSDKDynamic */,
 			);
 			productName = NotificationService;
 			productReference = DBF8AE13263293E400C9C23C /* NotificationService.appex */;
@@ -4644,21 +4644,21 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		357FEE8629522CA50021C9DC /* MastodonSDK */ = {
+		357FEEAE29523D470021C9DC /* MastodonSDKDynamic */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = MastodonSDK;
+			productName = MastodonSDKDynamic;
 		};
-		357FEE8929522CB60021C9DC /* MastodonSDK */ = {
+		357FEEB129523D510021C9DC /* MastodonSDKDynamic */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = MastodonSDK;
+			productName = MastodonSDKDynamic;
 		};
-		357FEE8D29522CC00021C9DC /* MastodonSDK */ = {
+		357FEEB529523D5C0021C9DC /* MastodonSDKDynamic */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = MastodonSDK;
+			productName = MastodonSDKDynamic;
 		};
-		357FEE9129522CE60021C9DC /* MastodonSDK */ = {
+		357FEEB929523D660021C9DC /* MastodonSDKDynamic */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = MastodonSDK;
+			productName = MastodonSDKDynamic;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Mastodon.xcodeproj/project.pbxproj
+++ b/Mastodon.xcodeproj/project.pbxproj
@@ -75,6 +75,11 @@
 		2DAC9E46262FC9FD0062E1A6 /* SuggestionAccountTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAC9E45262FC9FD0062E1A6 /* SuggestionAccountTableViewCell.swift */; };
 		2DCB73FD2615C13900EC03D4 /* SearchRecommendCollectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB73FC2615C13900EC03D4 /* SearchRecommendCollectionHeader.swift */; };
 		2DE0FACE2615F7AD00CDF649 /* RecommendAccountSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE0FACD2615F7AD00CDF649 /* RecommendAccountSection.swift */; };
+		357FEE8729522CA50021C9DC /* MastodonSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 357FEE8629522CA50021C9DC /* MastodonSDK */; };
+		357FEE8829522CA50021C9DC /* MastodonSDK in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 357FEE8629522CA50021C9DC /* MastodonSDK */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		357FEE8A29522CB60021C9DC /* MastodonSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 357FEE8929522CB60021C9DC /* MastodonSDK */; };
+		357FEE8E29522CC00021C9DC /* MastodonSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 357FEE8D29522CC00021C9DC /* MastodonSDK */; };
+		357FEE9229522CE60021C9DC /* MastodonSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 357FEE9129522CE60021C9DC /* MastodonSDK */; };
 		5B24BBDA262DB14800A9381B /* ReportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B24BBD7262DB14800A9381B /* ReportViewModel.swift */; };
 		5B24BBDB262DB14800A9381B /* ReportStatusViewModel+Diffable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B24BBD8262DB14800A9381B /* ReportStatusViewModel+Diffable.swift */; };
 		5B90C45E262599800002E742 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B90C456262599800002E742 /* SettingsViewModel.swift */; };
@@ -169,10 +174,6 @@
 		DB1FD44425F26CCC004CFCFC /* PickServerSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1FD44325F26CCC004CFCFC /* PickServerSection.swift */; };
 		DB1FD45025F26FA1004CFCFC /* MastodonPickServerViewModel+Diffable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1FD44F25F26FA1004CFCFC /* MastodonPickServerViewModel+Diffable.swift */; };
 		DB1FD45A25F27898004CFCFC /* CategoryPickerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1FD45925F27898004CFCFC /* CategoryPickerItem.swift */; };
-		DB22C92228E700A10082A9E9 /* MastodonSDK in Frameworks */ = {isa = PBXBuildFile; productRef = DB22C92128E700A10082A9E9 /* MastodonSDK */; };
-		DB22C92428E700A80082A9E9 /* MastodonSDK in Frameworks */ = {isa = PBXBuildFile; productRef = DB22C92328E700A80082A9E9 /* MastodonSDK */; };
-		DB22C92628E700AF0082A9E9 /* MastodonSDK in Frameworks */ = {isa = PBXBuildFile; productRef = DB22C92528E700AF0082A9E9 /* MastodonSDK */; };
-		DB22C92828E700B70082A9E9 /* MastodonSDK in Frameworks */ = {isa = PBXBuildFile; productRef = DB22C92728E700B70082A9E9 /* MastodonSDK */; };
 		DB2B3ABC25E37E15007045F9 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = DB2B3ABE25E37E15007045F9 /* InfoPlist.strings */; };
 		DB2F073525E8ECF000957B2D /* AuthenticationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2F073325E8ECF000957B2D /* AuthenticationViewModel.swift */; };
 		DB2FF510260B113300ADA9FE /* ComposeStatusPollExpiresOptionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2FF50F260B113300ADA9FE /* ComposeStatusPollExpiresOptionCollectionViewCell.swift */; };
@@ -492,6 +493,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				357FEE8829522CA50021C9DC /* MastodonSDK in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1085,7 +1087,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DB22C92428E700A80082A9E9 /* MastodonSDK in Frameworks */,
+				357FEE8729522CA50021C9DC /* MastodonSDK in Frameworks */,
 				DBF96326262EC0A6001D8D25 /* AuthenticationServices.framework in Frameworks */,
 				87FFDA5D898A5C42ADCB35E7 /* Pods_Mastodon.framework in Frameworks */,
 			);
@@ -1112,7 +1114,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DB22C92828E700B70082A9E9 /* MastodonSDK in Frameworks */,
+				357FEE9229522CE60021C9DC /* MastodonSDK in Frameworks */,
 				DB8FABC726AEC7B2008E5AF4 /* Intents.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1121,7 +1123,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DB22C92628E700AF0082A9E9 /* MastodonSDK in Frameworks */,
+				357FEE8E29522CC00021C9DC /* MastodonSDK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1129,7 +1131,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DB22C92228E700A10082A9E9 /* MastodonSDK in Frameworks */,
+				357FEE8A29522CB60021C9DC /* MastodonSDK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2755,7 +2757,7 @@
 			);
 			name = Mastodon;
 			packageProductDependencies = (
-				DB22C92328E700A80082A9E9 /* MastodonSDK */,
+				357FEE8629522CA50021C9DC /* MastodonSDK */,
 			);
 			productName = Mastodon;
 			productReference = DB427DD225BAA00100D1B89D /* Mastodon.app */;
@@ -2814,7 +2816,7 @@
 			);
 			name = MastodonIntent;
 			packageProductDependencies = (
-				DB22C92728E700B70082A9E9 /* MastodonSDK */,
+				357FEE9129522CE60021C9DC /* MastodonSDK */,
 			);
 			productName = MastodonIntent;
 			productReference = DB8FABC626AEC7B2008E5AF4 /* MastodonIntent.appex */;
@@ -2834,7 +2836,7 @@
 			);
 			name = ShareActionExtension;
 			packageProductDependencies = (
-				DB22C92528E700AF0082A9E9 /* MastodonSDK */,
+				357FEE8D29522CC00021C9DC /* MastodonSDK */,
 			);
 			productName = ShareActionExtension;
 			productReference = DBC6461226A170AB00B0E31B /* ShareActionExtension.appex */;
@@ -2854,7 +2856,7 @@
 			);
 			name = NotificationService;
 			packageProductDependencies = (
-				DB22C92128E700A10082A9E9 /* MastodonSDK */,
+				357FEE8929522CB60021C9DC /* MastodonSDK */,
 			);
 			productName = NotificationService;
 			productReference = DBF8AE13263293E400C9C23C /* NotificationService.appex */;
@@ -4642,19 +4644,19 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		DB22C92128E700A10082A9E9 /* MastodonSDK */ = {
+		357FEE8629522CA50021C9DC /* MastodonSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MastodonSDK;
 		};
-		DB22C92328E700A80082A9E9 /* MastodonSDK */ = {
+		357FEE8929522CB60021C9DC /* MastodonSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MastodonSDK;
 		};
-		DB22C92528E700AF0082A9E9 /* MastodonSDK */ = {
+		357FEE8D29522CC00021C9DC /* MastodonSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MastodonSDK;
 		};
-		DB22C92728E700B70082A9E9 /* MastodonSDK */ = {
+		357FEE9129522CE60021C9DC /* MastodonSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MastodonSDK;
 		};

--- a/MastodonSDK/Package.swift
+++ b/MastodonSDK/Package.swift
@@ -3,6 +3,17 @@
 
 import PackageDescription
 
+let publicLibraryTargets = [
+    "CoreDataStack",
+    "MastodonAsset",
+    "MastodonCommon",
+    "MastodonCore",
+    "MastodonExtension",
+    "MastodonLocalization",
+    "MastodonSDK",
+    "MastodonUI",
+]
+
 let package = Package(
     name: "MastodonSDK",
     defaultLocalization: "en",
@@ -10,19 +21,16 @@ let package = Package(
         .iOS(.v14),
     ],
     products: [
+        // Static Library
         .library(
             name: "MastodonSDK",
+            targets: publicLibraryTargets
+        ),
+        // Dynamic Library
+        .library(
+            name: "MastodonSDKDynamic",
             type: .dynamic,
-            targets: [
-                "CoreDataStack",
-                "MastodonAsset",
-                "MastodonCommon",
-                "MastodonCore",
-                "MastodonExtension",
-                "MastodonLocalization",
-                "MastodonSDK",
-                "MastodonUI",
-            ]
+            targets: publicLibraryTargets
         )
     ],
     dependencies: [

--- a/MastodonSDK/Package.swift
+++ b/MastodonSDK/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
     products: [
         .library(
             name: "MastodonSDK",
+            type: .dynamic,
             targets: [
                 "CoreDataStack",
                 "MastodonAsset",
@@ -21,7 +22,8 @@ let package = Package(
                 "MastodonLocalization",
                 "MastodonSDK",
                 "MastodonUI",
-            ])
+            ]
+        )
     ],
     dependencies: [
         .package(name: "ArkanaKeys", path: "../dependencies/ArkanaKeys"),


### PR DESCRIPTION
RE: https://twitter.com/emergetools/status/1604934684869201920

## Summary

In order to reduce Mastodon application size, switch to a dynamic framework packaging of the `MastodonSDK` in order to reduce code duplication between the iOS application and the extensions. This transition means the iOS extensions just link the `MastodonSDK` present in `Mastodon.app/Frameworks/MastodonSDK.framework` instead of within each `.appex` bundle.

There's still duplication in the:

- `MastodonSDK_CoreDataStack.bundle`s
- `MastodonSDK_MastodonAsset.bundle`s
- `MastodonSDK_MastodonLocalization.bundle`s

Simplistically, (no archive or anything, just a simple build in the config for simulator) this goes from:

|Config|Before|After|
|---|---|---|
|Debug|<img width="377" alt="Screenshot 2022-12-19 at 9 12 08 PM" src="https://user-images.githubusercontent.com/5728070/208579751-ec29e2ad-9a42-40a2-a0cb-c5f8e541b498.png">|<img width="377" alt="Screenshot 2022-12-19 at 9 39 13 PM" src="https://user-images.githubusercontent.com/5728070/208579769-1d14070e-80de-44e2-baec-c7274e148201.png">|
|Release|<img width="377" alt="Screenshot 2022-12-19 at 10 03 20 PM" src="https://user-images.githubusercontent.com/5728070/208581117-497b5ba0-6ec4-4c8a-8fd7-aaee0e1e2c05.png">|<img width="377" alt="Screenshot 2022-12-19 at 10 00 29 PM" src="https://user-images.githubusercontent.com/5728070/208581121-2d9d8450-6557-48f3-8ab0-953a7072a87f.png">|

## Package Changes

Add `MastodonSDKDynamic` (dynamic linkage) to use internally/external while leaving `MastodonSDK` (static) so consumers of the library don't have to change any references.