### PR TITLE
Prevent reblogging DMs

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -160,12 +160,10 @@ extension StatusView {
                 $isMyself
             )
             .map { visibility, isMyself in
-                if isMyself {
-                    return true
-                }
-                
                 switch visibility {
                 case .public, .unlisted:
+                    return true
+                case .private where isMyself:
                     return true
                 case .private, .direct, ._other:
                     return false

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -161,11 +161,11 @@ extension StatusView {
             )
             .map { visibility, isMyself in
                 switch visibility {
-                case .public, .unlisted:
+                case .public, .unlisted, ._other:
                     return true
                 case .private where isMyself:
                     return true
-                case .private, .direct, ._other:
+                case .private, .direct:
                     return false
                 }
             }


### PR DESCRIPTION
I noticed that I was able to tap the reblog button on direct posts, but the request failed and reset the reblog counter back to 0. This PR replicates the logic of the web frontend: [line 1](https://github.com/mastodon/mastodon/blob/de21695162d9600ae4e0a7ae54d62254b87ae460/app/javascript/mastodon/components/status_action_bar.js#L332) [line 2](https://github.com/mastodon/mastodon/blob/de21695162d9600ae4e0a7ae54d62254b87ae460/app/javascript/mastodon/components/status_action_bar.js#L356)