### PR TITLE
Accept missing metadata on attachments

### DIFF
--- a/MastodonSDK/Sources/MastodonCore/Extension/CoreDataStack/Status+Property.swift
+++ b/MastodonSDK/Sources/MastodonCore/Extension/CoreDataStack/Status+Property.swift
@@ -51,14 +51,28 @@ extension Mastodon.Entity.Status {
         guard let mediaAttachments = mediaAttachments else { return [] }
         
         let attachments = mediaAttachments.compactMap { media -> MastodonAttachment? in
-            guard let kind = media.attachmentKind,
-                  let meta = media.meta,
-                  let original = meta.original,
-                  let width = original.width,       // audio has width/height
-                  let height = original.height
+            guard let kind = media.attachmentKind
             else { return nil }
-            
-            let durationMS: Int? = original.duration.flatMap { Int($0 * 1000) }
+
+            let width: Int;
+            let height: Int;
+            let durationMS: Int?;
+
+            if let meta = media.meta,
+               let original = meta.original,
+               let originalWidth = original.width,
+               let originalHeight = original.height {
+                width = originalWidth;              // audio has width/height
+                height = originalHeight;
+                durationMS = original.duration.flatMap { Int($0 * 1000) }
+            }
+            else {
+                // In case metadata field is missing, use default values.
+                width = 32;
+                height = 32;
+                durationMS = nil;
+            }
+
             return MastodonAttachment(
                 id: media.id,
                 kind: kind,

--- a/MastodonSDK/Sources/MastodonCore/Extension/CoreDataStack/Status+Property.swift
+++ b/MastodonSDK/Sources/MastodonCore/Extension/CoreDataStack/Status+Property.swift
@@ -62,9 +62,9 @@ extension Mastodon.Entity.Status {
                let original = meta.original,
                let originalWidth = original.width,
                let originalHeight = original.height {
-                width = originalWidth;              // audio has width/height
-                height = originalHeight;
-                durationMS = original.duration.flatMap { Int($0 * 1000) }
+                width = originalWidth               // audio has width/height
+                height = originalHeight
+                durationMS = original.duration.map { Int($0 * 1000) }
             }
             else {
                 // In case metadata field is missing, use default values.


### PR DESCRIPTION
Akkoma/Pleroma (and Friendica until recently) aren't providing attachment meta information like width or height.

Because Mastodon app enforced those fields to be present, attachments would end up being filtered out.

This PR changes the behaviour of Mastodon.Entity.Status.mastodonAttachments by allowing those values to be missing and use default values instead.

Close #470

Before vs after:
<img width="612" alt="Screenshot 2022-12-21 at 22 56 02" src="https://user-images.githubusercontent.com/1760003/209012865-4335118a-60e7-46c5-ac18-bf6f142d127b.png">
<img width="612" alt="Screenshot 2022-12-21 at 22 56 53" src="https://user-images.githubusercontent.com/1760003/209012879-6fea7ca0-af07-4070-91f9-d899f9536401.png">
