### PR TITLE
Do not show deleted status on Explore tab

### DIFF
--- a/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Block.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Block.swift
@@ -152,12 +152,7 @@ extension APIService {
 
 extension MastodonUser {
     func deleteStatusAndNotificationFeeds(in context: NSManagedObjectContext) {
-        statuses.map {
-            $0.feeds
-                .union($0.reblogFrom.map { $0.feeds }.flatMap { $0 })
-                .union($0.notifications.map { $0.feeds }.flatMap { $0 })
-        }
-        .flatMap { $0 }
+        statuses    
         .forEach(context.delete)
         
         notifications.map {


### PR DESCRIPTION
Resolves #731 
The current the behavior of `MastodonUser.deleteStatusAndNotificationFeeds()` deletes only feeds associated with a user. I changed it so it deletes statuses entirely.