### PR TITLE
Replace a deprecated constant

### DIFF
--- a/MastodonSDK/Sources/MastodonCore/Extension/NSItemProvider.swift
+++ b/MastodonSDK/Sources/MastodonCore/Extension/NSItemProvider.swift
@@ -65,7 +65,7 @@ extension NSItemProvider {
                 }
                 
                 let data = NSMutableData()
-                guard let imageDestination = CGImageDestinationCreateWithData(data, kUTTypeJPEG, 1, nil) else {
+                guard let imageDestination = CGImageDestinationCreateWithData(data, UTType.jpeg.identifier as CFString, 1, nil) else {
                     continuation.resume(with: .success(nil))
                     assertionFailure()
                     return


### PR DESCRIPTION
Hi,

This PR replaces the deprecated `kUTTypeJPEG` constant to resolve the following compiler warning:

```
'kUTTypeJPEG' was deprecated in iOS 15.0: Use UTTypeJPEG instead.
```