### PR TITLE
Allow AltViewController text to scroll + increase HUDButton contrast

### DIFF
--- a/Mastodon/Scene/MediaPreview/AltViewController.swift
+++ b/Mastodon/Scene/MediaPreview/AltViewController.swift
@@ -9,7 +9,14 @@ import SwiftUI
 
 class AltViewController: UIViewController {
     private var alt: String
-    let label = UITextView()
+    let label = {
+        if #available(iOS 16, *) {
+            // TODO: update code below to use TextKit 2 when dropping iOS 15 support
+            return UITextView(usingTextLayoutManager: false)
+        } else {
+            return UITextView()
+        }
+    }()
 
     init(alt: String, sourceView: UIView?) {
         self.alt = alt
@@ -49,7 +56,8 @@ class AltViewController: UIViewController {
         label.isEditable = false
         label.tintColor = .white
         label.text = alt
-        label.textContainerInset = UIEdgeInsets(horizontal: 8, vertical: 16)
+        label.textContainerInset = UIEdgeInsets(top: 12, left: 8, bottom: 8, right: 8)
+        label.contentInsetAdjustmentBehavior = .always
         label.verticalScrollIndicatorInsets.bottom = 4
 
         view.backgroundColor = .systemBackground
@@ -64,9 +72,10 @@ class AltViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         UIView.performWithoutAnimation {
+            let size = label.layoutManager.boundingRect(forGlyphRange: NSMakeRange(0, (label.textStorage.string as NSString).length), in: label.textContainer).size
             preferredContentSize = CGSize(
-                width: label.contentSize.width + 16,
-                height: label.contentSize.height + view.layoutMargins.top + view.layoutMargins.bottom
+                width: size.width + (8 + label.textContainer.lineFragmentPadding) * 2,
+                height: size.height + 12 + (label.textContainer.lineFragmentPadding * 2)
             )
         }
     }

--- a/Mastodon/Scene/MediaPreview/AltViewController.swift
+++ b/Mastodon/Scene/MediaPreview/AltViewController.swift
@@ -24,6 +24,11 @@ class AltViewController: UIViewController {
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    override func loadView() {
+        super.loadView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -38,22 +43,16 @@ class AltViewController: UIViewController {
             right: 0
         )
         label.font = .preferredFont(forTextStyle: .callout)
-        label.isScrollEnabled = false
+        label.isScrollEnabled = true
         label.backgroundColor = .clear
         label.isOpaque = false
         label.isEditable = false
         label.tintColor = .white
         label.text = alt
 
-        view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(label)
 
-        NSLayoutConstraint.activate(
-            NSLayoutConstraint.constraints(withVisualFormat: "V:|-[label]-|", metrics: nil, views: ["label": label])
-        )
-        NSLayoutConstraint.activate(
-            NSLayoutConstraint.constraints(withVisualFormat: "H:|-(8)-[label]-(8)-|", metrics: nil, views: ["label": label])
-        )
+        label.pinToParent(padding: UIEdgeInsets(horizontal: 8, vertical: 0))
         NSLayoutConstraint.activate([
             label.widthAnchor.constraint(lessThanOrEqualToConstant: 400),
         ])
@@ -63,8 +62,8 @@ class AltViewController: UIViewController {
         super.viewDidLayoutSubviews()
         UIView.performWithoutAnimation {
             preferredContentSize = CGSize(
-                width: label.intrinsicContentSize.width + 16,
-                height: label.intrinsicContentSize.height + view.layoutMargins.top + view.layoutMargins.bottom
+                width: label.contentSize.width + 16,
+                height: label.contentSize.height + view.layoutMargins.top + view.layoutMargins.bottom
             )
         }
     }

--- a/Mastodon/Scene/MediaPreview/AltViewController.swift
+++ b/Mastodon/Scene/MediaPreview/AltViewController.swift
@@ -49,10 +49,13 @@ class AltViewController: UIViewController {
         label.isEditable = false
         label.tintColor = .white
         label.text = alt
+        label.textContainerInset = UIEdgeInsets(horizontal: 8, vertical: 16)
+        label.verticalScrollIndicatorInsets.bottom = 4
 
+        view.backgroundColor = .systemBackground
         view.addSubview(label)
 
-        label.pinToParent(padding: UIEdgeInsets(horizontal: 8, vertical: 0))
+        label.pinToParent()
         NSLayoutConstraint.activate([
             label.widthAnchor.constraint(lessThanOrEqualToConstant: 400),
         ])

--- a/Mastodon/Scene/MediaPreview/AltViewController.swift
+++ b/Mastodon/Scene/MediaPreview/AltViewController.swift
@@ -79,6 +79,11 @@ class AltViewController: UIViewController {
             )
         }
     }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        label.font = .preferredFont(forTextStyle: .callout)
+    }
 }
 
 // MARK: UIPopoverPresentationControllerDelegate

--- a/MastodonSDK/Sources/MastodonExtension/UIEdgeInsets.swift
+++ b/MastodonSDK/Sources/MastodonExtension/UIEdgeInsets.swift
@@ -8,6 +8,9 @@
 import UIKit
 
 extension UIEdgeInsets {
+    public init(horizontal: CGFloat, vertical: CGFloat) {
+        self.init(top: vertical, left: horizontal, bottom: vertical, right: horizontal)
+    }
     public static func constant(_ offset: CGFloat) -> Self {
         UIEdgeInsets(top: offset, left: offset, bottom: offset, right: offset)
     }

--- a/MastodonSDK/Sources/MastodonUI/View/Button/HUDButton.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Button/HUDButton.swift
@@ -12,18 +12,17 @@ public class HUDButton: UIView {
     public static let height: CGFloat = 30
 
     let background: UIVisualEffectView = {
-        let backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
-        backgroundView.alpha = 0.9
+        let backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .systemThinMaterial))
         backgroundView.layer.masksToBounds = true
         backgroundView.layer.cornerRadius = HUDButton.height * 0.5
         return backgroundView
     }()
 
-    let vibrancyView = UIVisualEffectView(effect: UIVibrancyEffect(blurEffect: UIBlurEffect(style: .systemUltraThinMaterial)))
+    let vibrancyView = UIVisualEffectView(effect: UIVibrancyEffect(blurEffect: UIBlurEffect(style: .systemThinMaterial)))
 
     public let button: UIButton = {
         let button = HighlightDimmableButton()
-        button.expandEdgeInsets = UIEdgeInsets(top: -10, left: -10, bottom: -10, right: -10)
+        button.expandEdgeInsets = .constant(-10)
         button.contentEdgeInsets = .constant(7)
         button.imageView?.tintColor = .label
         button.titleLabel?.font = UIFontMetrics(forTextStyle: .body).scaledFont(for: .systemFont(ofSize: 15, weight: .bold))

--- a/MastodonSDK/Sources/MastodonUI/View/Button/HUDButton.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Button/HUDButton.swift
@@ -12,13 +12,13 @@ public class HUDButton: UIView {
     public static let height: CGFloat = 30
 
     let background: UIVisualEffectView = {
-        let backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .systemThinMaterial))
+        let backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .systemMaterial))
         backgroundView.layer.masksToBounds = true
         backgroundView.layer.cornerRadius = HUDButton.height * 0.5
         return backgroundView
     }()
 
-    let vibrancyView = UIVisualEffectView(effect: UIVibrancyEffect(blurEffect: UIBlurEffect(style: .systemThinMaterial)))
+    let vibrancyView = UIVisualEffectView(effect: UIVibrancyEffect(blurEffect: UIBlurEffect(style: .systemMaterial)))
 
     public let button: UIButton = {
         let button = HighlightDimmableButton()


### PR DESCRIPTION
Fixes #806.

I’m not adding scrolling to the inline alt text viewer because:

- at larger text sizes you really can’t fit much text, especially if someone has posted >1 image, so users would need to scroll a lot
- IMO the primary action for swiping up/down on a feed/thread should be scrolling, and having a scrollable region inside of a post feels like it could be weird to me.
- I’m lazy :)

…but happy to add it if still desired