### PR TITLE
GIF improvements

### DIFF
--- a/Mastodon/Scene/MediaPreview/Video/MediaPreviewVideoViewModel.swift
+++ b/Mastodon/Scene/MediaPreview/Video/MediaPreviewVideoViewModel.swift
@@ -67,7 +67,9 @@ final class MediaPreviewVideoViewModel {
                 case .unknown, .buffering, .readyToPlay:
                     break
                 case .playing:
-                    try? AVAudioSession.sharedInstance().setCategory(.playback)
+                    if case .video = item {
+                        try? AVAudioSession.sharedInstance().setCategory(.playback)
+                    }
                     try? AVAudioSession.sharedInstance().setActive(true)
                 case .paused, .stopped, .failed:
                     try? AVAudioSession.sharedInstance().setCategory(.ambient)  // set to ambient to allow mixed (needed for GIFV)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -191,7 +191,19 @@ extension MediaView {
         playerViewController.showsPlaybackControls = false
         
         // auto play for GIF
-        player.play()
+        if !UIAccessibility.isReduceMotionEnabled {
+            player.play()
+        }
+        NotificationCenter.default
+            .publisher(for: UIAccessibility.reduceMotionStatusDidChangeNotification)
+            .sink { _ in
+                if UIAccessibility.isReduceMotionEnabled {
+                    player.pause()
+                } else {
+                    player.play()
+                }
+            }
+            .store(in: &_disposeBag)
 
         bindAlt(configuration: configuration, altDescription: info.altDescription)
     }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -333,6 +333,7 @@ extension MediaView {
         let playerItem = AVPlayerItem(url: url)
         let player = AVQueuePlayer(playerItem: playerItem)
         player.isMuted = true
+        player.preventsDisplaySleepDuringVideoPlayback = false
         return player
     }
     


### PR DESCRIPTION
- Music/podcasts are no longer temporarily paused when you tap to expand a GIF
- GIFs will no longer play in threads/timelines if the “Reduce Motion” setting is enabled.
  - Related: #396 (not calling it “fixed” since folks shouldn’t have to turn on Reduce Motion to stop GIFs)
  - Related: https://github.com/mastodon/mastodon/pull/22706
- Display sleep is no longer prevented when viewing a GIF in a thread/timeline (but it is still prevented when the media preview is expanded)
  - #545 still happens for some reason
  - happy to remove this commit since it doesn’t appear to work