### PR TITLE
Improve scrolling performance in threads

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/Extension/Task.swift
+++ b/MastodonSDK/Sources/MastodonUI/Extension/Task.swift
@@ -1,0 +1,14 @@
+//
+//  Task.swift
+//  
+//
+//  Created by Jed Fox on 2022-12-23.
+//
+
+import Combine
+
+extension Task {
+    func store(in set: inout Set<AnyCancellable>) {
+        set.insert(AnyCancellable(cancel))
+    }
+}

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
@@ -194,10 +194,16 @@ extension StatusView {
                     ))
                 }
             }
-            let header = self.createReplyHeader(name: user.displayNameWithFallback, emojis: user.emojis.asDictionary)
+            
             try Task.checkCancellation()
             await MainActor.run {
-                self.viewModel.header = header
+                Publishers.CombineLatest3(
+                    user.publisher(for: \.displayName),
+                    user.publisher(for: \.username),
+                    user.publisher(for: \.emojis)
+                ).receive(on: RunLoop.main).sink { [unowned self] _ in
+                    self.viewModel.header = self.createReplyHeader(name: user.displayNameWithFallback, emojis: user.emojis.asDictionary)
+                }.store(in: &self.disposeBag)
             }
         }.store(in: &disposeBag)
     }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
@@ -200,6 +200,7 @@ extension StatusView {
                 }
                 return nil
             }
+            try Task.checkCancellation()
             await MainActor.run {
                 if let header {
                     self.viewModel.header = header
@@ -207,7 +208,7 @@ extension StatusView {
                     self.fetchReplyToAccount(inReplyToAccountID)
                 }
             }
-        }
+        }.store(in: &disposeBag)
     }
     
     public func configureAuthor(author: MastodonUser) {

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
@@ -103,15 +103,16 @@ extension StatusView {
         name: String?,
         emojis: MastodonContent.Emojis?
     ) -> ViewModel.Header {
-        let fallbackMetaContent = PlaintextMetaContent(string: L10n.Common.Controls.Status.userRepliedTo("…"))
         guard let name = name,
               let emojis = emojis
         else {
-            return .reply(header: fallbackMetaContent)
+            let unknownUserMetaContent = PlaintextMetaContent(string: L10n.Common.Controls.Status.userRepliedTo("…"))
+            return .reply(header: unknownUserMetaContent)
         }
         
         let content = MastodonContent(content: L10n.Common.Controls.Status.userRepliedTo(name), emojis: emojis)
         guard let metaContent = try? MastodonMetaContent.convert(document: content) else {
+            let fallbackMetaContent = PlaintextMetaContent(string: L10n.Common.Controls.Status.userRepliedTo(name))
             return .reply(header: fallbackMetaContent)
         }
         return .reply(header: metaContent)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
@@ -99,8 +99,26 @@ extension StatusView {
 }
 
 extension StatusView {
+    private func createReplyHeader(
+        name: String?,
+        emojis: MastodonContent.Emojis?
+    ) -> ViewModel.Header {
+        let fallbackMetaContent = PlaintextMetaContent(string: L10n.Common.Controls.Status.userRepliedTo("…"))
+        guard let name = name,
+              let emojis = emojis
+        else {
+            return .reply(header: fallbackMetaContent)
+        }
+        
+        let content = MastodonContent(content: L10n.Common.Controls.Status.userRepliedTo(name), emojis: emojis)
+        guard let metaContent = try? MastodonMetaContent.convert(document: content) else {
+            return .reply(header: fallbackMetaContent)
+        }
+        return .reply(header: metaContent)
+    }
+
     private func configureHeader(status: Status) {
-        if let _ = status.reblog {
+        if status.reblog != nil {
             Publishers.CombineLatest(
                 status.author.publisher(for: \.displayName),
                 status.author.publisher(for: \.emojis)
@@ -110,82 +128,66 @@ extension StatusView {
                 let content = MastodonContent(content: text, emojis: emojis.asDictionary)
                 do {
                     let metaContent = try MastodonMetaContent.convert(document: content)
-                    return .repost(info: .init(header: metaContent))
+                    return .repost(header: metaContent)
                 } catch {
                     let metaContent = PlaintextMetaContent(string: name)
-                    return .repost(info: .init(header: metaContent))
+                    return .repost(header: metaContent)
                 }
                 
             }
             .assign(to: \.header, on: viewModel)
             .store(in: &disposeBag)
-        } else if let _ = status.inReplyToID,
-                  let inReplyToAccountID = status.inReplyToAccountID
-        {
-            func createHeader(
-                name: String?,
-                emojis: MastodonContent.Emojis?
-            ) -> ViewModel.Header {
-                let fallbackMetaContent = PlaintextMetaContent(string: L10n.Common.Controls.Status.userRepliedTo("-"))
-                let fallbackReplyHeader = ViewModel.Header.reply(info: .init(header: fallbackMetaContent))
-                guard let name = name,
-                      let emojis = emojis
-                else {
-                    return fallbackReplyHeader
-                }
-                
-                let content = MastodonContent(content: L10n.Common.Controls.Status.userRepliedTo(name), emojis: emojis)
-                guard let metaContent = try? MastodonMetaContent.convert(document: content) else {
-                    return fallbackReplyHeader
-                }
-                let header = ViewModel.Header.reply(info: .init(header: metaContent))
-                return header
-            }
+            return
+        }
 
-            if let replyTo = status.replyTo {
-                // A. replyTo status exist
-                let header = createHeader(name: replyTo.author.displayNameWithFallback, emojis: replyTo.author.emojis.asDictionary)
-                viewModel.header = header
-            } else {
-                // B. replyTo status not exist
-                
-                let request = MastodonUser.sortedFetchRequest
-                request.predicate = MastodonUser.predicate(domain: status.domain, id: inReplyToAccountID)
-                if let user = status.managedObjectContext?.safeFetch(request).first {
-                    // B1. replyTo user exist
-                    let header = createHeader(name: user.displayNameWithFallback, emojis: user.emojis.asDictionary)
-                    viewModel.header = header
-                } else {
-                    // B2. replyTo user not exist
-                    let header = createHeader(name: nil, emojis: nil)
-                    viewModel.header = header
-                    
-                    if let authenticationBox = viewModel.authContext?.mastodonAuthenticationBox {
-                        Just(inReplyToAccountID)
-                            .asyncMap { userID in
-                                return try await Mastodon.API.Account.accountInfo(
-                                    session: .shared,
-                                    domain: authenticationBox.domain,
-                                    userID: userID,
-                                    authorization: authenticationBox.userAuthorization
-                                ).singleOutput()
-                            }
-                            .receive(on: DispatchQueue.main)
-                            .sink { completion in
-                                // do nothing
-                            } receiveValue: { [weak self] response in
-                                guard let self = self else { return }
-                                let user = response.value
-                                let header = createHeader(name: user.displayNameWithFallback, emojis: user.emojiMeta)
-                                self.viewModel.header = header
-                            }
-                            .store(in: &disposeBag)
-                    }   // end if let
-                }   // end else B2.
-            }   // end else B.
-            
-        } else {
+        guard
+            status.inReplyToID != nil,
+            let inReplyToAccountID = status.inReplyToAccountID
+        else {
             viewModel.header = .none
+            return
+        }
+
+        if let replyTo = status.replyTo {
+            // A. replyTo status exist
+            let header = createReplyHeader(name: replyTo.author.displayNameWithFallback, emojis: replyTo.author.emojis.asDictionary)
+            viewModel.header = header
+            return
+        }
+
+        // B. replyTo status not exist
+        let request = MastodonUser.sortedFetchRequest
+        request.predicate = MastodonUser.predicate(domain: status.domain, id: inReplyToAccountID)
+        if let user = status.managedObjectContext?.safeFetch(request).first {
+            // B1. replyTo user exist
+            let header = createReplyHeader(name: user.displayNameWithFallback, emojis: user.emojis.asDictionary)
+            viewModel.header = header
+            return
+        }
+        // B2. replyTo user not exist
+        let header = createReplyHeader(name: nil, emojis: nil)
+        viewModel.header = header
+        
+        if let authenticationBox = viewModel.authContext?.mastodonAuthenticationBox {
+            Just(inReplyToAccountID)
+                .asyncMap { userID in
+                    return try await Mastodon.API.Account.accountInfo(
+                        session: .shared,
+                        domain: authenticationBox.domain,
+                        userID: userID,
+                        authorization: authenticationBox.userAuthorization
+                    ).singleOutput()
+                }
+                .receive(on: DispatchQueue.main)
+                .sink { completion in
+                    // do nothing
+                } receiveValue: { [weak self] response in
+                    guard let self = self else { return }
+                    let user = response.value
+                    let header = self.createReplyHeader(name: user.displayNameWithFallback, emojis: user.emojiMeta)
+                    self.viewModel.header = header
+                }
+                .store(in: &disposeBag)
         }
     }
     

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -121,25 +121,9 @@ extension StatusView {
         
         public enum Header {
             case none
-            case reply(info: ReplyInfo)
-            case repost(info: RepostInfo)
+            case reply(header: MetaContent)
+            case repost(header: MetaContent)
             // case notification(info: NotificationHeaderInfo)
-            
-            public class ReplyInfo {
-                public let header: MetaContent
-                
-                public init(header: MetaContent) {
-                    self.header = header
-                }
-            }
-            
-            public struct RepostInfo {
-                public let header: MetaContent
-                
-                public init(header: MetaContent) {
-                    self.header = header
-                }
-            }
         }
         
         public func prepareForReuse() {
@@ -216,14 +200,14 @@ extension StatusView.ViewModel {
                 switch header {
                 case .none:
                     return
-                case .repost(let info):
+                case .repost(let header):
                     statusView.headerIconImageView.image = Asset.Arrow.repeatSmall.image.withRenderingMode(.alwaysTemplate)
-                    statusView.headerInfoLabel.configure(content: info.header)
+                    statusView.headerInfoLabel.configure(content: header)
                     statusView.setHeaderDisplay()
-                case .reply(let info):
+                case .reply(let header):
                     assert(Thread.isMainThread)
                     statusView.headerIconImageView.image = UIImage(systemName: "arrowshape.turn.up.left.fill")
-                    statusView.headerInfoLabel.configure(content: info.header)
+                    statusView.headerInfoLabel.configure(content: header)
                     statusView.setHeaderDisplay()
                 }
             }
@@ -740,12 +724,12 @@ extension StatusView.ViewModel {
             case .none:
                 strings.append(authorName?.string)
                 strings.append(authorUsername)
-            case .reply(let info):
+            case .reply(let header):
                 strings.append(authorName?.string)
                 strings.append(authorUsername)
-                strings.append(info.header.string)
-            case .repost(let info):
-                strings.append(info.header.string)
+                strings.append(header.string)
+            case .repost(let header):
+                strings.append(header.string)
                 strings.append(authorName?.string)
                 strings.append(authorUsername)
             }
@@ -784,10 +768,10 @@ extension StatusView.ViewModel {
             switch header {
             case .none:
                 return "\(nameAndUsername), \(timestamp)"
-            case .repost(info: let info):
-                return "\(info.header.string) \(nameAndUsername), \(timestamp)"
-            case .reply(info: let info):
-                return "\(nameAndUsername) \(info.header.string), \(timestamp)"
+            case .repost(let header):
+                return "\(header.string) \(nameAndUsername), \(timestamp)"
+            case .reply(let header):
+                return "\(nameAndUsername) \(header.string), \(timestamp)"
             }
         }
         .assign(to: \.accessibilityLabel, on: statusView.authorView)


### PR DESCRIPTION
I profiled using Instruments and the largest cause of hitches appeared to be the synchronous call to `status.managedObjectContext?.safeFetch` to get the info for the user being replied to. I was able to move this to a background thread. I also took the opportunity to split out the functionality here to reduce nesting and hopefully make it easier to understand for folks making updates into the future.

The one negative consequence is that now when you scroll rapidly through a thread you’ll briefly see “Replied to …” for a fraction of a second before the username is loaded.

probably closes #150 (although that issue is very old, I wasn’t able to find any other scrolling hangs on my 13 Pro)