### PR TITLE
Wipe the web view when preparing the status view for reuse

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
@@ -245,6 +245,14 @@ public final class StatusCardControl: UIControl {
         }
         set {}
     }
+
+    public func prepareForReuse() {
+        if let webView {
+            // wipe out current page contents
+            webView.load(URLRequest(url: URL(string: "about:blank")!))
+            webView.removeFromSuperview()
+        }
+    }
 }
 
 // MARK: WKWebView delegates

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -326,6 +326,7 @@ public final class StatusView: UIView {
         setPollDisplay(isDisplay: false)
         setFilterHintLabelDisplay(isDisplay: false)
         setStatusCardControlDisplay(isDisplay: false)
+        statusCardControl.prepareForReuse()
     }
 
     public override init(frame: CGRect) {


### PR DESCRIPTION
Should fix #826, although it seems like the cell may not be removed from the view hierarchy once you start playing media in it. But now at least when the cell is reused it will clean up the web view’s content and remove it from the view hierarchy.