### PR TITLE
feat: Implement abbreviated status counts

### DIFF
--- a/Mastodon/Diffable/Onboarding/PickServerSection.swift
+++ b/Mastodon/Diffable/Onboarding/PickServerSection.swift
@@ -77,7 +77,7 @@ extension PickServerSection {
             let paragraphStyle = NSMutableParagraphStyle()
             paragraphStyle.lineHeightMultiple = 1.12
             let valueAttributedString = NSAttributedString(
-                string: parseUsersCount(server.totalUsers),
+                string: server.totalUsers.asAbbreviatedCountString(),
                 attributes: [
                     .paragraphStyle: paragraphStyle
                 ]
@@ -125,17 +125,6 @@ extension PickServerSection {
             }
             .store(in: &cell.disposeBag)
     }
-    
-    private static func parseUsersCount(_ usersCount: Int) -> String {
-        switch usersCount {
-        case 0..<1000:
-            return "\(usersCount)"
-        default:
-            let usersCountInThousand = Float(usersCount) / 1000.0
-            return String(format: "%.1fK", usersCountInThousand)
-        }
-    }
-    
 }
 
 extension PickServerSection {

--- a/MastodonSDK/Sources/MastodonExtension/Int.swift
+++ b/MastodonSDK/Sources/MastodonExtension/Int.swift
@@ -1,0 +1,31 @@
+//
+//  Int.swift
+//  
+//
+//  Created by Marcus Kida on 28.12.22.
+//
+
+import Foundation
+
+public extension Int {
+    func asAbbreviatedCountString() -> String {
+        switch self {
+        case ..<1_000:
+            return String(format: "%d", locale: Locale.current, self)
+        case 1_000 ..< 999_999:
+            return String(format: "%.1fK", locale: Locale.current, Double(self) / 1_000)
+                .sanitizedAbbreviatedCountString(for: "K")
+        default:
+            return String(format: "%.1fM", locale: Locale.current, Double(self) / 1_000_000)
+                .sanitizedAbbreviatedCountString(for: "M")
+        }
+    }
+}
+
+fileprivate extension String {
+    func sanitizedAbbreviatedCountString(for value: String) -> String {
+        [".0", ",0", "٫٠"].reduce(self) { res, acc in
+            return res.replacingOccurrences(of: "\(acc)\(value)", with: value)
+        }
+    }
+}

--- a/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
@@ -9,6 +9,7 @@ import os.log
 import UIKit
 import MastodonAsset
 import MastodonLocalization
+import MastodonExtension
 
 public protocol ActionToolbarContainerDelegate: AnyObject {
     func actionToolbarContainer(_ actionToolbarContainer: ActionToolbarContainer, buttonDidPressed button: UIButton, action: ActionToolbarContainer.Action)
@@ -283,7 +284,7 @@ extension ActionToolbarContainer {
 extension ActionToolbarContainer {
     private static func title(from number: Int?) -> String {
         guard let number = number, number > 0 else { return "" }
-        return String(number)
+        return number.asAbbreviatedCountString()
     }
 }
 

--- a/MastodonSDK/Tests/MastodonExtensionTests/IntTests.swift
+++ b/MastodonSDK/Tests/MastodonExtensionTests/IntTests.swift
@@ -1,0 +1,53 @@
+//
+//  IntTests.swift
+//  
+//
+//  Created by Marcus Kida on 28.12.22.
+//
+
+import XCTest
+@testable import MastodonSDK
+
+class IntFriendlyCountTests: XCTestCase {
+    func testFriendlyCount_for_1000() {
+        let input = 1_000
+        let expectedOutput = "1K"
+        
+        XCTAssertEqual(expectedOutput, input.asAbbreviatedCountString())
+    }
+    
+    func testFriendlyCount_for_1200() {
+        let input = 1_200
+        let expectedOutput = "1.2K"
+        
+        XCTAssertEqual(expectedOutput, input.asAbbreviatedCountString())
+    }
+    
+    func testFriendlyCount_for_50000() {
+        let input = 50_000
+        let expectedOutput = "50K"
+        
+        XCTAssertEqual(expectedOutput, input.asAbbreviatedCountString())
+    }
+    
+    func testFriendlyCount_for_70666() {
+        let input = 70_666
+        let expectedOutput = "70.7K"
+        
+        XCTAssertEqual(expectedOutput, input.asAbbreviatedCountString())
+    }
+    
+    func testFriendlyCount_for_1M() {
+        let input = 1_000_000
+        let expectedOutput = "1M"
+        
+        XCTAssertEqual(expectedOutput, input.asAbbreviatedCountString())
+    }
+    
+    func testFriendlyCount_for_1dot5M() {
+        let input = 1_499_000
+        let expectedOutput = "1.5M"
+        
+        XCTAssertEqual(expectedOutput, input.asAbbreviatedCountString())
+    }
+}


### PR DESCRIPTION
# Rationale

Improves style of favorite / reblog count on status by showing an abbreviated version for thousands (K) and millions (M).

# Demo

| Before | After
|---|---|
| <img width="439" alt="Bildschirm­foto 2022-12-28 um 11 59 02" src="https://user-images.githubusercontent.com/126418/209802000-5379bc6b-6850-4d63-b047-261de8f61fa6.png"> | <img width="442" alt="Bildschirm­foto 2022-12-28 um 11 58 20" src="https://user-images.githubusercontent.com/126418/209802036-949a1319-8978-4c57-a73e-fc74518adda0.png"> |