### PR TITLE
fix: Poll percentages were wrong due to wrong count being used (votes vs voters)

### DIFF
--- a/Mastodon/Scene/Share/View/Content/PollOptionView+Configuration.swift
+++ b/Mastodon/Scene/Share/View/Content/PollOptionView+Configuration.swift
@@ -33,12 +33,12 @@ extension PollOptionView {
             .store(in: &disposeBag)
         // percentage
         Publishers.CombineLatest(
-            option.poll.publisher(for: \.votesCount),
+            option.poll.publisher(for: \.votersCount),
             option.publisher(for: \.votesCount)
         )
-        .map { pollVotesCount, optionVotesCount -> Double? in
-            guard pollVotesCount > 0, optionVotesCount >= 0 else { return 0 }
-            return Double(optionVotesCount) / Double(pollVotesCount)
+        .map { pollVotersCount, optionVotesCount -> Double? in
+            guard pollVotersCount > 0, optionVotesCount >= 0 else { return 0 }
+            return Double(optionVotesCount) / Double(pollVotersCount)
         }
         .assign(to: \.percentage, on: viewModel)
         .store(in: &disposeBag)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/PollOptionView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/PollOptionView+ViewModel.swift
@@ -175,7 +175,7 @@ extension PollOptionView.ViewModel {
                     view.voteProgressStripView.setProgress(0.0, animated: false)
                 case .reveal(let voted, let percentage, let animating):
                     view.optionPercentageLabel.isHidden = false
-                    view.optionPercentageLabel.text = String(Int(100 * percentage)) + "%"
+                    view.optionPercentageLabel.text = String(Int(round(100 * percentage))) + "%"
                     view.voteProgressStripView.isHidden = false
                     view.voteProgressStripView.tintColor = voted ? self.primaryStripProgressViewTintColor : self.secondaryStripProgressViewTintColor
                     view.voteProgressStripView.setProgress(CGFloat(percentage), animated: animating)


### PR DESCRIPTION
# Rationale

Fix incorrect poll votes percentage.

Reference status with which to reproduce issue with current App Store version: https://mastodon.social/@Gargron/109502941346549786

# Demo

| Before | After |
|---|---|
| <img width="432" alt="Bildschirm­foto 2022-12-28 um 12 42 57" src="https://user-images.githubusercontent.com/126418/209806984-2c272247-1e73-4ea1-a403-e97b9ed9e5b9.png"> | <img width="429" alt="Bildschirm­foto 2022-12-28 um 12 39 35" src="https://user-images.githubusercontent.com/126418/209806926-a57aa390-73e6-4573-a4c6-91cead174e97.png"> |