### PR TITLE
Replace deprecated properties

### DIFF
--- a/MastodonSDK/Sources/CoreDataStack/Extension/UIFont.swift
+++ b/MastodonSDK/Sources/CoreDataStack/Extension/UIFont.swift
@@ -22,9 +22,9 @@ extension UIFont {
         let fontDescription = UIFontDescriptor.preferredFontDescriptor(withTextStyle: textStyle).addingAttributes([
             UIFontDescriptor.AttributeName.featureSettings: [
                 [
-                    UIFontDescriptor.FeatureKey.featureIdentifier:
+                    UIFontDescriptor.FeatureKey.type:
                         kNumberSpacingType,
-                    UIFontDescriptor.FeatureKey.typeIdentifier:
+                    UIFontDescriptor.FeatureKey.selector:
                         kMonospacedNumbersSelector
                 ]
             ]


### PR DESCRIPTION
Hi,

This PR replaces deprecated properties with new ones to resolve the following compiler warnings:

```
'featureIdentifier' was deprecated in iOS 15.0
'typeIdentifier' was deprecated in iOS 15.0
```

- https://developer.apple.com/documentation/uikit/uifontdescriptor/featurekey/1616715-featureidentifier
- https://developer.apple.com/documentation/uikit/uifontdescriptor/featurekey/1616687-typeidentifier