### PR TITLE
Limit posts to 15 lines unless they are expanded

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -447,6 +447,8 @@ extension StatusView.Style {
         statusView.contentContainer.setContentCompressionResistancePriority(.required - 1, for: .vertical)
 
         // status content
+        statusView.contentMetaText.textView.textContainer.maximumNumberOfLines = 20
+        statusView.contentMetaText.textView.textContainer.lineBreakMode = .byTruncatingTail
         statusView.contentContainer.addArrangedSubview(statusView.contentMetaText.textView)
         statusView.contentContainer.addArrangedSubview(statusView.statusCardControl)
 
@@ -516,6 +518,9 @@ extension StatusView.Style {
         // container: V - [ … | statusMetricView ]
         base(statusView: statusView)      // override the base style
         
+        // remove line count limit
+        statusView.contentMetaText.textView.textContainer.maximumNumberOfLines = 0
+
         // statusMetricView
         statusView.statusMetricViewAdaptiveMarginContainerView.contentView = statusView.statusMetricView
         statusView.statusMetricViewAdaptiveMarginContainerView.margin = StatusView.containerLayoutMargin

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -447,7 +447,7 @@ extension StatusView.Style {
         statusView.contentContainer.setContentCompressionResistancePriority(.required - 1, for: .vertical)
 
         // status content
-        statusView.contentMetaText.textView.textContainer.maximumNumberOfLines = 20
+        statusView.contentMetaText.textView.textContainer.maximumNumberOfLines = 15
         statusView.contentMetaText.textView.textContainer.lineBreakMode = .byTruncatingTail
         statusView.contentContainer.addArrangedSubview(statusView.contentMetaText.textView)
         statusView.contentContainer.addArrangedSubview(statusView.statusCardControl)


### PR DESCRIPTION
Fixes #730. I went with ~20~ 15 lines since it felt long enough to accommodate most content but not allow things to get too much longer than one screen. When you tap on a post you’ll be always be able to see its full content.

Currently the only indication of whether a post is truncated is the “…” at the end. I considered doing a “Read More” button (inline or on a new line) but it seems that doing so is a bit messy since it requires iterating through all of the lines in the post until a truncation is found. (and whether or not the post is truncated could change dynamically based on text size or (on iPad) multitasking status).

<img src=https://user-images.githubusercontent.com/25517624/209846794-0d2ae4ab-f75b-4d84-911a-09e8ba03df3c.jpeg width=390><img src=https://user-images.githubusercontent.com/25517624/209846804-58d5d04a-39c4-4dd5-a163-b4d2f1cbaea1.jpeg width=390>
