### PR TITLE
Improve handling of media in the share extension

### DIFF
--- a/MastodonSDK/Sources/CoreDataStack/CoreDataStack.swift
+++ b/MastodonSDK/Sources/CoreDataStack/CoreDataStack.swift
@@ -96,15 +96,11 @@ public final class CoreDataStack {
             callback()
             
             #if DEBUG
-            do {
-                let storeURL = URL.storeURL(for: AppName.groupID, databaseName: "shared")
-                let data = try Data(contentsOf: storeURL)
-                let formatter = ByteCountFormatter()
-                formatter.allowedUnits = [.useMB]
-                formatter.countStyle = .file
-                let size = formatter.string(fromByteCount: Int64(data.count))
-                CoreDataStack.logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): Database size: \(size)")
-            } catch {
+            let storeURL = URL.storeURL(for: AppName.groupID, databaseName: "shared")
+            if let size = try? storeURL.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+                let formattedSize = size.formatted(.byteCount(style: .file, allowedUnits: .mb))
+                CoreDataStack.logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): Database size: \(formattedSize, privacy: .public)")
+            } else {
                 CoreDataStack.logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): Cannot get database size")
             }
             #endif

--- a/MastodonSDK/Sources/MastodonCore/Extension/NSItemProvider.swift
+++ b/MastodonSDK/Sources/MastodonCore/Extension/NSItemProvider.swift
@@ -81,6 +81,7 @@ extension NSItemProvider {
                 type: cgImage.utType.flatMap { UTType($0 as String) }
             )
         } else {
+            assertionFailure("Invalid image type \(type(of: result))")
             return nil
         }
     }

--- a/MastodonSDK/Sources/MastodonCore/Extension/NSItemProvider.swift
+++ b/MastodonSDK/Sources/MastodonCore/Extension/NSItemProvider.swift
@@ -29,74 +29,61 @@ extension NSItemProvider {
     }
 
     public func loadImageData() async throws -> ImageLoadResult? {
-        try await withCheckedThrowingContinuation { continuation in
-            loadFileRepresentation(forTypeIdentifier: UTType.image.identifier) { url, error in
-                if let error = error {
-                    continuation.resume(with: .failure(error))
-                    return
-                }
-                
-                guard let url = url else {
-                    continuation.resume(with: .success(nil))
-                    assertionFailure()
-                    return
-                }
-                
-                let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
-                guard let source = CGImageSourceCreateWithURL(url as CFURL, sourceOptions) else {
-                    return
-                }
+        #if APP_EXTENSION
+        let maxPixelSize = 4096        // not limit but may upload fail
+        #else
+        let maxPixelSize = 1536        // fit 120MB RAM limit
+        #endif
 
-                #if APP_EXTENSION
-                let maxPixelSize: Int = 4096        // not limit but may upload fail
-                #else
-                let maxPixelSize: Int = 1536        // fit 120MB RAM limit
-                #endif
-                
-                let downsampleOptions = [
+        let result = try await self.loadItem(forTypeIdentifier: UTType.image.identifier, options: [NSItemProviderPreferredImageSizeKey: CGSize(width: maxPixelSize, height: maxPixelSize)])
+        if let image = result as? UIImage {
+            let isPNG = (image.cgImage?.utType as String?) == UTType.png.identifier
+            guard let data = isPNG ? image.pngData() : image.jpegData(compressionQuality: 0.75) else {
+                return nil
+            }
+            
+            NSItemProvider.logger.debug("\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): load image \(data.count.formatted(.byteCount(style: .memory)), privacy: .public)")
+            return ImageLoadResult(
+                data: data,
+                type: isPNG ? .png : .jpeg
+            )
+        } else if let url = result as? URL {
+            guard
+                let source = CGImageSourceCreateWithURL(url as CFURL, [kCGImageSourceShouldCache: false] as CFDictionary)
+            else {
+                assertionFailure()
+                return nil
+            }
+            
+            guard
+                let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, [
                     kCGImageSourceCreateThumbnailFromImageAlways: true,
                     kCGImageSourceCreateThumbnailWithTransform: true,
                     kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
-                ] as CFDictionary
-                
-                guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, downsampleOptions) else {
-                    continuation.resume(with: .success(nil))
-                    return
-                }
-                
-                let data = NSMutableData()
-                guard let imageDestination = CGImageDestinationCreateWithData(data, UTType.jpeg.identifier as CFString, 1, nil) else {
-                    continuation.resume(with: .success(nil))
-                    assertionFailure()
-                    return
-                }
-            
-                let isPNG: Bool = {
-                    guard let utType = cgImage.utType else { return false }
-                    return (utType as String) == UTType.png.identifier
-                    
-                }()
-                                
-                let destinationProperties = [
-                    kCGImageDestinationLossyCompressionQuality: isPNG ? 1.0 : 0.75
-                ] as CFDictionary
-                
-                CGImageDestinationAddImage(imageDestination, cgImage, destinationProperties)
-                CGImageDestinationFinalize(imageDestination)
-                
-                let dataSize = ByteCountFormatter.string(fromByteCount: Int64(data.length), countStyle: .memory)
-                NSItemProvider.logger.debug("\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): load image \(dataSize)")
-                
-                let result = ImageLoadResult(
-                    data: data as Data,
-                    type: cgImage.utType.flatMap { UTType($0 as String) }
-                )
+                ] as CFDictionary)
+            else { return nil }
+            let isPNG = (cgImage.utType as String?) == UTType.png.identifier
 
-                continuation.resume(with: .success(result))
+            let data = NSMutableData()
+            guard let imageDestination = CGImageDestinationCreateWithData(data, UTType.jpeg.identifier as CFString, 1, nil) else {
+                return nil
             }
+            
+            CGImageDestinationAddImage(imageDestination, cgImage, [
+                kCGImageDestinationLossyCompressionQuality: isPNG ? 1.0 : 0.75
+            ] as CFDictionary)
+            CGImageDestinationFinalize(imageDestination)
+
+            NSItemProvider.logger.debug("\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): load image \(data.length.formatted(.byteCount(style: .memory)))")
+            
+            return ImageLoadResult(
+                data: data as Data,
+                type: cgImage.utType.flatMap { UTType($0 as String) }
+            )
+        } else {
+            return nil
         }
     }
-    
 }
 
 extension NSItemProvider {


### PR DESCRIPTION
- Only grab one value from each item provider, so that e.g. the file: URLs of images aren’t included as starter post content (fixes #830)
- fix crashes in dev mode by reading the DB size from the file system for logging purposes rather than reading it into an in-memory `Data` object and then getting the size of that object. (should also improve dev mode startup perf!)
- Handle being passed a `UIImage` object instead of a URL to an image file on disk. (some third party apps do this) (fixes #829)