### PR TITLE
Make the “reply” button on profiles start a DM instead

### DIFF
--- a/Mastodon/Scene/Compose/ComposeViewController.swift
+++ b/Mastodon/Scene/Compose/ComposeViewController.swift
@@ -35,7 +35,8 @@ final class ComposeViewController: UIViewController, NeedsDependency {
             context: context,
             authContext: viewModel.authContext,
             destination: viewModel.destination,
-            initialContent: viewModel.initialContent
+            initialContent: viewModel.initialContent,
+            initialVisibility: viewModel.initialVisibility
         )
     }()
     private(set) lazy var composeContentViewController: ComposeContentViewController = {

--- a/Mastodon/Scene/Compose/ComposeViewModel.swift
+++ b/Mastodon/Scene/Compose/ComposeViewModel.swift
@@ -31,6 +31,7 @@ final class ComposeViewModel {
     let authContext: AuthContext
     let destination: ComposeContentViewModel.Destination
     let initialContent: String
+    let initialVisibility: Mastodon.Entity.Status.Visibility?
 
     let traitCollectionDidChangePublisher = CurrentValueSubject<Void, Never>(Void())      // use CurrentValueSubject to make initial event emit
     
@@ -43,12 +44,14 @@ final class ComposeViewModel {
         context: AppContext,
         authContext: AuthContext,
         destination: ComposeContentViewModel.Destination,
-        initialContent: String = ""
+        initialContent: String = "",
+        initialVisibility: Mastodon.Entity.Status.Visibility? = nil
     ) {
         self.context = context
         self.authContext = authContext
         self.destination = destination
         self.initialContent = initialContent
+        self.initialVisibility = initialVisibility
         // end init
         
         self.title = {

--- a/Mastodon/Scene/Profile/ProfileViewController.swift
+++ b/Mastodon/Scene/Profile/ProfileViewController.swift
@@ -91,8 +91,8 @@ final class ProfileViewController: UIViewController, NeedsDependency, MediaPrevi
         return barButtonItem
     }()
 
-    private(set) lazy var replyBarButtonItem: UIBarButtonItem = {
-        let barButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrowshape.turn.up.left"), style: .plain, target: self, action: #selector(ProfileViewController.replyBarButtonItemPressed(_:)))
+    private(set) lazy var dmBarButtonItem: UIBarButtonItem = {
+        let barButtonItem = UIBarButtonItem(image: UIImage(systemName: "envelope"), style: .plain, target: self, action: #selector(ProfileViewController.dmBarButtonItemPressed(_:)))
         barButtonItem.tintColor = .white
         barButtonItem.accessibilityLabel = L10n.Common.Controls.Actions.reply
         return barButtonItem
@@ -203,7 +203,7 @@ extension ProfileViewController {
 
         let barButtonItemHiddenPublisher = Publishers.CombineLatest3(
             viewModel.$isMeBarButtonItemsHidden,
-            viewModel.$isReplyBarButtonItemHidden,
+            viewModel.$isDMBarButtonItemHidden,
             viewModel.$isMoreMenuBarButtonItemHidden
         )
 
@@ -225,7 +225,7 @@ extension ProfileViewController {
         .sink { [weak self] isSuspended, isTitleViewDisplaying, tuple1, tuple2 in
             guard let self = self else { return }
             let (isEditing, _) = tuple1
-            let (isMeBarButtonItemsHidden, isReplyBarButtonItemHidden, isMoreMenuBarButtonItemHidden) = tuple2
+            let (isMeBarButtonItemsHidden, isDMBarButtonItemHidden, isMoreMenuBarButtonItemHidden) = tuple2
 
             var items: [UIBarButtonItem] = []
             defer {
@@ -261,8 +261,8 @@ extension ProfileViewController {
             if !isMoreMenuBarButtonItemHidden {
                 items.append(self.moreMenuBarButtonItem)
             }
-            if !isReplyBarButtonItemHidden {
-                items.append(self.replyBarButtonItem)
+            if !isDMBarButtonItemHidden {
+                items.append(self.dmBarButtonItem)
             }
         }
         .store(in: &disposeBag)
@@ -550,7 +550,7 @@ extension ProfileViewController {
         _ = coordinator.present(scene: .bookmark(viewModel: bookmarkViewModel), from: self, transition: .show)
     }
 
-    @objc private func replyBarButtonItemPressed(_ sender: UIBarButtonItem) {
+    @objc private func dmBarButtonItemPressed(_ sender: UIBarButtonItem) {
         os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
         guard let mastodonUser = viewModel.user else { return }
         let mention = "@" + mastodonUser.acct
@@ -559,7 +559,8 @@ extension ProfileViewController {
             context: context,
             authContext: viewModel.authContext,
             destination: .topLevel,
-            initialContent: mention
+            initialContent: mention,
+            initialVisibility: .direct
         )
         _ = coordinator.present(scene: .compose(viewModel: composeViewModel), from: self, transition: .modal(animated: true, completion: nil))
     }

--- a/Mastodon/Scene/Profile/ProfileViewModel.swift
+++ b/Mastodon/Scene/Profile/ProfileViewModel.swift
@@ -51,7 +51,7 @@ class ProfileViewModel: NSObject {
     @Published var userIdentifier: UserIdentifier? = nil
     
     @Published var isRelationshipActionButtonHidden: Bool = true
-    @Published var isReplyBarButtonItemHidden: Bool = true
+    @Published var isDMBarButtonItemHidden: Bool = true
     @Published var isMoreMenuBarButtonItemHidden: Bool = true
     @Published var isMeBarButtonItemsHidden: Bool = true
     @Published var isPagingEnabled = true
@@ -111,14 +111,14 @@ class ProfileViewModel: NSObject {
             .sink { [weak self] optionSet in
                 guard let self = self else { return }
                 guard let optionSet = optionSet, !optionSet.contains(.none) else {
-                    self.isReplyBarButtonItemHidden = true
+                    self.isDMBarButtonItemHidden = true
                     self.isMoreMenuBarButtonItemHidden = true
                     self.isMeBarButtonItemsHidden = true
                     return
                 }
                 
                 let isMyself = optionSet.contains(.isMyself)
-                self.isReplyBarButtonItemHidden = isMyself
+                self.isDMBarButtonItemHidden = isMyself
                 self.isMoreMenuBarButtonItemHidden = isMyself
                 self.isMeBarButtonItemsHidden = !isMyself
             }

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
@@ -138,12 +138,16 @@ public final class ComposeContentViewModel: NSObject, ObservableObject {
         context: AppContext,
         authContext: AuthContext,
         destination: Destination,
-        initialContent: String
+        initialContent: String,
+        initialVisibility: Mastodon.Entity.Status.Visibility?
     ) {
         self.context = context
         self.authContext = authContext
         self.destination = destination
         self.visibility = {
+            if let initialVisibility {
+                return initialVisibility
+            }
             // default private when user locked
             var visibility: Mastodon.Entity.Status.Visibility = {
                 guard let author = authContext.mastodonAuthenticationBox.authenticationRecord.object(in: context.managedObjectContext)?.user else {

--- a/ShareActionExtension/Scene/ShareViewController.swift
+++ b/ShareActionExtension/Scene/ShareViewController.swift
@@ -100,7 +100,8 @@ extension ShareViewController {
                 context: context,
                 authContext: authContext,
                 destination: .topLevel,
-                initialContent: ""
+                initialContent: "",
+                initialVisibility: nil
             )
             let composeContentViewController = ComposeContentViewController()
             composeContentViewController.viewModel = composeContentViewModel


### PR DESCRIPTION
“reply” didn’t make much sense to me as a top level action so I’m proposing this. I’m not sure that this is the best approach, especially since the app currently isn’t very in-your-face about the currently selected visibility option.