### PR TITLE
Fix Share Extension Display Name

### DIFF
--- a/ShareActionExtension/Info.plist
+++ b/ShareActionExtension/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>ShareActionExtension</string>
+	<string>Mastodon</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
# Rationale

Currently, when using the iPad App on an Apple Silicon Machine, the Share Extension is revealing it's display name as **ShareActionExtension**.

# Screenshots

| Before | After |
|---|---|
| <img width="254" alt="Bildschirm­foto 2023-01-04 um 14 12 25" src="https://user-images.githubusercontent.com/126418/210578658-41134491-530a-4266-ad61-23d8b8f962c4.png"> | <img width="250" alt="Bildschirm­foto 2023-01-04 um 15 31 11" src="https://user-images.githubusercontent.com/126418/210578652-5082fb59-052a-4e5b-980e-1b27ce7a2f85.png"> |
