### PR TITLE
Fix crash on media upload

### DIFF
--- a/MastodonSDK/Sources/MastodonSDK/Query/SerialStream.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Query/SerialStream.swift
@@ -127,6 +127,7 @@ final class SerialStream: NSObject {
     
     deinit {
         os_log(.debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
+        boundStreams.output.delegate = nil
     }
     
 }


### PR DESCRIPTION
May fix #782.

Using the information linked by @kenji21 (Thank you so much for the pointer), I noticed that the `OutputStream` of `SerialStream` has its delegate set, but the delegate is never unset. `OutputStream` does indeed mark its delegate as `unowned(unsafe)` so this is likely the cause of the crash. I have not however tested this change since I haven’t seen the crash on my end.

I’m also a little concerned about the correctness of `SerialStream`. It’s not clear to me how long its lifetime is, and the fact that the crash occurred in at least one case “around 200kb/2.82MB” makes me worry that the `SerialStream` is being prematurely released. Not sure if there’s a good way to make sure it stays alive until the request is done.