### PR TITLE
fix(deeplinking): Fix profile resolving didn't use WebFinger so resolving non-local profiles might fail

### DIFF
--- a/Mastodon/Scene/Profile/RemoteProfileViewModel.swift
+++ b/Mastodon/Scene/Profile/RemoteProfileViewModel.swift
@@ -90,41 +90,41 @@ final class RemoteProfileViewModel: ProfileViewModel {
         }   // end Task
     }
     
-    init(context: AppContext, authContext: AuthContext, acct: String) {
-           super.init(context: context, authContext: authContext, optionalMastodonUser: nil)
-           
-           let domain = authContext.mastodonAuthenticationBox.domain
-           let authorization = authContext.mastodonAuthenticationBox.userAuthorization
-           Just(acct)
-               .asyncMap { acct in
-                   try await context.apiService.accountSearch(
-                       domain: domain,
-                       query: .init(acct: acct),
-                       authorization: authorization
-                   )
-               }
-               .retry(3)
-               .receive(on: DispatchQueue.main)
-               .sink { completion in
-                   switch completion {
-                   case .failure(let error):
-                       // TODO: handle error
-                       os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s: remote user %s fetch failed: %s", ((#file as NSString).lastPathComponent), #line, #function, acct, error.localizedDescription)
-                   case .finished:
-                       os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s: remote user %s fetched", ((#file as NSString).lastPathComponent), #line, #function, acct)
-                   }
-               } receiveValue: { [weak self] response in
-                   guard let self = self else { return }
-                   let managedObjectContext = context.managedObjectContext
-                   let request = MastodonUser.sortedFetchRequest
-                   request.fetchLimit = 1
-                   request.predicate = MastodonUser.predicate(domain: domain, id: response.value.id)
-                   guard let mastodonUser = managedObjectContext.safeFetch(request).first else {
-                       assertionFailure()
-                       return
-                   }
-                   self.user = mastodonUser
-               }
-               .store(in: &disposeBag)
-       }
+    init(context: AppContext, authContext: AuthContext, acct: String){
+        super.init(context: context, authContext: authContext, optionalMastodonUser: nil)
+
+        let domain = authContext.mastodonAuthenticationBox.domain
+        let authenticationBox = authContext.mastodonAuthenticationBox
+
+        Just(acct)
+            .asyncMap { acct -> Mastodon.Response.Content<Mastodon.Entity.Account?> in
+                try await context.apiService.search(
+                    query: .init(q: acct, type: .accounts, resolve: true),
+                    authenticationBox: authenticationBox
+                ).map { $0.accounts.first }
+            }
+            .retry(3)
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                switch completion {
+                case .failure(let error):
+                    // TODO: handle error
+                    os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s: remote user %s fetch failed: %s", ((#file as NSString).lastPathComponent), #line, #function, acct, error.localizedDescription)
+                case .finished:
+                    os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s: remote user %s fetched", ((#file as NSString).lastPathComponent), #line, #function, acct)
+                }
+            } receiveValue: { [weak self] response in
+                guard let self = self, let value = response.value else { return }
+                let managedObjectContext = context.managedObjectContext
+                let request = MastodonUser.sortedFetchRequest
+                request.fetchLimit = 1
+                request.predicate = MastodonUser.predicate(domain: domain, id: value.id)
+                guard let mastodonUser = managedObjectContext.safeFetch(request).first else {
+                    assertionFailure()
+                    return
+                }
+                self.user = mastodonUser
+            }
+            .store(in: &disposeBag)
+    }
 }

--- a/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Account.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Account.swift
@@ -240,34 +240,3 @@ extension APIService {
         return result
     }
 }
-
-extension APIService {
-    public func accountSearch(
-        domain: String,
-        query: Mastodon.API.Account.AccountLookupQuery,
-        authorization: Mastodon.API.OAuth.Authorization
-    ) async throws -> Mastodon.Response.Content<Mastodon.Entity.Account> {
-        let response = try await Mastodon.API.Account.lookupAccount(
-            session: session,
-            domain: domain,
-            query: query,
-            authorization: authorization
-        ).singleOutput()
-        
-        // user
-        let managedObjectContext = self.backgroundManagedObjectContext
-        try await managedObjectContext.performChanges {
-            _ = Persistence.MastodonUser.createOrMerge(
-                in: managedObjectContext,
-                context: Persistence.MastodonUser.PersistContext(
-                    domain: domain,
-                    entity: response.value,
-                    cache: nil,
-                    networkDate: response.networkDate
-                )
-            )
-        }
-        
-        return response
-    }
-}


### PR DESCRIPTION
# Rationale

The current profile resolution when coming from a url scheme e.g. `mastodon://profile/marcus@bearologics.social` will not use WebFinger, so in case the user account is not known to your server, the resolution will fail. I've migrated the resolution to be done via the search API and using WebFinger now.