### PR TITLE
Fix correcting image rotation

### DIFF
--- a/MastodonSDK/Package.swift
+++ b/MastodonSDK/Package.swift
@@ -141,5 +141,9 @@ let package = Package(
             name: "MastodonSDKTests",
             dependencies: ["MastodonSDK"]
         ),
+        .testTarget(
+            name: "MastodonUITests",
+            dependencies: ["MastodonUI"]
+        ),
     ]
 )

--- a/MastodonSDK/Sources/MastodonUI/Extension/UIImage.swift
+++ b/MastodonSDK/Sources/MastodonUI/Extension/UIImage.swift
@@ -18,12 +18,8 @@ extension UIImage {
 }
 
 extension UIImage {
-    public func normalized() -> UIImage? {
-        if imageOrientation == .up { return self }
-        UIGraphicsBeginImageContext(size)
-        draw(in: CGRect(origin: CGPoint.zero, size: size))
-        let image = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return image
+    public func normalized() -> UIImage {
+        guard imageOrientation != .up, let cgImage = cgImage else { return self }
+        return UIImage(cgImage: cgImage, scale: scale, orientation: .up)
     }
- }
+}

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentViewModel+Load.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentViewModel+Load.swift
@@ -16,7 +16,7 @@ extension AttachmentViewModel {
     func load(input: Input) async throws -> Output {
         switch input {
         case .image(let image):
-            guard let data = image.normalized()?.pngData() else {
+            guard let data = image.normalized().pngData() else {
                 throw AttachmentError.invalidAttachmentType
             }
             return .image(data, imageKind: .png)

--- a/MastodonSDK/Tests/MastodonUITests/UIImageExtensionTests.swift
+++ b/MastodonSDK/Tests/MastodonUITests/UIImageExtensionTests.swift
@@ -1,0 +1,25 @@
+//
+//  UIImageExtensionTests.swift
+//  MastodonUITests
+//
+//  Created by woxtu on 2023/01/07.
+//
+
+@testable import MastodonUI
+import XCTest
+
+final class UIImageExtensionTests: XCTestCase {
+    func testNormalizeImage() {
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 200, height: 100)).image { _ in }
+        XCTAssertEqual(image.imageOrientation, .up)
+        XCTAssertEqual(image.size, CGSize(width: 200, height: 100))
+        
+        let rotatedImage = UIImage(cgImage: image.cgImage!, scale: image.scale, orientation: .right)
+        XCTAssertEqual(rotatedImage.imageOrientation, .right)
+        XCTAssertEqual(rotatedImage.size, CGSize(width: 100, height: 200))
+        
+        let normalizedImage = rotatedImage.normalized()
+        XCTAssertEqual(normalizedImage?.imageOrientation, .up)
+        XCTAssertEqual(normalizedImage?.size, CGSize(width: 200, height: 100))
+    }
+}

--- a/MastodonSDK/Tests/MastodonUITests/UIImageExtensionTests.swift
+++ b/MastodonSDK/Tests/MastodonUITests/UIImageExtensionTests.swift
@@ -19,7 +19,7 @@ final class UIImageExtensionTests: XCTestCase {
         XCTAssertEqual(rotatedImage.size, CGSize(width: 100, height: 200))
         
         let normalizedImage = rotatedImage.normalized()
-        XCTAssertEqual(normalizedImage?.imageOrientation, .up)
-        XCTAssertEqual(normalizedImage?.size, CGSize(width: 200, height: 100))
+        XCTAssertEqual(normalizedImage.imageOrientation, .up)
+        XCTAssertEqual(normalizedImage.size, CGSize(width: 200, height: 100))
     }
 }


### PR DESCRIPTION
Hi,

The `normalized` method that corrects image rotation returns a wrong size image, so this PR fixes that.