### PR TITLE
fix(share-menu): Fixes URL for shared status when using square.and.arrow.up share menu on status

### DIFF
--- a/Mastodon/Protocol/Provider/DataSourceFacade+Status.swift
+++ b/Mastodon/Protocol/Provider/DataSourceFacade+Status.swift
@@ -312,10 +312,16 @@ extension DataSourceFacade {
             }   // end Task
         case .shareStatus:
             Task {
-                guard let status = menuContext.status else {
+                let managedObjectContext = dependency.context.managedObjectContext
+                guard let status: ManagedObjectRecord<Status> = try? await managedObjectContext.perform(block: {
+                    guard let object = menuContext.status?.object(in: managedObjectContext) else { return nil }
+                    let objectID = (object.reblog ?? object).objectID
+                    return .init(objectID: objectID)
+                }) else {
                     assertionFailure()
                     return
                 }
+
                 let activityViewController = try await DataSourceFacade.createActivityViewController(
                     dependency: dependency,
                     status: status


### PR DESCRIPTION
# Expected Behavior

Sharing a link always uses the permalink of the post.

# Actual Behavior

Sharing a link from a reblog uses the permalink of the reblog (which kind of doesn't exist).

# Steps to Reproduce the Problem
(Using the share menu on the upper right hand side of a status)

* Have a post in timeline that is a reblog
* Click share

# The Fix

Currently the `menuContext.status` is being used, which is the actual reblog status and not the reblogged item's status. This is valid in most cases, such as muting the reblogging user etc. but it's not useful when sharing the status as you want to share the shared status.