### PR TITLE
Left-align the username in the profile header

### DIFF
--- a/Mastodon/Scene/Profile/Header/View/ProfileHeaderView.swift
+++ b/Mastodon/Scene/Profile/Header/View/ProfileHeaderView.swift
@@ -187,6 +187,8 @@ final class ProfileHeaderView: UIView {
         button.titleLabel?.font = UIFontMetrics(forTextStyle: .callout).scaledFont(for: .systemFont(ofSize: 16, weight: .regular))
         button.titleLabel?.adjustsFontSizeToFitWidth = true
         button.titleLabel?.minimumScaleFactor = 0.5
+        button.titleLabel?.textAlignment = .natural
+        button.contentHorizontalAlignment = .leading
         button.setTitleColor(Asset.Colors.Label.secondary.color, for: .normal)
         button.menu = usernameButtonMenu
         button.showsMenuAsPrimaryAction = true


### PR DESCRIPTION
The changes to add a menu to the username so it can be copied also center-aligned it under the display name. This PR overrides the text alignment so that it returns to its previous position.