### PR TITLE
Add template for header

### DIFF
--- a/Mastodon.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/Mastodon.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,3 @@
+{
+	FILEHEADER = " Copyright © ___YEAR___ Mastodon gGmbH. All rights reserved.";
+}


### PR DESCRIPTION
This changes the header at the beginning of a file when you create a new file.

In other words: The PR changes this:

<img width="401" alt="grafik" src="https://user-images.githubusercontent.com/2580019/212010638-084c0a98-fb70-48e6-a677-ad24476d5645.png">

into this:

<img width="477" alt="grafik" src="https://user-images.githubusercontent.com/2580019/212010735-eaadc9ec-644a-4eeb-8c59-1815cc33460a.png">

All the other information (When was this file created? And by whom?) is stored in git. This is more or less a proposal, lmk, when something should be different.