### PR TITLE
Fix accessibility label for posts with custom emoji

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -751,7 +751,7 @@ extension StatusView.ViewModel {
             }
 
             if isContentReveal {
-                strings.append(content?.string)
+                strings.append(statusView.contentMetaText.backedString)
             }
             
             return strings.compactMap { $0 }.joined(separator: ", ")
@@ -769,6 +769,7 @@ extension StatusView.ViewModel {
         contentAccessibilityLabel
             .sink { contentAccessibilityLabel in
                 statusView.spoilerOverlayView.accessibilityLabel = contentAccessibilityLabel
+                statusView.contentMetaText.textView.accessibilityLabel = contentAccessibilityLabel
             }
             .store(in: &disposeBag)
 


### PR DESCRIPTION
Posts will now be read as `foo :emoji: bar` instead of `foo, , Attachment.png, bar`