### PR TITLE
Apply languageIdentifier attribute to user-generated content where possible

### DIFF
--- a/Mastodon/Protocol/Provider/DataSourceFacade+Media.swift
+++ b/Mastodon/Protocol/Provider/DataSourceFacade+Media.swift
@@ -66,10 +66,10 @@ extension DataSourceFacade {
         previewContext: AttachmentPreviewContext
     ) async throws {
         let managedObjectContext = dependency.context.managedObjectContext
-        let attachments: [MastodonAttachment] = try await managedObjectContext.perform {
-            guard let _status = status.object(in: managedObjectContext) else { return [] }
+        let (attachments, language): ([MastodonAttachment], String?) = try await managedObjectContext.perform {
+            guard let _status = status.object(in: managedObjectContext) else { return ([], nil) }
             let status = _status.reblog ?? _status
-            return status.attachments
+            return (status.attachments, status.language)
         }
         
         let thumbnails = await previewContext.thumbnails()
@@ -120,7 +120,8 @@ extension DataSourceFacade {
         let mediaPreviewItem = MediaPreviewViewModel.PreviewItem.attachment(.init(
             attachments: attachments,
             initialIndex: previewContext.index,
-            thumbnails: thumbnails
+            thumbnails: thumbnails,
+            language: language
         ))
         
         coordinateToMediaPreviewScene(

--- a/Mastodon/Scene/MediaPreview/AltTextViewController.swift
+++ b/Mastodon/Scene/MediaPreview/AltTextViewController.swift
@@ -20,12 +20,10 @@ class AltTextViewController: UIViewController {
 
         textView.textContainer.maximumNumberOfLines = 0
         textView.textContainer.lineBreakMode = .byWordWrapping
-        textView.font = .preferredFont(forTextStyle: .callout)
         textView.isScrollEnabled = true
         textView.backgroundColor = .clear
         textView.isOpaque = false
         textView.isEditable = false
-        textView.tintColor = .white
         textView.textContainerInset = UIEdgeInsets(top: 12, left: 8, bottom: 8, right: 8)
         textView.contentInsetAdjustmentBehavior = .always
         textView.verticalScrollIndicatorInsets.bottom = 4
@@ -33,8 +31,12 @@ class AltTextViewController: UIViewController {
         return textView
     }()
 
-    init(alt: String, sourceView: UIView?) {
-        textView.text = alt
+    init(alt: String, language: String?, sourceView: UIView?) {
+        textView.attributedText = NSAttributedString(string: alt, attributes: [
+            .languageIdentifier: "",
+            .foregroundColor: UIColor.white,
+            .font: UIFont.preferredFont(forTextStyle: .callout),
+        ])
         super.init(nibName: nil, bundle: nil)
         self.modalPresentationStyle = .popover
         self.popoverPresentationController?.delegate = self

--- a/Mastodon/Scene/MediaPreview/Image/MediaPreviewImageViewController.swift
+++ b/Mastodon/Scene/MediaPreview/Image/MediaPreviewImageViewController.swift
@@ -68,7 +68,12 @@ extension MediaPreviewImageViewController {
         let previewImageViewContextMenuInteraction = UIContextMenuInteraction(delegate: self)
         previewImageView.addInteraction(previewImageViewContextMenuInteraction)
 
-        previewImageView.imageView.accessibilityLabel = viewModel.item.altText
+        previewImageView.imageView.attributedAccessibilityLabel = viewModel.item.altText.map { altText in
+            AttributedString(
+                altText,
+                attributes: AttributeContainer(\.languageIdentifier, value: viewModel.item.language)
+            )
+        }
 
         if let thumbnail = viewModel.item.thumbnail {
             previewImageView.imageView.image = thumbnail

--- a/Mastodon/Scene/MediaPreview/Image/MediaPreviewImageViewModel.swift
+++ b/Mastodon/Scene/MediaPreview/Image/MediaPreviewImageViewModel.swift
@@ -34,6 +34,7 @@ extension MediaPreviewImageViewModel {
         let assetURL: URL?
         let thumbnail: UIImage?
         let altText: String?
+        let language: String?
     }
 
 }

--- a/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
+++ b/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
@@ -186,7 +186,7 @@ extension MediaPreviewViewController {
     @objc private func altButtonPressed(_ sender: UIButton) {
         guard let alt = viewModel.altText else { return }
 
-        present(AltTextViewController(alt: alt, sourceView: sender), animated: true)
+        present(AltTextViewController(alt: alt, language: viewModel.language, sourceView: sender), animated: true)
     }
 }
 

--- a/Mastodon/Scene/MediaPreview/MediaPreviewViewModel.swift
+++ b/Mastodon/Scene/MediaPreview/MediaPreviewViewModel.swift
@@ -58,7 +58,8 @@ final class MediaPreviewViewModel: NSObject {
                         item: .init(
                             assetURL: attachment.assetURL.flatMap { URL(string: $0) },
                             thumbnail: previewContext.thumbnail(at: i),
-                            altText: attachment.altDescription
+                            altText: attachment.altDescription,
+                            language: previewContext.language
                         )
                     )
                     viewController.viewModel = viewModel
@@ -96,7 +97,8 @@ final class MediaPreviewViewModel: NSObject {
                 item: .init(
                     assetURL: previewContext.assetURL.flatMap { URL(string: $0) },
                     thumbnail: previewContext.thumbnail,
-                    altText: nil
+                    altText: nil,
+                    language: nil
                 )
             )
             viewController.viewModel = viewModel
@@ -108,7 +110,8 @@ final class MediaPreviewViewModel: NSObject {
                 item: .init(
                     assetURL: previewContext.assetURL.flatMap { URL(string: $0) },
                     thumbnail: previewContext.thumbnail,
-                    altText: nil
+                    altText: nil,
+                    language: nil
                 )
             )
             viewController.viewModel = viewModel
@@ -161,6 +164,7 @@ extension MediaPreviewViewModel {
         let attachments: [MastodonAttachment]
         let initialIndex: Int
         let thumbnails: [UIImage?]
+        let language: String?
         
         func thumbnail(at index: Int) -> UIImage? {
             guard index < thumbnails.count else { return nil }

--- a/Mastodon/Scene/MediaPreview/MediaPreviewViewModel.swift
+++ b/Mastodon/Scene/MediaPreview/MediaPreviewViewModel.swift
@@ -28,6 +28,7 @@ final class MediaPreviewViewModel: NSObject {
     @Published var currentPage: Int
     @Published var showingChrome = true
     @Published var altText: String?
+    @Published var language: String?
 
     // output
     let viewControllers: [MediaPreviewPage]
@@ -47,6 +48,7 @@ final class MediaPreviewViewModel: NSObject {
         switch item {
         case .attachment(let previewContext):
             getAltText = { previewContext.attachments[$0].altDescription }
+            self.language = previewContext.language
 
             currentPage = previewContext.initialIndex
             for (i, attachment) in previewContext.attachments.enumerated() {

--- a/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCell.swift
+++ b/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCell.swift
@@ -83,7 +83,7 @@ extension StatusTableViewCell {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] accessibilityLabel in
                 guard let self = self else { return }
-                self.accessibilityLabel = accessibilityLabel
+                self.attributedAccessibilityLabel = accessibilityLabel
             }
             .store(in: &_disposeBag)
 
@@ -92,7 +92,7 @@ extension StatusTableViewCell {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] contentLabel, accessibilityLabel in
                 guard let self = self else { return }
-                self.accessibilityUserInputLabels = [contentLabel, accessibilityLabel]
+                self.attributedAccessibilityUserInputLabels = [contentLabel, accessibilityLabel]
             }
             .store(in: &_disposeBag)
 

--- a/MastodonSDK/Sources/CoreDataStack/Entity/Mastodon/StatusEdit.swift
+++ b/MastodonSDK/Sources/CoreDataStack/Entity/Mastodon/StatusEdit.swift
@@ -31,6 +31,9 @@ public final class StatusEdit: NSManagedObject {
     // sourcery: autoUpdatableObject, autoGenerateProperty
     @NSManaged public var spoilerText: String?
 
+    // sourcery: autoUpdatableObject, autoGenerateProperty
+    @NSManaged public var status: Status?
+
     // MARK: - AutoGenerateProperty
     // sourcery:inline:StatusEdit.AutoGenerateProperty
 
@@ -203,6 +206,11 @@ extension StatusEdit: AutoUpdatableObject {
     public func update(spoilerText: String?) {
     	if self.spoilerText != spoilerText {
     		self.spoilerText = spoilerText
+    	}
+    }
+    public func update(status: Status?) {
+    	if self.status != status {
+    		self.status = status
     	}
     }
     public func update(emojis: [MastodonEmoji]) {

--- a/MastodonSDK/Sources/MastodonExtension/AttributeContainer.swift
+++ b/MastodonSDK/Sources/MastodonExtension/AttributeContainer.swift
@@ -1,0 +1,17 @@
+// Copyright © 2023 Mastodon gGmbH. All rights reserved.
+
+import Foundation
+
+extension AttributeContainer {
+    public init<T>(_ attribute: WritableKeyPath<AttributeContainer, T>, value: T) {
+        self.init()
+        self[keyPath: attribute] = value
+    }
+
+    public init<T>(_ attribute: WritableKeyPath<AttributeContainer, T>, value: T?) {
+        self.init()
+        if let value {
+            self[keyPath: attribute] = value
+        }
+    }
+}

--- a/MastodonSDK/Sources/MastodonExtension/NSAccessibility.swift
+++ b/MastodonSDK/Sources/MastodonExtension/NSAccessibility.swift
@@ -1,0 +1,25 @@
+// Copyright © 2023 Mastodon gGmbH. All rights reserved.
+
+import UIKit
+
+extension NSObject {
+    @inlinable public var attributedAccessibilityLabel: AttributedString? {
+        get { accessibilityAttributedLabel.map(AttributedString.init) }
+        set { accessibilityAttributedLabel = newValue.map(NSAttributedString.init) }
+    }
+    
+    @inlinable public var attributedAccessibilityValue: AttributedString? {
+        get { accessibilityAttributedValue.map(AttributedString.init) }
+        set { accessibilityAttributedValue = newValue.map(NSAttributedString.init) }
+    }
+    
+    @inlinable public var attributedAccessibilityHint: AttributedString? {
+        get { accessibilityAttributedHint.map(AttributedString.init) }
+        set { accessibilityAttributedHint = newValue.map(NSAttributedString.init) }
+    }
+
+    @inlinable public var attributedAccessibilityUserInputLabels: [AttributedString]! {
+        get { accessibilityAttributedUserInputLabels?.map(AttributedString.init) }
+        set { accessibilityAttributedUserInputLabels = newValue?.map(NSAttributedString.init) }
+    }
+}

--- a/MastodonSDK/Sources/MastodonExtension/Sequence.swift
+++ b/MastodonSDK/Sources/MastodonExtension/Sequence.swift
@@ -1,0 +1,26 @@
+// Copyright © 2023 Mastodon gGmbH. All rights reserved.
+
+import Foundation
+
+extension Collection<AttributedString> {
+    // ref: https://github.com/apple/swift/blob/700bcb4e4b97da61517c8b8831c72015207612f9/stdlib/public/core/String.swift#L727-L750
+    @inlinable public func joined(separator: AttributedString = "") -> AttributedString {
+        var result: AttributedString = ""
+        if separator.characters.isEmpty {
+            for x in self {
+                result.append(x)
+            }
+            return result
+        }
+        
+        var iter = makeIterator()
+        if let first = iter.next() {
+            result.append(first)
+            while let next = iter.next() {
+                result.append(separator)
+                result.append(next)
+            }
+        }
+        return result
+    }
+}

--- a/MastodonSDK/Sources/MastodonUI/Protocol/StatusCompatible.swift
+++ b/MastodonSDK/Sources/MastodonUI/Protocol/StatusCompatible.swift
@@ -8,6 +8,7 @@ public protocol StatusCompatible {
     var attachments: [MastodonAttachment] { get }
     var isMediaSensitive: Bool { get }
     var isSensitiveToggled: Bool { get }
+    var language: String? { get }
 }
 
 extension Status: StatusCompatible {}
@@ -23,5 +24,9 @@ extension StatusEdit: StatusCompatible {
     
     public var isSensitiveToggled: Bool {
         true
+    }
+
+    public var language: String? {
+        status?.language
     }
 }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView+Configuration.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView+Configuration.swift
@@ -20,6 +20,7 @@ extension MediaView {
         var disposeBag = Set<AnyCancellable>()
         
         public let info: Info
+        public let language: String?
         public let blurhash: String?
         public let index: Int
         public let total: Int
@@ -31,11 +32,13 @@ extension MediaView {
         
         public init(
             info: MediaView.Configuration.Info,
+            language: String?,
             blurhash: String?,
             index: Int,
             total: Int
         ) {
             self.info = info
+            self.language = language
             self.blurhash = blurhash
             self.index = index
             self.total = total
@@ -203,6 +206,7 @@ extension MediaView {
                     )
                     return .init(
                         info: .image(info: info),
+                        language: status.language,
                         blurhash: attachment.blurhash,
                         index: idx,
                         total: attachments.count
@@ -211,6 +215,7 @@ extension MediaView {
                     let info = videoInfo(from: attachment)
                     return .init(
                         info: .video(info: info),
+                        language: status.language,
                         blurhash: attachment.blurhash,
                         index: idx,
                         total: attachments.count
@@ -219,6 +224,7 @@ extension MediaView {
                     let info = videoInfo(from: attachment)
                     return .init(
                         info: .gif(info: info),
+                        language: status.language,
                         blurhash: attachment.blurhash,
                         index: idx,
                         total: attachments.count
@@ -227,6 +233,7 @@ extension MediaView {
                     let info = videoInfo(from: attachment)
                     return .init(
                         info: .video(info: info),
+                        language: status.language,
                         blurhash: attachment.blurhash,
                         index: idx,
                         total: attachments.count

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -209,14 +209,29 @@ extension MediaView {
     }
     
     private func bindAlt(configuration: Configuration, altDescription: String?) {
+        let languageAttributes: AttributeContainer = {
+            var container = AttributeContainer()
+            if let language = configuration.language {
+                container.languageIdentifier = language
+            }
+            return container
+        }()
+                
         if configuration.total > 1 {
-            accessibilityLabel = L10n.Common.Controls.Status.Media.accessibilityLabel(
-                altDescription ?? "",
+            let placeholder = "<description>"
+            let labelString = L10n.Common.Controls.Status.Media.accessibilityLabel(
+                placeholder,
                 configuration.index + 1,
                 configuration.total
             )
+            var label = AttributedString(labelString)
+            label.replaceSubrange(
+                label.range(of: placeholder)!,
+                with: AttributedString(altDescription ?? "", attributes: languageAttributes)
+            )
+            self.attributedAccessibilityLabel = label
         } else {
-            accessibilityLabel = altDescription
+            self.attributedAccessibilityLabel = altDescription.map { AttributedString($0, attributes: languageAttributes) }
         }
 
         badgeViewController.rootView.altDescription = altDescription

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -209,13 +209,7 @@ extension MediaView {
     }
     
     private func bindAlt(configuration: Configuration, altDescription: String?) {
-        let languageAttributes: AttributeContainer = {
-            var container = AttributeContainer()
-            if let language = configuration.language {
-                container.languageIdentifier = language
-            }
-            return container
-        }()
+        let languageAttributes = AttributeContainer(\.languageIdentifier, value: configuration.language)
                 
         if configuration.total > 1 {
             let placeholder = "<description>"

--- a/MastodonSDK/Sources/MastodonUI/View/Content/NewsView+Configuration.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/NewsView+Configuration.swift
@@ -42,6 +42,7 @@ extension NewsView {
                 assetURL: link.image,
                 altDescription: nil
             )),
+            language: nil,
             blurhash: link.blurhash,
             index: 1,
             total: 1

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -798,7 +798,10 @@ extension StatusView.ViewModel {
             $isContentReveal,
             $spoilerContent,
             $content,
-            $language
+            Publishers.CombineLatest($language, $translatedFromLanguage)
+                .map { language, translatedFromLanguage in
+                    translatedFromLanguage != nil  ? nil : language
+                }
         )
         .map { isContentReveal, spoilerContent, content, language in
             var strings: [AttributedString] = []

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -111,8 +111,8 @@ extension StatusView {
         @Published public var filterContext: Mastodon.Entity.Filter.Context?
         @Published public var isFiltered = false
 
-        @Published public var groupedAccessibilityLabel = ""
-        @Published public var contentAccessibilityLabel = ""
+        @Published public var groupedAccessibilityLabel: AttributedString = ""
+        @Published public var contentAccessibilityLabel: AttributedString = ""
 
         let timestampUpdatePublisher = Timer.publish(every: 1.0, on: .main, in: .common)
             .autoconnect()
@@ -734,7 +734,7 @@ extension StatusView.ViewModel {
             $authorUsername,
             $timestampText
         )
-        .map { header, authorName, authorUsername, timestamp -> String? in
+        .map { header, authorName, authorUsername, timestamp -> String in
             var strings: [String?] = []
             
             switch header {
@@ -794,30 +794,38 @@ extension StatusView.ViewModel {
         .assign(to: \.accessibilityLabel, on: statusView.authorView)
         .store(in: &disposeBag)
 
-        Publishers.CombineLatest3(
+        Publishers.CombineLatest4(
             $isContentReveal,
             $spoilerContent,
-            $content
+            $content,
+            $language
         )
-        .map { isContentReveal, spoilerContent, content in
-            var strings: [String?] = []
+        .map { isContentReveal, spoilerContent, content, language in
+            var strings: [AttributedString] = []
             
+            let languageAttributes: AttributeContainer = {
+                var container = AttributeContainer()
+                container.languageIdentifier = language
+                return container
+            }()
+
             if let spoilerContent = spoilerContent, !spoilerContent.string.isEmpty {
-                strings.append(L10n.Common.Controls.Status.contentWarning)
-                strings.append(spoilerContent.string)
+                strings.append(AttributedString(L10n.Common.Controls.Status.contentWarning))
+                strings.append(AttributedString(spoilerContent.string, attributes: languageAttributes))
                 
                 // TODO: replace with "Tap to reveal"
-                strings.append(L10n.Common.Controls.Status.mediaContentWarning)
+                strings.append(AttributedString(L10n.Common.Controls.Status.mediaContentWarning))
             }
 
             if isContentReveal {
-                strings.append(statusView.contentMetaText.backedString)
+                strings.append(AttributedString(statusView.contentMetaText.backedString, attributes: languageAttributes))
             }
             
-            return strings.compactMap { $0 }.joined(separator: ", ")
+            return strings.joined(separator: ", ")
         }
+        .removeDuplicates()
         .assign(to: &$contentAccessibilityLabel)
-        
+
         $isContentReveal
             .map { isContentReveal in
                 isContentReveal ? L10n.Scene.Compose.Accessibility.enableContentWarning : L10n.Scene.Compose.Accessibility.disableContentWarning
@@ -829,13 +837,13 @@ extension StatusView.ViewModel {
         
         $contentAccessibilityLabel
             .sink { contentAccessibilityLabel in
-                statusView.spoilerOverlayView.accessibilityLabel = contentAccessibilityLabel
-                statusView.contentMetaText.textView.accessibilityLabel = contentAccessibilityLabel
+                statusView.spoilerOverlayView.attributedAccessibilityLabel = contentAccessibilityLabel
+                statusView.contentMetaText.textView.attributedAccessibilityLabel = contentAccessibilityLabel
             }
             .store(in: &disposeBag)
 
         let mediaAccessibilityLabel = $mediaViewConfigurations
-            .map { configurations -> String? in
+            .map { configurations in
                 let count = configurations.count
                 return L10n.Plural.Count.media(count)
             }
@@ -914,21 +922,23 @@ extension StatusView.ViewModel {
             mediaAccessibilityLabel
         )
         .map { author, content, translated, media in
-            var labels: [String?] = [content, translated, media]
+            var labels = [content]
+            if let translated {
+                labels.append(content)
+            }
+            labels.append(AttributedString(media))
 
             if statusView.style != .notification {
-                labels.insert(author, at: 0)
+                labels.insert(AttributedString(author), at: 0)
             }
 
-            return labels
-                .compactMap { $0 }
-                .joined(separator: ", ")
+            return labels.joined(separator: ", ")
         }
         .assign(to: &$groupedAccessibilityLabel)
         
         $groupedAccessibilityLabel
             .sink { accessibilityLabel in
-                statusView.accessibilityLabel = accessibilityLabel
+                statusView.attributedAccessibilityLabel = accessibilityLabel
             }
             .store(in: &disposeBag)
 

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -802,13 +802,7 @@ extension StatusView.ViewModel {
         )
         .map { isContentReveal, spoilerContent, content, language in
             var strings: [AttributedString] = []
-            
-            let languageAttributes: AttributeContainer = {
-                var container = AttributeContainer()
-                container.languageIdentifier = language
-                return container
-            }()
-
+            let languageAttributes = AttributeContainer(\.languageIdentifier, value: language)
             if let spoilerContent = spoilerContent, !spoilerContent.string.isEmpty {
                 strings.append(AttributedString(L10n.Common.Controls.Status.contentWarning))
                 strings.append(AttributedString(spoilerContent.string, attributes: languageAttributes))

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -811,7 +811,7 @@ extension StatusView.ViewModel {
             }
 
             if isContentReveal {
-                strings.append(content?.string)
+                strings.append(statusView.contentMetaText.backedString)
             }
             
             return strings.compactMap { $0 }.joined(separator: ", ")
@@ -830,6 +830,7 @@ extension StatusView.ViewModel {
         $contentAccessibilityLabel
             .sink { contentAccessibilityLabel in
                 statusView.spoilerOverlayView.accessibilityLabel = contentAccessibilityLabel
+                statusView.contentMetaText.textView.accessibilityLabel = contentAccessibilityLabel
             }
             .store(in: &disposeBag)
 


### PR DESCRIPTION
[builds on #880, feel free to merge just this one to get the changes from both]

This allows VoiceOver to dynamically switch voices based on the language a post was written in, without affecting the pronunciation of UI elements. For example, if reading a German post while the device is set to English, the English voice would read the username, date, “# media,” and “Actions available”, while the German voice would read the actual post content. This also applies to alt text (which inherits the language of the post).

It would be nice to also read people’s names and bios in the appropriate language, but that’s blocked on https://github.com/mastodon/mastodon/issues/23067 which I’ve just opened.