### PR TITLE
fix(Mention): Fixes an issue where user Profiles are not found because matching is not done via href

### DIFF
--- a/Mastodon/Protocol/Provider/DataSourceFacade+Profile.swift
+++ b/Mastodon/Protocol/Provider/DataSourceFacade+Profile.swift
@@ -66,15 +66,19 @@ extension DataSourceFacade {
     ) async {
         let domain = provider.authContext.mastodonAuthenticationBox.domain
         
-        let href = userInfo?["href"] as? String
-        guard let url = href.flatMap({ URL(string: $0) }) else { return }
+        guard
+            let href = userInfo?["href"] as? String,
+            let url = URL(string: href)
+        else {
+            return
+        }
     
         let managedObjectContext = provider.context.managedObjectContext
         let mentions = try? await managedObjectContext.perform {
             return status.object(in: managedObjectContext)?.mentions ?? []
         }
         
-        guard let mention = mentions?.first(where: { $0.username == mention }) else {
+        guard let mention = mentions?.first(where: { $0.url == href }) else {
             _  = await provider.coordinator.present(
                 scene: .safari(url: url),
                 from: provider,


### PR DESCRIPTION
## Expected Behavior
When tapping a username the profile screen should show up

## Actual Behavior
Currently, in some cases, Safari shows up

## Steps to Reproduce the Problem

* Using this link in Safari on iOS → https://macaw.social/@biz/109706104213039270
* Tap Share (Arrow up) and "Open using Mastodon"
* Then tap the username included in the post

## Fix:
* Implement href matching instead of trying to match the username