### PR TITLE
Use the website name and description in the card when available

### DIFF
--- a/MastodonSDK/Sources/CoreDataStack/Entity/Mastodon/Card.swift
+++ b/MastodonSDK/Sources/CoreDataStack/Entity/Mastodon/Card.swift
@@ -57,6 +57,17 @@ public final class Card: NSManagedObject {
 }
 
 extension Card {
+    public var websiteName: String? {
+        if let authorName, !authorName.isEmpty {
+            return authorName
+        } else if let host = url?.host {
+            return host
+        }
+        return nil
+    }
+}
+
+extension Card {
 
     @discardableResult
     public static func insert(

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
@@ -31,7 +31,7 @@ public final class StatusCardControl: UIControl {
     private let dividerView = UIView()
     private let imageView = UIImageView()
     private let titleLabel = UILabel()
-    private let linkLabel = UILabel()
+    private let siteNameLabel = UILabel()
     private lazy var showEmbedButton: UIButton = {
         var configuration = UIButton.Configuration.gray()
         configuration.background.visualEffect = UIBlurEffect(style: .systemUltraThinMaterial)
@@ -87,9 +87,9 @@ public final class StatusCardControl: UIControl {
         titleLabel.textColor = Asset.Colors.Label.primary.color
         titleLabel.font = .preferredFont(forTextStyle: .body)
 
-        linkLabel.numberOfLines = 1
-        linkLabel.textColor = Asset.Colors.Label.secondary.color
-        linkLabel.font = .preferredFont(forTextStyle: .subheadline)
+        siteNameLabel.numberOfLines = 1
+        siteNameLabel.textColor = Asset.Colors.Label.secondary.color
+        siteNameLabel.font = .preferredFont(forTextStyle: .subheadline)
 
         imageView.tintColor = Asset.Colors.Label.secondary.color
         imageView.contentMode = .scaleAspectFill
@@ -100,7 +100,7 @@ public final class StatusCardControl: UIControl {
         imageView.setContentCompressionResistancePriority(.zero, for: .vertical)
 
         labelStackView.addArrangedSubview(titleLabel)
-        labelStackView.addArrangedSubview(linkLabel)
+        labelStackView.addArrangedSubview(siteNameLabel)
         labelStackView.layoutMargins = .init(top: 10, left: 10, bottom: 10, right: 10)
         labelStackView.isLayoutMarginsRelativeArrangement = true
         labelStackView.axis = .vertical
@@ -139,14 +139,14 @@ public final class StatusCardControl: UIControl {
 
     public func configure(card: Card) {
         let title = card.title.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let host = card.url?.host {
-            accessibilityLabel = "\(title) \(host)"
+        if let websiteName = card.websiteName {
+            accessibilityLabel = "\(title) \(websiteName)"
         } else {
             accessibilityLabel = title
         }
 
         titleLabel.text = title
-        linkLabel.text = card.url?.host
+        siteNameLabel.text = card.websiteName
         imageView.contentMode = .center
 
         imageView.sd_setImage(

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
@@ -31,6 +31,7 @@ public final class StatusCardControl: UIControl {
     private let dividerView = UIView()
     private let imageView = UIImageView()
     private let titleLabel = UILabel()
+    private let descriptionLabel = UILabel()
     private let siteNameLabel = UILabel()
     private lazy var showEmbedButton: UIButton = {
         var configuration = UIButton.Configuration.gray()
@@ -85,7 +86,16 @@ public final class StatusCardControl: UIControl {
 
         titleLabel.numberOfLines = 2
         titleLabel.textColor = Asset.Colors.Label.primary.color
-        titleLabel.font = .preferredFont(forTextStyle: .body)
+        let descriptor = UIFont.preferredFont(forTextStyle: .body)
+            .fontDescriptor
+            .addingAttributes([.traits: [UIFontDescriptor.TraitKey.weight: UIFont.Weight.medium]])
+        titleLabel.font = UIFontMetrics(forTextStyle: .body)
+            .scaledFont(for: UIFont(descriptor: descriptor, size: descriptor.pointSize))
+        titleLabel.adjustsFontForContentSizeCategory = false
+        
+        descriptionLabel.numberOfLines = 2
+        descriptionLabel.textColor = Asset.Colors.Label.primary.color
+        descriptionLabel.font = .preferredFont(forTextStyle: .caption1)
 
         siteNameLabel.numberOfLines = 1
         siteNameLabel.textColor = Asset.Colors.Label.secondary.color
@@ -100,6 +110,7 @@ public final class StatusCardControl: UIControl {
         imageView.setContentCompressionResistancePriority(.zero, for: .vertical)
 
         labelStackView.addArrangedSubview(titleLabel)
+        labelStackView.addArrangedSubview(descriptionLabel)
         labelStackView.addArrangedSubview(siteNameLabel)
         labelStackView.layoutMargins = .init(top: 10, left: 10, bottom: 10, right: 10)
         labelStackView.isLayoutMarginsRelativeArrangement = true
@@ -146,6 +157,7 @@ public final class StatusCardControl: UIControl {
         }
 
         titleLabel.text = title
+        descriptionLabel.text = card.desc.trimmingCharacters(in: .whitespacesAndNewlines)
         siteNameLabel.text = card.websiteName
         imageView.contentMode = .center
 
@@ -208,6 +220,7 @@ public final class StatusCardControl: UIControl {
                     .constraint(lessThanOrEqualToConstant: 400),
             ]
             dividerConstraint = dividerView.heightAnchor.constraint(equalToConstant: pixelSize).activate()
+            descriptionLabel.isHidden = false
         case .compact:
             containerStackView.alignment = .center
             containerStackView.axis = .horizontal
@@ -219,6 +232,7 @@ public final class StatusCardControl: UIControl {
                 dividerView.heightAnchor.constraint(equalTo: containerStackView.heightAnchor),
             ]
             dividerConstraint = dividerView.widthAnchor.constraint(equalToConstant: pixelSize).activate()
+            descriptionLabel.isHidden = true
         }
 
         NSLayoutConstraint.activate(layoutConstraints)


### PR DESCRIPTION
This better matches what the web version does. The host is less important since you can usually see that from the text of the URL in the post.

<img width=390 src=https://user-images.githubusercontent.com/25517624/213818879-da88aba4-056d-4319-9547-d90f7452195d.jpeg> <img width=390 src=https://user-images.githubusercontent.com/25517624/213818928-fa111ede-7c96-4c04-9c52-0dc9d2f7e918.jpeg>
