### PR TITLE
Deprecation note for UIButton.setInsets(forContentPadding:imageTitlePadding:)

### DIFF
--- a/MastodonSDK/Sources/MastodonExtension/UIButton.swift
+++ b/MastodonSDK/Sources/MastodonExtension/UIButton.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 extension UIButton {
+    @available(iOS, deprecated: 15.0, message: "This method is ignored when using UIButtonConfiguration. The effect of this method can be replicated via UIButtonConfiguration.contentInset and UIButtonConfiguration.imagePadding.")
     public func setInsets(
         forContentPadding contentPadding: UIEdgeInsets,
         imageTitlePadding: CGFloat


### PR DESCRIPTION
### Problem

`UIButton.setInsets(forContentPadding:imageTitlePadding:)` hides the warnings about UIButton.contentEdgeInsets and UIButton.titleEdgeInsets. 

### Impact of the change

All uses of the function will be highlighted by Xcode. The developer will be informed that the function includes the deprecated API.