### PR TITLE
IOS-67: Add the “Header” and “Button” traits to the logo button

### DIFF
--- a/Mastodon/Scene/HomeTimeline/View/HomeTimelineNavigationBarTitleView.swift
+++ b/Mastodon/Scene/HomeTimeline/View/HomeTimelineNavigationBarTitleView.swift
@@ -62,6 +62,7 @@ extension HomeTimelineNavigationBarTitleView {
         button.addTarget(self, action: #selector(HomeTimelineNavigationBarTitleView.buttonDidPressed(_:)), for: .touchUpInside)
         
         logoButton.accessibilityIdentifier = "TitleButton"
+        logoButton.accessibilityTraits = [.header, .button]
         button.accessibilityIdentifier = "TitleButton"
     }
 }


### PR DESCRIPTION
I added the “header” and “button” traits but could not find a “label” trait. There is “[static text](https://developer.apple.com/documentation/uikit/uiaccessibilitytraits/1620206-statictext)” but that doesn’t feel appropriate for a button.

<img src=https://user-images.githubusercontent.com/25517624/217130773-e5a19eac-1cab-496d-8885-cf6663e75981.jpeg width=390>
