### PR TITLE
IOS-81: Make “Translated From” UI accessible

### DIFF
--- a/Localization/StringsConvertor/input/Base.lproj/app.json
+++ b/Localization/StringsConvertor/input/Base.lproj/app.json
@@ -186,7 +186,7 @@
                     "translated_from": "Translated from %s using %s",
                     "unknown_language": "Unknown",
                     "unknown_provider": "Unknown",
-                    "show_original": "Shown Original"
+                    "show_original": "Show Original"
                 },
                 "media": {
                     "accessibility_label": "%s, attachment %d of %d",

--- a/Localization/app.json
+++ b/Localization/app.json
@@ -186,7 +186,7 @@
                     "translated_from": "Translated from %s using %s",
                     "unknown_language": "Unknown",
                     "unknown_provider": "Unknown",
-                    "show_original": "Shown Original"
+                    "show_original": "Show Original"
                 },
                 "media": {
                     "accessibility_label": "%s, attachment %d of %d",

--- a/Mastodon/Scene/Share/View/TableviewCell/StatusThreadRootTableViewCell.swift
+++ b/Mastodon/Scene/Share/View/TableviewCell/StatusThreadRootTableViewCell.swift
@@ -108,6 +108,7 @@ extension StatusThreadRootTableViewCell {
                 statusView.viewModel.isContentReveal
                 ? statusView.contentMetaText.textView
                 : statusView.spoilerOverlayView,
+                statusView.translatedInfoView,
                 statusView.mediaGridContainerView,
                 statusView.pollTableView,
                 statusView.pollStatusStackView,

--- a/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
+++ b/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
@@ -391,8 +391,8 @@ public enum L10n {
           public static let url = L10n.tr("Localizable", "Common.Controls.Status.Tag.Url", fallback: "URL")
         }
         public enum Translation {
-          /// Shown Original
-          public static let showOriginal = L10n.tr("Localizable", "Common.Controls.Status.Translation.ShowOriginal", fallback: "Shown Original")
+          /// Show Original
+          public static let showOriginal = L10n.tr("Localizable", "Common.Controls.Status.Translation.ShowOriginal", fallback: "Show Original")
           /// Translated from %@ using %@
           public static func translatedFrom(_ p1: Any, _ p2: Any) -> String {
             return L10n.tr("Localizable", "Common.Controls.Status.Translation.TranslatedFrom", String(describing: p1), String(describing: p2), fallback: "Translated from %@ using %@")

--- a/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
+++ b/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
@@ -137,7 +137,7 @@ Please check your internet connection.";
 "Common.Controls.Status.Tag.Mention" = "Mention";
 "Common.Controls.Status.Tag.Url" = "URL";
 "Common.Controls.Status.TapToReveal" = "Tap to reveal";
-"Common.Controls.Status.Translation.ShowOriginal" = "Shown Original";
+"Common.Controls.Status.Translation.ShowOriginal" = "Show Original";
 "Common.Controls.Status.Translation.TranslatedFrom" = "Translated from %@ using %@";
 "Common.Controls.Status.Translation.UnknownLanguage" = "Unknown";
 "Common.Controls.Status.Translation.UnknownProvider" = "Unknown";

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -857,13 +857,14 @@ extension StatusView.ViewModel {
             }
             .store(in: &disposeBag)
 
-        Publishers.CombineLatest3(
+        Publishers.CombineLatest4(
             shortAuthorAccessibilityLabel,
             contentAccessibilityLabel,
+            translatedFromLabel,
             mediaAccessibilityLabel
         )
-        .map { author, content, media in
-            var labels: [String?] = [content, media]
+        .map { author, content, translated, media in
+            var labels: [String?] = [content, translated, media]
 
             if statusView.style != .notification {
                 labels.insert(author, at: 0)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -356,6 +356,18 @@ extension StatusView.ViewModel {
                 statusView.authorView.contentSensitiveeToggleButton.setImage(image, for: .normal)
             }
             .store(in: &disposeBag)
+
+        $isCurrentlyTranslating
+            .receive(on: DispatchQueue.main)
+            .sink { isTranslating in
+                switch isTranslating {
+                case true:
+                    statusView.isTranslatingLoadingView.startAnimating()
+                case false:
+                    statusView.isTranslatingLoadingView.stopAnimating()
+                }
+            }
+            .store(in: &disposeBag)
     }
     
     private func bindMedia(statusView: StatusView) {
@@ -820,7 +832,31 @@ extension StatusView.ViewModel {
             }
             .assign(to: \.toolbarActions, on: statusView)
             .store(in: &disposeBag)
-    
+
+        let translatedFromLabel = Publishers.CombineLatest($translatedFromLanguage, $translatedUsingProvider)
+            .map { (language, provider) -> String? in
+                if let language {
+                    return L10n.Common.Controls.Status.Translation.translatedFrom(
+                        Locale.current.localizedString(forIdentifier: language) ?? L10n.Common.Controls.Status.Translation.unknownLanguage,
+                        provider ?? L10n.Common.Controls.Status.Translation.unknownProvider
+                    )
+                }
+                return nil
+            }
+
+        translatedFromLabel
+            .receive(on: DispatchQueue.main)
+            .sink { label in
+                if let label {
+                    statusView.translatedInfoLabel.text = label
+                    statusView.translatedInfoView.accessibilityValue = label
+                    statusView.translatedInfoView.isHidden = false
+                } else {
+                    statusView.translatedInfoView.isHidden = true
+                }
+            }
+            .store(in: &disposeBag)
+
         Publishers.CombineLatest3(
             shortAuthorAccessibilityLabel,
             contentAccessibilityLabel,

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -190,7 +190,7 @@ public final class StatusView: UIView {
         activityIndicatorView.stopAnimating()
         return activityIndicatorView
     }()
-    private let translatedInfoLabel: UILabel = {
+    let translatedInfoLabel: UILabel = {
         let label = UILabel()
         label.font = UIFontMetrics(forTextStyle: .footnote).scaledFont(for: .systemFont(ofSize: 13, weight: .regular))
         label.textColor = Asset.Colors.Label.secondary.color
@@ -286,7 +286,6 @@ public final class StatusView: UIView {
         setPollDisplay(isDisplay: false)
         setFilterHintLabelDisplay(isDisplay: false)
         setStatusCardControlDisplay(isDisplay: false)
-        setupTranslationIndicator()
     }
 
     public override init(frame: CGRect) {
@@ -750,43 +749,6 @@ extension StatusView: MastodonMenuDelegate {
     public func menuAction(_ action: MastodonMenu.Action) {
         logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public)")
         delegate?.statusView(self, menuButton: authorView.menuButton, didSelectAction: action)
-    }
-}
-
-extension StatusView {
-    func setupTranslationIndicator() {
-        viewModel.$isCurrentlyTranslating
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] isTranslating in
-                switch isTranslating {
-                case true:
-                    self?.isTranslatingLoadingView.startAnimating()
-                case false:
-                    self?.isTranslatingLoadingView.stopAnimating()
-                }
-            }
-            .store(in: &disposeBag)
-
-        Publishers.CombineLatest(
-            viewModel.$translatedFromLanguage,
-            viewModel.$translatedUsingProvider
-        )
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] translatedFromLanguage, translatedUsingProvider in
-                guard let self = self else { return }
-                if let translatedFromLanguage = translatedFromLanguage {
-                    let label = L10n.Common.Controls.Status.Translation.translatedFrom(
-                        Locale.current.localizedString(forIdentifier: translatedFromLanguage) ?? L10n.Common.Controls.Status.Translation.unknownLanguage,
-                        translatedUsingProvider ?? L10n.Common.Controls.Status.Translation.unknownProvider
-                    )
-                    self.translatedInfoLabel.text = label
-                    self.translatedInfoView.accessibilityValue = label
-                    self.translatedInfoView.isHidden = false
-                } else {
-                    self.translatedInfoView.isHidden = true
-                }
-            }
-            .store(in: &disposeBag)
     }
 }
 

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -628,9 +628,18 @@ extension StatusView {
         get {
             (contentMetaText.textView.accessibilityCustomActions ?? [])
             + toolbarActions
+            + (hideTranslationAction.map { [$0] } ?? [])
             + (authorView.accessibilityCustomActions ?? [])
         }
         set { }
+    }
+
+    private var hideTranslationAction: UIAccessibilityCustomAction? {
+        guard viewModel.translatedFromLanguage != nil else { return nil }
+        return UIAccessibilityCustomAction(name: L10n.Common.Controls.Status.Translation.showOriginal) { [weak self] _ in
+            self?.revertTranslation()
+            return true
+        }
     }
 }
 


### PR DESCRIPTION
Fixes IOS-81.

- Added “Show Original” action in threads/feeds
- Added “Translated from X using Y” to the accessibility label in threads/feeds
- Added the “Translated from X using Y / Show Original” button as an accessibility action on the main post in a thread

<img width=250 src=https://user-images.githubusercontent.com/25517624/217136250-2f155800-a556-4f9b-bbda-dcb8bb43ed4c.PNG><img width=250 src=https://user-images.githubusercontent.com/25517624/217136252-824cff5e-e972-4497-8fa1-a7a41324534c.jpeg><img width=250 src=https://user-images.githubusercontent.com/25517624/217136256-8c74e7d0-8217-481b-863e-beec18c48c5b.jpeg>
