### PR TITLE
IOS-77: Improve accessibility of account rows in search results/recent searches

### DIFF
--- a/Mastodon/Scene/Search/SearchDetail/SearchHistory/Cell/SearchHistoryUserCollectionViewCell.swift
+++ b/Mastodon/Scene/Search/SearchDetail/SearchHistory/Cell/SearchHistoryUserCollectionViewCell.swift
@@ -54,6 +54,8 @@ extension SearchHistoryUserCollectionViewCell {
             contentView.trailingAnchor.constraint(equalTo: userView.trailingAnchor, constant: 16),
             userView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
         ])
+
+        userView.accessibilityTraits.insert(.button)
     }
     
     override func updateConfiguration(using state: UICellConfigurationState) {

--- a/Mastodon/Scene/Search/SearchDetail/SearchHistory/Cell/SearchHistoryUserCollectionViewCell.swift
+++ b/Mastodon/Scene/Search/SearchDetail/SearchHistory/Cell/SearchHistoryUserCollectionViewCell.swift
@@ -51,7 +51,7 @@ extension SearchHistoryUserCollectionViewCell {
         NSLayoutConstraint.activate([
             userView.topAnchor.constraint(equalTo: contentView.topAnchor),
             userView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
-            userView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: 16),
+            contentView.trailingAnchor.constraint(equalTo: userView.trailingAnchor, constant: 16),
             userView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
         ])
     }

--- a/Mastodon/Scene/Share/View/TableviewCell/UserTableViewCell.swift
+++ b/Mastodon/Scene/Share/View/TableviewCell/UserTableViewCell.swift
@@ -61,6 +61,8 @@ extension UserTableViewCell {
             separatorLine.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             separatorLine.heightAnchor.constraint(equalToConstant: UIView.separatorLineHeight(of: contentView)).priority(.required - 1),
         ])
+
+        userView.accessibilityTraits.insert(.button)
     }
     
 }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/UserView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/UserView+ViewModel.swift
@@ -52,14 +52,26 @@ extension UserView.ViewModel {
             }
             .store(in: &disposeBag)
         // username
-        $authorUsername
+        let displayUsername = $authorUsername
             .map { text -> String in
                 guard let text = text else { return "" }
                 return "@\(text)"
             }
+
+        displayUsername
             .sink { username in
                 let metaContent = PlaintextMetaContent(string: username)
                 userView.authorUsernameLabel.configure(content: metaContent)
+            }
+            .store(in: &disposeBag)
+
+        Publishers.CombineLatest($authorName, displayUsername)
+            .sink { name, username in
+                if let name {
+                    userView.accessibilityLabel = "\(name.string), \(username)"
+                } else {
+                    userView.accessibilityLabel = username
+                }
             }
             .store(in: &disposeBag)
     }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/UserView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/UserView.swift
@@ -90,6 +90,8 @@ extension UserView {
         avatarButton.isUserInteractionEnabled = false
         authorNameLabel.isUserInteractionEnabled = false
         authorUsernameLabel.isUserInteractionEnabled = false
+
+        isAccessibilityElement = true
     }
     
 }


### PR DESCRIPTION
Also fixes a layout issue that could cause clipping of very long display names / handles

<img src=https://user-images.githubusercontent.com/25517624/217141803-8a47e006-d433-4ee2-a3cf-8fa118165ce9.PNG width=390>
