### PR TITLE
IOS-73: Mark AvatarButton as an image

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Button/AvatarButton.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Button/AvatarButton.swift
@@ -36,6 +36,7 @@ open class AvatarButton: UIControl {
         
         isAccessibilityElement = true
         accessibilityLabel = L10n.Common.Controls.Status.showUserProfile
+        accessibilityTraits.insert(.image)
     }
     
     public override func layoutSubviews() {


### PR DESCRIPTION
VoiceOver now describes the avatar! “a person smiling and posing for a photo in front of a multicolored background” You can even swipe to access the “Explore Image” action and this UI shows up: (example: `@QasimRashid@mastodon.social`)

<img width=300 src=https://user-images.githubusercontent.com/25517624/217143192-443a8ff9-e21b-4404-b7ec-dc1211c3bd7a.jpeg>
