### PR TITLE
IOS-76: Improve accessibility of the About fields on profiles

### DIFF
--- a/Mastodon/Diffable/Profile/ProfileFieldSection.swift
+++ b/Mastodon/Diffable/Profile/ProfileFieldSection.swift
@@ -92,12 +92,17 @@ extension ProfileFieldSection {
                 formatter.dateStyle = .medium
                 formatter.timeStyle = .short
                 let dateString = formatter.string(from: verifiedAt)
-                cell.checkmark.accessibilityLabel = L10n.Scene.Profile.Fields.Verified.long(dateString)
+                let longLabel = L10n.Scene.Profile.Fields.Verified.long(dateString)
+                cell.checkmark.accessibilityLabel = longLabel
+                cell.accessibilityValue = "\(cell.valueMetaLabel.backedString), \(longLabel)"
                 cell.checkmarkPopoverString = L10n.Scene.Profile.Fields.Verified.short(dateString)
             } else {
                 cell.checkmark.isHidden = true
                 cell.checkmarkPopoverString = nil
+                cell.accessibilityValue = cell.valueMetaLabel.backedString
             }
+
+            cell.accessibilityLabel = cell.keyMetaLabel.backedString
 
             cell.delegate = configuration.profileFieldCollectionViewCellDelegate
         }

--- a/Mastodon/Scene/Profile/About/Cell/ProfileFieldCollectionViewCell.swift
+++ b/Mastodon/Scene/Profile/About/Cell/ProfileFieldCollectionViewCell.swift
@@ -13,7 +13,7 @@ import MastodonAsset
 import MastodonLocalization
 
 protocol ProfileFieldCollectionViewCellDelegate: AnyObject {
-    func profileFieldCollectionViewCell(_ cell: ProfileFieldCollectionViewCell, metaLebel: MetaLabel, didSelectMeta meta: Meta)
+    func profileFieldCollectionViewCell(_ cell: ProfileFieldCollectionViewCell, metaLabel: MetaLabel, didSelectMeta meta: Meta)
 }
 
 final class ProfileFieldCollectionViewCell: UICollectionViewCell {
@@ -151,7 +151,7 @@ extension ProfileFieldCollectionViewCell {
 extension ProfileFieldCollectionViewCell: MetaLabelDelegate {
     func metaLabel(_ metaLabel: MetaLabel, didSelectMeta meta: Meta) {
         os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
-        delegate?.profileFieldCollectionViewCell(self, metaLebel: metaLabel, didSelectMeta: meta)
+        delegate?.profileFieldCollectionViewCell(self, metaLabel: metaLabel, didSelectMeta: meta)
     }
 }
 

--- a/Mastodon/Scene/Profile/About/Cell/ProfileFieldCollectionViewCell.swift
+++ b/Mastodon/Scene/Profile/About/Cell/ProfileFieldCollectionViewCell.swift
@@ -107,6 +107,8 @@ extension ProfileFieldCollectionViewCell {
         
         keyMetaLabel.linkDelegate = self
         valueMetaLabel.linkDelegate = self
+
+        isAccessibilityElement = true
     }
     
     @objc public func didTapCheckmark(_ recognizer: UITapGestureRecognizer) {

--- a/Mastodon/Scene/Profile/About/Cell/ProfileFieldCollectionViewCell.swift
+++ b/Mastodon/Scene/Profile/About/Cell/ProfileFieldCollectionViewCell.swift
@@ -129,6 +129,40 @@ extension ProfileFieldCollectionViewCell {
             UIMenuController.shared.showMenu(from: checkmark, rect: checkmark.bounds)
         }
     }
+
+    private var valueMetas: [(title: String, Meta)] {
+        var result: [(title: String, Meta)] = []
+        valueMetaLabel.textStorage.enumerateAttribute(NSAttributedString.Key("MetaAttributeKey.meta"), in: NSMakeRange(0, valueMetaLabel.textStorage.length)) { value, range, _ in
+            if let value = value as? Meta {
+                result.append((valueMetaLabel.textStorage.string.substring(with: range), value))
+            }
+        }
+        return result
+    }
+
+    override func accessibilityActivate() -> Bool {
+        if let (_, meta) = valueMetas.first {
+            delegate?.profileFieldCollectionViewCell(self, metaLabel: valueMetaLabel, didSelectMeta: meta)
+            return true
+        }
+        return false
+    }
+
+    override var accessibilityCustomActions: [UIAccessibilityCustomAction]? {
+        get {
+            let valueMetas = valueMetas
+            if valueMetas.count < 2 { return nil }
+            return valueMetas.compactMap { title, meta in
+                guard let name = meta.accessibilityLabel else { return nil }
+                return UIAccessibilityCustomAction(name: name) { [weak self] _ in
+                    guard let self, let delegate = self.delegate else { return false }
+                    delegate.profileFieldCollectionViewCell(self, metaLabel: self.valueMetaLabel, didSelectMeta: meta)
+                    return true
+                }
+            }
+        }
+        set {}
+    }
 }
 
 // UIMenuController boilerplate

--- a/Mastodon/Scene/Profile/About/ProfileAboutViewController.swift
+++ b/Mastodon/Scene/Profile/About/ProfileAboutViewController.swift
@@ -144,8 +144,8 @@ extension ProfileAboutViewController: UICollectionViewDelegate {
 
 // MARK: - ProfileFieldCollectionViewCellDelegate
 extension ProfileAboutViewController: ProfileFieldCollectionViewCellDelegate {
-    func profileFieldCollectionViewCell(_ cell: ProfileFieldCollectionViewCell, metaLebel: MetaLabel, didSelectMeta meta: Meta) {
-        delegate?.profileAboutViewController(self, profileFieldCollectionViewCell: cell, metaLabel: metaLebel, didSelectMeta: meta)
+    func profileFieldCollectionViewCell(_ cell: ProfileFieldCollectionViewCell, metaLabel: MetaLabel, didSelectMeta meta: Meta) {
+        delegate?.profileAboutViewController(self, profileFieldCollectionViewCell: cell, metaLabel: metaLabel, didSelectMeta: meta)
     }
 }
 

--- a/MastodonSDK/Sources/MastodonUI/Extension/Meta+Accessibility.swift
+++ b/MastodonSDK/Sources/MastodonUI/Extension/Meta+Accessibility.swift
@@ -8,9 +8,9 @@
 import Meta
 import MastodonLocalization
 
-extension Meta.Entity {
-    var accessibilityCustomActionLabel: String? {
-        switch meta {
+extension Meta {
+    public var accessibilityLabel: String? {
+        switch self {
         case .url(_, trimmed: _, url: let url, userInfo: _):
             return L10n.Common.Controls.Status.MetaEntity.url(url)
         case .hashtag(_, hashtag: let hashtag, userInfo: _):

--- a/MastodonSDK/Sources/MastodonUI/Extension/MetaLabel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Extension/MetaLabel.swift
@@ -152,4 +152,18 @@ extension MetaLabel {
         ]
     }
 
+    public var backedString: String {
+        let string = textStorage.string
+        let nsString = NSMutableString(string: string)
+        textStorage.enumerateAttribute(
+            .attachment,
+            in: NSRange(location: 0, length: textStorage.length),
+            options: [.reverse])
+        { value, range, _ in
+            guard let attachment = value as? MetaAttachment else { return }
+            nsString.replaceCharacters(in: range, with: attachment.string)
+        }
+        return nsString as String
+    }
+
 }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -889,7 +889,7 @@ extension StatusView.ViewModel {
         .map { content, isRevealed in
             guard isRevealed, let entities = content?.entities else { return [] }
             return entities.compactMap { entity in
-                guard let name = entity.accessibilityCustomActionLabel else { return nil }
+                guard let name = entity.meta.accessibilityLabel else { return nil }
                 return UIAccessibilityCustomAction(name: name) { action in
                     statusView.delegate?.statusView(statusView, metaText: statusView.contentMetaText, didSelectMeta: entity.meta)
                     return true


### PR DESCRIPTION
Actioning the item will open the first link, and you can swipe through all of the links as secondary actions.

<img width=250 src=https://user-images.githubusercontent.com/25517624/217361705-e98ce7a0-c15f-4b19-b493-e21a7b35796f.jpeg><img width=250 src=https://user-images.githubusercontent.com/25517624/217361743-298ddae6-1981-4992-aa01-1c0cd1a000fe.jpeg><img width=250 src=https://user-images.githubusercontent.com/25517624/217362239-c0469e81-eab2-45c2-a886-e8cb0b2d1db9.jpeg>
