### PR TITLE
IOS-92: Enlarge post action buttons at larger text sizes

### DIFF
--- a/Mastodon/Protocol/Provider/DataSourceFacade+Status.swift
+++ b/Mastodon/Protocol/Provider/DataSourceFacade+Status.swift
@@ -135,11 +135,6 @@ extension DataSourceFacade {
                 provider: provider,
                 status: status
             )
-        case .bookmark:
-            try await DataSourceFacade.responseToStatusBookmarkAction(
-                provider: provider,
-                status: status
-            )
         case .share:
             try await DataSourceFacade.responseToStatusShareAction(
                 provider: provider,

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -558,7 +558,6 @@ extension StatusView.Style {
         // action toolbar
         statusView.actionToolbarAdaptiveMarginContainerView.contentView = statusView.actionToolbarContainer
         statusView.actionToolbarAdaptiveMarginContainerView.margin = StatusView.containerLayoutMargin
-        statusView.actionToolbarContainer.configure(for: .inline)
         statusView.containerStackView.addArrangedSubview(statusView.actionToolbarAdaptiveMarginContainerView)
         
         // filterHintLabel

--- a/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
@@ -64,6 +64,7 @@ extension ActionToolbarContainer {
         reblogButton.addTarget(self, action: #selector(ActionToolbarContainer.buttonDidPressed(_:)), for: .touchUpInside)
         favoriteButton.addTarget(self, action: #selector(ActionToolbarContainer.buttonDidPressed(_:)), for: .touchUpInside)
         shareButton.addTarget(self, action: #selector(ActionToolbarContainer.buttonDidPressed(_:)), for: .touchUpInside)
+        addInteraction(UILargeContentViewerInteraction())
 
         container.arrangedSubviews.forEach { subview in
             container.removeArrangedSubview(subview)
@@ -78,6 +79,7 @@ extension ActionToolbarContainer {
             button.setTitleColor(.secondaryLabel, for: .normal)
             button.expandEdgeInsets = UIEdgeInsets(top: -10, left: -10, bottom: -10, right: -10)
             button.setInsets(forContentPadding: .zero, imageTitlePadding: 4)
+            button.showsLargeContentViewer = true
         }
         // add more expand for menu button
         shareButton.expandEdgeInsets = UIEdgeInsets(top: -10, left: -20, bottom: -10, right: -20)

--- a/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
@@ -125,7 +125,6 @@ extension ActionToolbarContainer {
         case reply
         case reblog
         case like
-        case bookmark
         case share
     }
     

--- a/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
@@ -35,6 +35,8 @@ public final class ActionToolbarContainer: UIView {
     public weak var delegate: ActionToolbarContainerDelegate?
     
     private let container = UIStackView()
+    private let firstContainer = UIStackView()
+    private let secondContainer = UIStackView()
 
     public override init(frame: CGRect) {
         super.init(frame: frame)
@@ -59,18 +61,13 @@ extension ActionToolbarContainer {
             trailingAnchor.constraint(equalTo: container.trailingAnchor),
             bottomAnchor.constraint(equalTo: container.bottomAnchor),
         ])
-        
+
         replyButton.addTarget(self, action: #selector(ActionToolbarContainer.buttonDidPressed(_:)), for: .touchUpInside)
         reblogButton.addTarget(self, action: #selector(ActionToolbarContainer.buttonDidPressed(_:)), for: .touchUpInside)
         favoriteButton.addTarget(self, action: #selector(ActionToolbarContainer.buttonDidPressed(_:)), for: .touchUpInside)
         shareButton.addTarget(self, action: #selector(ActionToolbarContainer.buttonDidPressed(_:)), for: .touchUpInside)
         addInteraction(UILargeContentViewerInteraction())
 
-        container.arrangedSubviews.forEach { subview in
-            container.removeArrangedSubview(subview)
-            subview.removeFromSuperview()
-        }
-        
         let buttons = [replyButton, reblogButton, favoriteButton, shareButton]
         buttons.forEach { button in
             button.tintColor = Asset.Colors.Button.actionToolbar.color
@@ -100,16 +97,27 @@ extension ActionToolbarContainer {
         shareButton.setImage(ActionToolbarContainer.shareImage, for: .normal)
 
         container.axis = .horizontal
-        container.distribution = .equalSpacing
+        container.distribution = .fillEqually
 
         replyButton.translatesAutoresizingMaskIntoConstraints = false
         reblogButton.translatesAutoresizingMaskIntoConstraints = false
         favoriteButton.translatesAutoresizingMaskIntoConstraints = false
         shareButton.translatesAutoresizingMaskIntoConstraints = false
-        container.addArrangedSubview(replyButton)
-        container.addArrangedSubview(reblogButton)
-        container.addArrangedSubview(favoriteButton)
-        container.addArrangedSubview(shareButton)
+
+        firstContainer.addArrangedSubview(replyButton)
+        firstContainer.addArrangedSubview(reblogButton)
+        firstContainer.translatesAutoresizingMaskIntoConstraints = false
+        firstContainer.axis = .horizontal
+        firstContainer.distribution = .equalCentering
+        container.addArrangedSubview(firstContainer)
+
+        secondContainer.addArrangedSubview(favoriteButton)
+        secondContainer.addArrangedSubview(shareButton)
+        secondContainer.translatesAutoresizingMaskIntoConstraints = false
+        secondContainer.axis = .horizontal
+        secondContainer.distribution = .equalSpacing
+        container.addArrangedSubview(secondContainer)
+
         NSLayoutConstraint.activate([
             replyButton.heightAnchor.constraint(equalToConstant: 36).priority(.defaultHigh),
             replyButton.heightAnchor.constraint(equalTo: reblogButton.heightAnchor).priority(.defaultHigh),
@@ -120,6 +128,14 @@ extension ActionToolbarContainer {
         ])
         shareButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         shareButton.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+
+        traitCollectionDidChange(nil)
+    }
+
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        container.axis = traitCollection.preferredContentSizeCategory.isAccessibilityCategory ? .vertical : .horizontal
     }
 }
 

--- a/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
@@ -35,8 +35,7 @@ public final class ActionToolbarContainer: UIView {
     public weak var delegate: ActionToolbarContainerDelegate?
     
     private let container = UIStackView()
-    private var style: Style?
-        
+
     public override init(frame: CGRect) {
         super.init(frame: frame)
         _init()
@@ -65,14 +64,7 @@ extension ActionToolbarContainer {
         reblogButton.addTarget(self, action: #selector(ActionToolbarContainer.buttonDidPressed(_:)), for: .touchUpInside)
         favoriteButton.addTarget(self, action: #selector(ActionToolbarContainer.buttonDidPressed(_:)), for: .touchUpInside)
         shareButton.addTarget(self, action: #selector(ActionToolbarContainer.buttonDidPressed(_:)), for: .touchUpInside)
-    }
-    
-    public func configure(for style: Style) {
-        guard needsConfigure(for: style) else {
-            return
-        }
-        
-        self.style = style
+
         container.arrangedSubviews.forEach { subview in
             container.removeArrangedSubview(subview)
             subview.removeFromSuperview()
@@ -85,7 +77,7 @@ extension ActionToolbarContainer {
             button.setTitle("", for: .normal)
             button.setTitleColor(.secondaryLabel, for: .normal)
             button.expandEdgeInsets = UIEdgeInsets(top: -10, left: -10, bottom: -10, right: -10)
-            button.setInsets(forContentPadding: .zero, imageTitlePadding: style.buttonTitleImagePadding)
+            button.setInsets(forContentPadding: .zero, imageTitlePadding: 4)
         }
         // add more expand for menu button
         shareButton.expandEdgeInsets = UIEdgeInsets(top: -10, left: -20, bottom: -10, right: -20)
@@ -95,61 +87,36 @@ extension ActionToolbarContainer {
         favoriteButton.accessibilityLabel = L10n.Common.Controls.Status.Actions.favorite    // needs update to follow state
         shareButton.accessibilityLabel = L10n.Common.Controls.Actions.share
         
-        switch style {
-        case .inline:
-            buttons.forEach { button in
-                button.contentHorizontalAlignment = .leading
-            }
-            replyButton.setImage(ActionToolbarContainer.replyImage, for: .normal)
-            reblogButton.setImage(ActionToolbarContainer.reblogImage, for: .normal)
-            favoriteButton.setImage(ActionToolbarContainer.starImage, for: .normal)
-            shareButton.setImage(ActionToolbarContainer.shareImage, for: .normal)
-            
-            container.axis = .horizontal
-            container.distribution = .equalSpacing
-            
-            replyButton.translatesAutoresizingMaskIntoConstraints = false
-            reblogButton.translatesAutoresizingMaskIntoConstraints = false
-            favoriteButton.translatesAutoresizingMaskIntoConstraints = false
-            shareButton.translatesAutoresizingMaskIntoConstraints = false
-            container.addArrangedSubview(replyButton)
-            container.addArrangedSubview(reblogButton)
-            container.addArrangedSubview(favoriteButton)
-            container.addArrangedSubview(shareButton)
-            NSLayoutConstraint.activate([
-                replyButton.heightAnchor.constraint(equalToConstant: 36).priority(.defaultHigh),
-                replyButton.heightAnchor.constraint(equalTo: reblogButton.heightAnchor).priority(.defaultHigh),
-                replyButton.heightAnchor.constraint(equalTo: favoriteButton.heightAnchor).priority(.defaultHigh),
-                replyButton.heightAnchor.constraint(equalTo: shareButton.heightAnchor).priority(.defaultHigh),
-                replyButton.widthAnchor.constraint(equalTo: reblogButton.widthAnchor).priority(.defaultHigh),
-                replyButton.widthAnchor.constraint(equalTo: favoriteButton.widthAnchor).priority(.defaultHigh),
-            ])
-            shareButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-            shareButton.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-            
-        case .plain:
-            buttons.forEach { button in
-                button.contentHorizontalAlignment = .center
-            }
-            replyButton.setImage(ActionToolbarContainer.replyImage, for: .normal)
-            reblogButton.setImage(ActionToolbarContainer.reblogImage, for: .normal)
-            favoriteButton.setImage(ActionToolbarContainer.starImage, for: .normal)
-            
-            container.axis = .horizontal
-            container.spacing = 8
-            container.distribution = .fillEqually
-            
-            container.addArrangedSubview(replyButton)
-            container.addArrangedSubview(reblogButton)
-            container.addArrangedSubview(favoriteButton)
+        buttons.forEach { button in
+            button.contentHorizontalAlignment = .leading
         }
+        replyButton.setImage(ActionToolbarContainer.replyImage, for: .normal)
+        reblogButton.setImage(ActionToolbarContainer.reblogImage, for: .normal)
+        favoriteButton.setImage(ActionToolbarContainer.starImage, for: .normal)
+        shareButton.setImage(ActionToolbarContainer.shareImage, for: .normal)
+
+        container.axis = .horizontal
+        container.distribution = .equalSpacing
+
+        replyButton.translatesAutoresizingMaskIntoConstraints = false
+        reblogButton.translatesAutoresizingMaskIntoConstraints = false
+        favoriteButton.translatesAutoresizingMaskIntoConstraints = false
+        shareButton.translatesAutoresizingMaskIntoConstraints = false
+        container.addArrangedSubview(replyButton)
+        container.addArrangedSubview(reblogButton)
+        container.addArrangedSubview(favoriteButton)
+        container.addArrangedSubview(shareButton)
+        NSLayoutConstraint.activate([
+            replyButton.heightAnchor.constraint(equalToConstant: 36).priority(.defaultHigh),
+            replyButton.heightAnchor.constraint(equalTo: reblogButton.heightAnchor).priority(.defaultHigh),
+            replyButton.heightAnchor.constraint(equalTo: favoriteButton.heightAnchor).priority(.defaultHigh),
+            replyButton.heightAnchor.constraint(equalTo: shareButton.heightAnchor).priority(.defaultHigh),
+            replyButton.widthAnchor.constraint(equalTo: reblogButton.widthAnchor).priority(.defaultHigh),
+            replyButton.widthAnchor.constraint(equalTo: favoriteButton.widthAnchor).priority(.defaultHigh),
+        ])
+        shareButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        shareButton.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
     }
-    
-    private func needsConfigure(for style: Style) -> Bool {
-        guard let oldStyle = self.style else { return true }
-        return oldStyle != style
-    }
-    
 }
 
 extension ActionToolbarContainer {
@@ -160,18 +127,6 @@ extension ActionToolbarContainer {
         case like
         case bookmark
         case share
-    }
-    
-    public enum Style {
-        case inline
-        case plain
-        
-        var buttonTitleImagePadding: CGFloat {
-            switch self {
-            case .inline:       return 4.0
-            case .plain:        return 0
-            }
-        }
     }
     
     private func isReblogButtonHighlightStateDidChange(to isHighlight: Bool) {
@@ -302,9 +257,7 @@ struct ActionToolbarContainer_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             UIViewPreview(width: 300) {
-                let toolbar = ActionToolbarContainer()
-                toolbar.configure(for: .inline)
-                return toolbar
+                ActionToolbarContainer()
             }
             .previewLayout(.fixed(width: 300, height: 44))
             .previewDisplayName("Inline")

--- a/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
@@ -74,12 +74,14 @@ extension ActionToolbarContainer {
         let buttons = [replyButton, reblogButton, favoriteButton, shareButton]
         buttons.forEach { button in
             button.tintColor = Asset.Colors.Button.actionToolbar.color
-            button.titleLabel?.font = .monospacedDigitSystemFont(ofSize: 12, weight: .regular)
+            button.titleLabel?.font = UIFontMetrics(forTextStyle: .caption1)
+                .scaledFont(for: .monospacedDigitSystemFont(ofSize: 12, weight: .regular))
+            button.titleLabel?.adjustsFontForContentSizeCategory = true
             button.setTitle("", for: .normal)
             button.setTitleColor(.secondaryLabel, for: .normal)
             button.expandEdgeInsets = UIEdgeInsets(top: -10, left: -10, bottom: -10, right: -10)
             button.setInsets(forContentPadding: .zero, imageTitlePadding: 4)
-            button.showsLargeContentViewer = true
+            button.adjustsImageSizeForAccessibilityContentSizeCategory = true
         }
         // add more expand for menu button
         shareButton.expandEdgeInsets = UIEdgeInsets(top: -10, left: -20, bottom: -10, right: -20)


### PR DESCRIPTION
The share icon does not appear aligned with the boost button because the images are slightly different widths. ¯\\\_(ツ)\_/¯

<img width=250 src=https://user-images.githubusercontent.com/25517624/226140552-5dbe7787-da86-4f36-972a-3004864ef814.jpeg><img width=250 src=https://user-images.githubusercontent.com/25517624/226140553-f043787c-f723-4817-b681-90dea7554a73.jpeg><img width=250 src=https://user-images.githubusercontent.com/25517624/226140554-176ea91a-a003-4766-8fb6-af802711942f.jpeg><img width=250 src=https://user-images.githubusercontent.com/25517624/226140555-4ac7530d-dc18-4a87-8d7d-0a52f95999e9.jpeg><img width=250 src=https://user-images.githubusercontent.com/25517624/226140556-cac48d46-ca64-4a48-8f7f-e0fb224f0c64.jpeg><img width=250 src=https://user-images.githubusercontent.com/25517624/226140557-5e430bea-8375-4b7a-bfb7-af589d85f12b.jpeg>
