### PR TITLE
Change random server picking logic to require "general" category, prefer no approval and own language code

### DIFF
--- a/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewModel.swift
+++ b/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewModel.swift
@@ -247,7 +247,7 @@ extension MastodonPickServerViewModel {
         let languageMatchesWithoutApproval = noApprovalRequired.filter { $0.language.lowercased() == language }
         let languageMatchesWithApproval = approvalRequired.filter { $0.language.lowercased() == language }
         let languageDoesNotMatchWithoutApproval = noApprovalRequired.filter { $0.language.lowercased() != language }
-        let languageDoesNotMatchWithApproval = noApprovalRequired.filter { $0.language.lowercased() != language }
+        let languageDoesNotMatchWithApproval = approvalRequired.filter { $0.language.lowercased() != language }
 
         switch (
             languageMatchesWithoutApproval.isEmpty,

--- a/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewModel.swift
+++ b/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewModel.swift
@@ -235,9 +235,37 @@ extension MastodonPickServerViewModel {
         let servers = indexedServers.value
         guard servers.isNotEmpty else { return nil }
 
-        let randomServer = servers.filter {
-            $0.language.lowercased() == language
-        }.randomElement()
+        let generalServers = servers.filter {
+            $0.categories.contains("general")
+        }
+        
+        let randomServer: Mastodon.Entity.Server?
+        
+        let noApprovalRequired = generalServers.filter { !$0.approvalRequired }
+        let approvalRequired = generalServers.filter { $0.approvalRequired }
+        
+        let languageMatchesWithoutApproval = noApprovalRequired.filter { $0.language.lowercased() == language }
+        let languageMatchesWithApproval = approvalRequired.filter { $0.language.lowercased() == language }
+        let languageDoesNotMatchWithoutApproval = noApprovalRequired.filter { $0.language.lowercased() != language }
+        let langaugeDoesNotMatchWithApproval = noApprovalRequired.filter { $0.language.lowercased() != language }
+        
+        if languageMatchesWithoutApproval.isEmpty {
+            if languageMatchesWithApproval.isEmpty {
+                if languageDoesNotMatchWithoutApproval.isEmpty {
+                    if langaugeDoesNotMatchWithApproval.isEmpty {
+                        randomServer = generalServers.randomElement()
+                    } else {
+                        randomServer = langaugeDoesNotMatchWithApproval.randomElement()
+                    }
+                } else {
+                    randomServer = languageDoesNotMatchWithoutApproval.randomElement()
+                }
+            } else {
+                randomServer = languageMatchesWithApproval.randomElement()
+            }
+        } else {
+            randomServer = languageMatchesWithoutApproval.randomElement()
+        }
 
         return randomServer ?? servers.randomElement() ?? servers.first
     }

--- a/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewModel.swift
+++ b/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewModel.swift
@@ -248,22 +248,22 @@ extension MastodonPickServerViewModel {
         let languageMatchesWithApproval = approvalRequired.filter { $0.language.lowercased() == language }
         let languageDoesNotMatchWithoutApproval = noApprovalRequired.filter { $0.language.lowercased() != language }
         let langaugeDoesNotMatchWithApproval = noApprovalRequired.filter { $0.language.lowercased() != language }
-        
-        if languageMatchesWithoutApproval.isEmpty {
-            if languageMatchesWithApproval.isEmpty {
-                if languageDoesNotMatchWithoutApproval.isEmpty {
-                    if langaugeDoesNotMatchWithApproval.isEmpty {
-                        randomServer = generalServers.randomElement()
-                    } else {
-                        randomServer = langaugeDoesNotMatchWithApproval.randomElement()
-                    }
-                } else {
-                    randomServer = languageDoesNotMatchWithoutApproval.randomElement()
-                }
-            } else {
-                randomServer = languageMatchesWithApproval.randomElement()
-            }
-        } else {
+
+        switch (
+            languageMatchesWithoutApproval.isEmpty,
+            languageMatchesWithApproval.isEmpty,
+            languageDoesNotMatchWithoutApproval.isEmpty,
+            langaugeDoesNotMatchWithApproval.isEmpty
+        ) {
+        case (true, true, true, true):
+            randomServer = generalServers.randomElement()
+        case (true, true, true, false):
+            randomServer = langaugeDoesNotMatchWithApproval.randomElement()
+        case (true, true, false, _):
+            randomServer = languageDoesNotMatchWithoutApproval.randomElement()
+        case (true, false, _, _):
+            randomServer = languageMatchesWithApproval.randomElement()
+        case (false, _, _, _):
             randomServer = languageMatchesWithoutApproval.randomElement()
         }
 

--- a/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewModel.swift
+++ b/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewModel.swift
@@ -247,18 +247,18 @@ extension MastodonPickServerViewModel {
         let languageMatchesWithoutApproval = noApprovalRequired.filter { $0.language.lowercased() == language }
         let languageMatchesWithApproval = approvalRequired.filter { $0.language.lowercased() == language }
         let languageDoesNotMatchWithoutApproval = noApprovalRequired.filter { $0.language.lowercased() != language }
-        let langaugeDoesNotMatchWithApproval = noApprovalRequired.filter { $0.language.lowercased() != language }
+        let languageDoesNotMatchWithApproval = noApprovalRequired.filter { $0.language.lowercased() != language }
 
         switch (
             languageMatchesWithoutApproval.isEmpty,
             languageMatchesWithApproval.isEmpty,
             languageDoesNotMatchWithoutApproval.isEmpty,
-            langaugeDoesNotMatchWithApproval.isEmpty
+            languageDoesNotMatchWithApproval.isEmpty
         ) {
         case (true, true, true, true):
             randomServer = generalServers.randomElement()
         case (true, true, true, false):
-            randomServer = langaugeDoesNotMatchWithApproval.randomElement()
+            randomServer = languageDoesNotMatchWithApproval.randomElement()
         case (true, true, false, _):
             randomServer = languageDoesNotMatchWithoutApproval.randomElement()
         case (true, false, _, _):


### PR DESCRIPTION
# Rationale

The following logic is desired:

```
general purpose (must), instant sign-up (should), matching language (should)
```