### PR TITLE
Work around the hang due to infinite layout shifts

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel+DataSource.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel+DataSource.swift
@@ -37,6 +37,7 @@ extension ComposeContentViewModel {
         $contentCellFrame
             .map { $0.height }
             .removeDuplicates()
+            .throttle(for: 0.5, scheduler: RunLoop.main, latest: true)
             .sink { [weak self] height in
                 guard let self = self else { return }
                 guard !tableView.visibleCells.isEmpty else { return }

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/View/ComposeContentView.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/View/ComposeContentView.swift
@@ -83,6 +83,7 @@ public struct ComposeContentView: View {
                 authorView
                     .padding(.top, 14)
                     .padding(.horizontal, ComposeContentView.margin)
+                    .fixedSize(horizontal: false, vertical: true)
                 // content editor
                 MetaTextViewRepresentable(
                     string: $viewModel.content,


### PR DESCRIPTION
Ref: #705. I have been unable to ever reproduce this hang, but based on an Instruments trace that was sent to me it appears that `contentCellFrame` was changing repeatedly. Ideally we’d figure out why that is happening and get rid of it. That might require rewriting the table view in SwiftUI though (or maybe replacing the UITableView with a UIScrollView?)

This change does slightly regress the UI because hitting return twice in a row causes the UI to flicker but hitting it once doesn’t. Not sure if that’s ok or not.

What would be best is if someone could get the bug to repro on their device and trace back why the layout is changing.

I don’t know if this will fix the issue.