### PR TITLE
Improve the UX around post translation

### DIFF
--- a/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
+++ b/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
@@ -483,7 +483,7 @@ extension StatusTableViewCellDelegate where Self: DataSourceProvider & AuthConte
                 return
             }
             
-            if let cell = cell as? StatusTableViewCell {
+            if case .translateStatus = action {
                 DispatchQueue.main.async {
                     if let cell = cell as? StatusTableViewCell {
                         cell.statusView.viewModel.isCurrentlyTranslating = true

--- a/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
+++ b/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
@@ -486,6 +486,7 @@ extension StatusTableViewCellDelegate where Self: DataSourceProvider & AuthConte
             if let cell = cell as? StatusTableViewCell {
                 DispatchQueue.main.async {
                     cell.statusView.viewModel.isCurrentlyTranslating = true
+                    cell.invalidateIntrinsicContentSize()
                 }
             }
                         

--- a/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
+++ b/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
@@ -485,7 +485,11 @@ extension StatusTableViewCellDelegate where Self: DataSourceProvider & AuthConte
             
             if let cell = cell as? StatusTableViewCell {
                 DispatchQueue.main.async {
-                    cell.statusView.viewModel.isCurrentlyTranslating = true
+                    if let cell = cell as? StatusTableViewCell {
+                        cell.statusView.viewModel.isCurrentlyTranslating = true
+                    } else if let cell = cell as? StatusThreadRootTableViewCell {
+                        cell.statusView.viewModel.isCurrentlyTranslating = true
+                    }
                     cell.invalidateIntrinsicContentSize()
                 }
             }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -448,11 +448,13 @@ extension StatusView.Style {
 
         // status content
         statusView.contentContainer.addArrangedSubview(statusView.contentMetaText.textView)
-        statusView.contentContainer.addArrangedSubview(statusView.statusCardControl)
 
         // translated info
         statusView.containerStackView.addArrangedSubview(statusView.isTranslatingLoadingView)
         statusView.containerStackView.addArrangedSubview(statusView.translatedInfoView)
+
+        // link preview card
+        statusView.contentContainer.addArrangedSubview(statusView.statusCardControl)
 
         statusView.spoilerOverlayView.translatesAutoresizingMaskIntoConstraints = false
         statusView.containerStackView.addSubview(statusView.spoilerOverlayView)


### PR DESCRIPTION
- move the activity indicator above the link card (since the card is not translated)
- stop showing the activity indicator when selecting actions other than “Translate from X”
- show the activity indicator on the root cell of threads
- improve some layout issues