### PR TITLE
IOS-88: Use post content as the primary user input label for posts in feeds/threads

### DIFF
--- a/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCell.swift
+++ b/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCell.swift
@@ -86,7 +86,16 @@ extension StatusTableViewCell {
                 self.accessibilityLabel = accessibilityLabel
             }
             .store(in: &_disposeBag)
-        
+
+        statusView.viewModel.$contentAccessibilityLabel
+            .combineLatest(statusView.viewModel.$groupedAccessibilityLabel)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] contentLabel, accessibilityLabel in
+                guard let self = self else { return }
+                self.accessibilityUserInputLabels = [contentLabel, accessibilityLabel]
+            }
+            .store(in: &_disposeBag)
+
         statusView.viewModel
             .$translatedFromLanguage
             .receive(on: DispatchQueue.main)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -108,6 +108,7 @@ extension StatusView {
         @Published public var isFiltered = false
 
         @Published public var groupedAccessibilityLabel = ""
+        @Published public var contentAccessibilityLabel = ""
 
         let timestampUpdatePublisher = Timer.publish(every: 1.0, on: .main, in: .common)
             .autoconnect()
@@ -746,12 +747,12 @@ extension StatusView.ViewModel {
         .assign(to: \.accessibilityLabel, on: statusView.authorView)
         .store(in: &disposeBag)
 
-        let contentAccessibilityLabel = Publishers.CombineLatest3(
+        Publishers.CombineLatest3(
             $isContentReveal,
             $spoilerContent,
             $content
         )
-        .map { isContentReveal, spoilerContent, content -> String? in
+        .map { isContentReveal, spoilerContent, content in
             var strings: [String?] = []
             
             if let spoilerContent = spoilerContent, !spoilerContent.string.isEmpty {
@@ -768,6 +769,7 @@ extension StatusView.ViewModel {
             
             return strings.compactMap { $0 }.joined(separator: ", ")
         }
+        .assign(to: &$contentAccessibilityLabel)
         
         $isContentReveal
             .map { isContentReveal in
@@ -778,7 +780,7 @@ extension StatusView.ViewModel {
             }
             .store(in: &disposeBag)
         
-        contentAccessibilityLabel
+        $contentAccessibilityLabel
             .sink { contentAccessibilityLabel in
                 statusView.spoilerOverlayView.accessibilityLabel = contentAccessibilityLabel
             }
@@ -859,7 +861,7 @@ extension StatusView.ViewModel {
 
         Publishers.CombineLatest4(
             shortAuthorAccessibilityLabel,
-            contentAccessibilityLabel,
+            $contentAccessibilityLabel,
             translatedFromLabel,
             mediaAccessibilityLabel
         )


### PR DESCRIPTION
Previously it used the VoiceOver label which starts with the author.

<img width=390 src=https://user-images.githubusercontent.com/25517624/218123417-f0956076-c6ea-496a-913d-346f26ae13e1.jpeg>
