### PR TITLE
Fix Crash when publishing a new post

### DIFF
--- a/MastodonSDK/Sources/CoreDataStack/Extension/NSManagedObjectContext.swift
+++ b/MastodonSDK/Sources/CoreDataStack/Extension/NSManagedObjectContext.swift
@@ -35,7 +35,7 @@ extension NSManagedObjectContext {
     
     public func performChanges(block: @escaping () -> Void) -> Future<Result<Void, Error>, Never> {
         Future { promise in
-            self.perform {
+            self.performAndWait {
                 block()
                 do {
                     try self.saveOrRollback()
@@ -50,13 +50,13 @@ extension NSManagedObjectContext {
 
 extension NSManagedObjectContext {
     public func perform<T>(block: @escaping () throws -> T) async throws -> T {
-        return try await perform(schedule: .enqueued) {
+        return try performAndWait {
             try block()
         }
     }
     
     public func performChanges<T>(block: @escaping () throws -> T) async throws -> T {
-        return try await perform(schedule: .enqueued) {
+        return try performAndWait {
             let value = try block()
             try self.saveOrRollback()
             return value

--- a/MastodonSDK/Sources/CoreDataStack/Extension/NSManagedObjectContext.swift
+++ b/MastodonSDK/Sources/CoreDataStack/Extension/NSManagedObjectContext.swift
@@ -35,7 +35,7 @@ extension NSManagedObjectContext {
     
     public func performChanges(block: @escaping () -> Void) -> Future<Result<Void, Error>, Never> {
         Future { promise in
-            self.performAndWait {
+            self.perform {
                 block()
                 do {
                     try self.saveOrRollback()
@@ -50,13 +50,13 @@ extension NSManagedObjectContext {
 
 extension NSManagedObjectContext {
     public func perform<T>(block: @escaping () throws -> T) async throws -> T {
-        return try performAndWait {
+        return try await perform(schedule: .enqueued) {
             try block()
         }
     }
     
     public func performChanges<T>(block: @escaping () throws -> T) async throws -> T {
-        return try performAndWait {
+        return try await perform(schedule: .enqueued) {
             let value = try block()
             try self.saveOrRollback()
             return value

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
@@ -532,13 +532,11 @@ extension ComposeContentViewModel {
         
         // save language to recent languages
         if let settings = context.settingService.currentSetting.value {
-            Task.detached(priority: .background) { [language] in
-                try await settings.managedObjectContext?.performChanges {
-                    settings.recentLanguages = [language] + settings.recentLanguages.filter { $0 != language }
-                }
+            settings.managedObjectContext?.performAndWait {
+                settings.recentLanguages = [language] + settings.recentLanguages.filter { $0 != language }
             }
         }
-        
+
         return MastodonStatusPublisher(
             author: author,
             replyTo: {


### PR DESCRIPTION
 When posting a new status, the app crashed occasionally when `try save()` in NSManagedObjectContext.swift. It seemed that the instance of NSManagedObjectContext just ... disappeared? The error-message was: `EXC_BAD_INSTRUCTION (code=EXC_I386_INVOP, subcode=0x0)`

It's been pretty tricky to reproduce the buggy behaviour. What worked for me (most of the time) was to write a post, change the language and press "Publish".

(Probably) fixes:

- #940 
- #939
- https://c.im/@Onlineadviser/109831831469594094