### PR TITLE
Fix errors and some warnings when building with Swift 5.8

### DIFF
--- a/MastodonSDK/Package.resolved
+++ b/MastodonSDK/Package.resolved
@@ -73,15 +73,6 @@
       }
     },
     {
-      "identity" : "kingfisher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/onevcat/Kingfisher.git",
-      "state" : {
-        "revision" : "44e891bdb61426a95e31492a67c7c0dfad1f87c5",
-        "version" : "7.4.1"
-      }
-    },
-    {
       "identity" : "metatextkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/TwidereProject/MetaTextKit.git",
@@ -214,15 +205,6 @@
       "state" : {
         "revision" : "4a4f7c755b875ffd4f9ef10d67a67883669d2465",
         "version" : "2.13.0"
-      }
-    },
-    {
-      "identity" : "thirdpartymailer",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vtourraine/ThirdPartyMailer.git",
-      "state" : {
-        "revision" : "44c1cfaa6969963f22691aa67f88a69e3b6d651f",
-        "version" : "2.1.0"
       }
     },
     {

--- a/MastodonSDK/Sources/CoreDataStack/CoreDataStack.swift
+++ b/MastodonSDK/Sources/CoreDataStack/CoreDataStack.swift
@@ -8,7 +8,7 @@
 import os
 import Foundation
 import Combine
-import CoreData
+@_exported import CoreData
 import MastodonCommon
 
 public final class CoreDataStack {

--- a/MastodonSDK/Sources/MastodonCore/Service/PublisherService/StatusPublisher.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/PublisherService/StatusPublisher.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Combine
 
 public protocol StatusPublisher: ProgressReporting {
     var state: Published<StatusPublisherState>.Publisher { get }

--- a/MastodonSDK/Sources/MastodonExtension/Collection.swift
+++ b/MastodonSDK/Sources/MastodonExtension/Collection.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 // https://gist.github.com/DougGregor/92a2e4f6e11f6d733fb5065e9d1c880f
-extension Collection {
-    public func parallelMap<T>(
+extension Collection where Self: Sendable, Index: Sendable {
+    public func parallelMap<T: Sendable>(
         parallelism requestedParallelism: Int? = nil,
-        _ transform: @escaping (Element) async throws -> T
+        _ transform: @escaping @Sendable (Element) async throws -> T
     ) async rethrows -> [T] {
         let defaultParallelism = 2
         let parallelism = requestedParallelism ?? defaultParallelism
@@ -57,7 +57,7 @@ extension Collection {
 
     func parallelEach(
         parallelism requestedParallelism: Int? = nil,
-        _ work: @escaping (Element) async throws -> Void
+        _ work: @escaping @Sendable (Element) async throws -> Void
     ) async rethrows {
         _ = try await parallelMap {
             try await work($0)

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Account.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Account.swift
@@ -17,7 +17,7 @@ extension Mastodon.Entity {
     ///   2021/1/28
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/account/)
-    public class Account: Codable {
+    public final class Account: Codable, Sendable {
         
         public typealias ID = String
 

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Activity.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Activity.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2021/1/28
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/activity/)
-    public struct Activity: Codable {
+    public struct Activity: Codable, Sendable {
         public let week: Date
         public let statuses: Int
         public let logins: Int

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Announcement.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Announcement.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2021/1/28
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/announcement/)
-    public struct Announcement: Codable {
+    public struct Announcement: Codable, Sendable {
         
         public typealias ID = String
         

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+AnnouncementReaction.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+AnnouncementReaction.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2021/1/28
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/announcementreaction/)
-    public struct AnnouncementReaction: Codable {
+    public struct AnnouncementReaction: Codable, Sendable {
         // Base
         public let name: String
         public let count: Int

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Application.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Application.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2021/1/28
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/application/)
-    public struct Application: Codable {
+    public struct Application: Codable, Sendable {
 
         public let name: String
 

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Attachment.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Attachment.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2021/1/28
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/attachment/)
-    public struct Attachment: Codable {
+    public struct Attachment: Codable, Sendable {
         
         public typealias ID = String
         
@@ -48,7 +48,7 @@ extension Mastodon.Entity {
 
 extension Mastodon.Entity.Attachment {
     public typealias AttachmentType = Type
-    public enum `Type`: RawRepresentable, Codable {
+    public enum `Type`: RawRepresentable, Codable, Sendable {
         case unknown
         case image
         case gifv
@@ -85,7 +85,7 @@ extension Mastodon.Entity.Attachment {
 extension Mastodon.Entity.Attachment {
     /// # Reference
     ///   https://github.com/tootsuite/mastodon/blob/v3.3.0/app/models/media_attachment.rb
-    public struct Meta: Codable {
+    public struct Meta: Codable, Sendable {
         public let original: Format?
         public let small: Format?
         public let focus: Focus?
@@ -122,7 +122,7 @@ extension Mastodon.Entity.Attachment {
 }
 
 extension Mastodon.Entity.Attachment.Meta {
-    public struct Format: Codable {
+    public struct Format: Codable, Sendable {
         public let width: Int?
         public let height: Int?
         public let size: String?
@@ -142,7 +142,7 @@ extension Mastodon.Entity.Attachment.Meta {
         }
     }
     
-    public struct Focus: Codable {
+    public struct Focus: Codable, Sendable {
         public let x: Double
         public let y: Double
     }

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Card.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Card.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2021/1/28
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/card/)
-    public struct Card: Codable {
+    public struct Card: Codable, Sendable {
         // Base
         public let url: String
         public let title: String
@@ -54,7 +54,7 @@ extension Mastodon.Entity {
 }
 
 extension Mastodon.Entity.Card {
-    public enum `Type`: RawRepresentable, Codable {
+    public enum `Type`: RawRepresentable, Codable, Sendable {
         case link
         case photo
         case video

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Category.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Category.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension Mastodon.Entity {
 
-    public struct Category: Codable {
+    public struct Category: Codable, Sendable {
         public let category: Kind
         public let serversCount: Int
 
@@ -25,7 +25,7 @@ extension Mastodon.Entity {
         
         /// # Reference
         ///   https://joinmastodon.org/communities
-        public enum Kind: RawRepresentable, Codable {
+        public enum Kind: RawRepresentable, Codable, Sendable {
             
             case general
             case regional

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Context.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Context.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2021/1/28
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/context/)
-    public struct Context: Codable {
+    public struct Context: Codable, Sendable {
         public let ancestors: [Status]
         public let descendants: [Status]
     }

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Emoji.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Emoji.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2021/1/28
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/emoji/)
-    public struct Emoji: Codable {
+    public struct Emoji: Codable, Sendable {
         public let shortcode: String
         public let url: String
         public let staticURL: String

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+FamiliarFollowers.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+FamiliarFollowers.swift
@@ -17,7 +17,7 @@ extension Mastodon.Entity {
     ///   2022/5/16
     /// # Reference
     ///  [Document](TBD)
-    public class FamiliarFollowers: Codable {
+    public class FamiliarFollowers: Codable, Sendable {
         public let id: Mastodon.Entity.Account.ID
         public let accounts: [Mastodon.Entity.Account]
     }

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Field.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Field.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2021/1/28
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/field/)
-    public struct Field: Codable {
+    public struct Field: Codable, Sendable {
         public let name: String
         public let value: String
         

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+History.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+History.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2021/1/28
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/history/)
-    public struct History: Codable {
+    public struct History: Codable, Sendable {
         /// UNIX timestamp on midnight of the given day
         public let day: Date
         public let uses: String

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Link.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Link.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2022/4/13
     /// # Reference
     ///  [Document](TBD)
-    public struct Link: Codable {
+    public struct Link: Codable, Sendable {
         public let url: String
         public let title: String
         public let description: String

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Mention.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Mention.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2021/1/28
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/mention/)
-    public struct Mention: Codable {
+    public struct Mention: Codable, Sendable {
         
         public typealias ID = String
         

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Notification.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Notification.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2021/1/29
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/notification/)
-    public struct Notification: Codable {
+    public struct Notification: Codable, Sendable {
         public typealias ID = String
         
         public let id: ID
@@ -38,7 +38,7 @@ extension Mastodon.Entity {
 
 extension Mastodon.Entity.Notification {
     public typealias NotificationType = Type
-    public enum `Type`: RawRepresentable, Codable {
+    public enum `Type`: RawRepresentable, Codable, Sendable {
         case follow
         case followRequest
         case mention

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Poll.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Poll.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2021/2/24
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/poll/)
-    public struct Poll: Codable {
+    public struct Poll: Codable, Sendable {
         public typealias ID = String
         
         public let id: ID
@@ -47,7 +47,7 @@ extension Mastodon.Entity {
 }
 
 extension Mastodon.Entity.Poll {
-    public struct Option: Codable {
+    public struct Option: Codable, Sendable {
         public let title: String
         /// nil if results are not published yet
         public let votesCount: Int?

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Relationship.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Relationship.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2021/1/29
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/relationship/)
-    public struct Relationship: Codable {
+    public struct Relationship: Codable, Sendable {
         public typealias ID = String
         
         public let id: ID

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+SearchResult.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+SearchResult.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 extension Mastodon.Entity {
-    public struct SearchResult: Codable {
+    public struct SearchResult: Codable, Sendable {
         public init(accounts: [Mastodon.Entity.Account], statuses: [Mastodon.Entity.Status], hashtags: [Mastodon.Entity.Tag]) {
             self.accounts = accounts
             self.statuses = statuses

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Source.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Source.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2021/2/3
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/source/)
-    public struct Source: Codable {
+    public struct Source: Codable, Sendable {
         
         // Base
         public let note: String
@@ -40,7 +40,7 @@ extension Mastodon.Entity {
 }
 
 extension Mastodon.Entity.Source {
-    public enum Privacy: RawRepresentable, Codable {
+    public enum Privacy: RawRepresentable, Codable, Sendable {
         case `public`
         case unlisted
         case `private`

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Status.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Status.swift
@@ -17,7 +17,7 @@ extension Mastodon.Entity {
     ///   2021/2/23
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/status/)
-    public class Status: Codable {
+    public final class Status: Codable, Sendable {
         
         public typealias ID = String
 
@@ -102,7 +102,7 @@ extension Mastodon.Entity {
 }
 
 extension Mastodon.Entity.Status {
-    public enum Visibility: RawRepresentable, Codable, Hashable {
+    public enum Visibility: RawRepresentable, Codable, Hashable, Sendable {
         case `public`
         case unlisted
         case `private`

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Subscription.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Subscription.swift
@@ -64,7 +64,7 @@ extension Mastodon.Entity {
         }
     }
     
-    public struct EmptySubscription: Codable {
+    public struct EmptySubscription: Codable, Sendable {
         
     }
 }

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Suggestion.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Suggestion.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension Mastodon.Entity.V2 {
 
-    public struct SuggestionAccount: Codable {
+    public struct SuggestionAccount: Codable, Sendable {
 
         public let source: String
         public let account: Mastodon.Entity.Account

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Tag.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Tag.swift
@@ -16,7 +16,7 @@ extension Mastodon.Entity {
     ///   2022/11/22
     /// # Reference
     ///  [Document](https://docs.joinmastodon.org/entities/tag/)
-    public struct Tag: Hashable, Codable {
+    public struct Tag: Hashable, Codable, Sendable {
         
         // Base
         public let name: String

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Translation.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Translation.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Mastodon.Entity {
-    public struct Translation: Codable {
+    public struct Translation: Codable, Sendable {
         public let content: String?
         public let sourceLanguage: String?
         public let provider: String?

--- a/MastodonSDK/Sources/MastodonSDK/Response/Mastodon+Response+Content.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Response/Mastodon+Response+Content.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Mastodon.Response {
-    public struct Content<T> {
+    public struct Content<T: Sendable>: Sendable {
         
         // entity
         public let value: T
@@ -67,7 +67,7 @@ extension Mastodon.Response.Content {
 }
 
 extension Mastodon.Response {
-    public struct RateLimit {
+    public struct RateLimit: Sendable {
         
         public let limit: Int
         public let remaining: Int
@@ -103,7 +103,7 @@ extension Mastodon.Response {
 }
 
 extension Mastodon.Response {
-    public struct Link {
+    public struct Link: Sendable {
         public let maxID: Mastodon.Entity.Status.ID?
         public let minID: Mastodon.Entity.Status.ID?
         public let linkIDs: [String: Mastodon.Entity.Status.ID]

--- a/MastodonSDK/Sources/MastodonUI/Extension/CGSize+Hashable.swift
+++ b/MastodonSDK/Sources/MastodonUI/Extension/CGSize+Hashable.swift
@@ -5,7 +5,7 @@
 //  Created by Jed Fox on 2022-12-20.
 //
 
-import Foundation
+import CoreGraphics
 
 extension CGSize: Hashable {
     public func hash(into hasher: inout Hasher) {

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentViewModel.swift
@@ -9,6 +9,7 @@ import os.log
 import UIKit
 import Combine
 import PhotosUI
+import MastodonSDK
 import MastodonCore
 import MastodonLocalization
 import func QuartzCore.CACurrentMediaTime

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Poll/PollAddOptionRow.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Poll/PollAddOptionRow.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import MastodonAsset
 import MastodonCore
+import Combine
 
 public struct PollAddOptionRow: View {
  

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Publisher/MastodonStatusPublisher.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Publisher/MastodonStatusPublisher.swift
@@ -7,6 +7,7 @@
 
 import os.log
 import Foundation
+import Combine
 import CoreData
 import CoreDataStack
 import MastodonCore

--- a/MastodonSDK/Sources/MastodonUI/View/Button/CircleAvatarButton.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Button/CircleAvatarButton.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 public final class CircleAvatarButton: AvatarButton {
     

--- a/WidgetExtension/Variants/FollowersCount/FollowersCountWidgetView.swift
+++ b/WidgetExtension/Variants/FollowersCount/FollowersCountWidgetView.swift
@@ -40,14 +40,12 @@ struct FollowersCountWidgetView: View {
     private func viewForSmallWidgetNoChart(_ account: FollowersEntryAccountable) -> some View {
         HStack {
             VStack(alignment: .leading, spacing: 0) {
-                if let avatarImage = account.avatarImage {
-                    Image(uiImage: avatarImage)
-                        .resizable()
-                        .frame(width: 50, height: 50)
-                        .cornerRadius(12)
-                        .padding(.bottom, 8)
-                }
-                
+                Image(uiImage: account.avatarImage)
+                    .resizable()
+                    .frame(width: 50, height: 50)
+                    .cornerRadius(12)
+                    .padding(.bottom, 8)
+
                 Text(account.followersCount.asAbbreviatedCountString())
                     .font(.largeTitle)
                     .lineLimit(1)
@@ -73,12 +71,10 @@ struct FollowersCountWidgetView: View {
     private func viewForSmallWidgetYesChart(_ account: FollowersEntryAccountable) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
-                if let avatarImage = account.avatarImage {
-                    Image(uiImage: avatarImage)
-                        .resizable()
-                        .frame(width: 23, height: 23)
-                        .cornerRadius(5)
-                }
+                Image(uiImage: account.avatarImage)
+                    .resizable()
+                    .frame(width: 23, height: 23)
+                    .cornerRadius(5)
                 VStack(alignment: .leading) {
                     Text(account.displayNameWithFallback)
                         .font(.caption)

--- a/WidgetExtension/Variants/LatestFollowers/LatestFollowersWidgetView.swift
+++ b/WidgetExtension/Variants/LatestFollowers/LatestFollowersWidgetView.swift
@@ -44,12 +44,10 @@ struct LatestFollowersWidgetView: View {
             
             ForEach(accounts, id: \.acct) { account in
                 HStack {
-                    if let avatarImage = account.avatarImage {
-                        Image(uiImage: avatarImage)
-                            .resizable()
-                            .frame(width: 32, height: 32)
-                            .cornerRadius(5)
-                    }
+                    Image(uiImage: account.avatarImage)
+                        .resizable()
+                        .frame(width: 32, height: 32)
+                        .cornerRadius(5)
                     VStack(alignment: .leading) {
                         
                     Text(account.displayNameWithFallback)
@@ -87,12 +85,10 @@ struct LatestFollowersWidgetView: View {
             
             ForEach(accounts, id: \.acct) { account in
                 HStack {
-                    if let avatarImage = account.avatarImage {
-                        Image(uiImage: avatarImage)
-                            .resizable()
-                            .frame(width: 32, height: 32)
-                            .cornerRadius(5)
-                    }
+                    Image(uiImage: account.avatarImage)
+                        .resizable()
+                        .frame(width: 32, height: 32)
+                        .cornerRadius(5)
                     VStack(alignment: .leading) {
                         
                         HStack {

--- a/WidgetExtension/Variants/MultiFollowersCount/MultiFollowersCountWidgetView.swift
+++ b/WidgetExtension/Variants/MultiFollowersCount/MultiFollowersCountWidgetView.swift
@@ -32,12 +32,10 @@ struct MultiFollowersCountWidgetView: View {
         VStack(alignment: .leading, spacing: 0) {
             ForEach(accounts, id: \.acct) { account in
                 HStack {
-                    if let avatarImage = account.avatarImage {
-                        Image(uiImage: avatarImage)
-                            .resizable()
-                            .frame(width: 32, height: 32)
-                            .cornerRadius(5)
-                    }
+                    Image(uiImage: account.avatarImage)
+                        .resizable()
+                        .frame(width: 32, height: 32)
+                        .cornerRadius(5)
                     VStack(alignment: .leading) {
                         Text(account.followersCount.asAbbreviatedCountString())
                             .font(.title2)
@@ -67,12 +65,10 @@ struct MultiFollowersCountWidgetView: View {
             ]) {
                 ForEach(accounts, id: \.acct) { account in
                     HStack {
-                        if let avatarImage = account.avatarImage {
-                            Image(uiImage: avatarImage)
-                                .resizable()
-                                .frame(width: 32, height: 32)
-                                .cornerRadius(5)
-                        }
+                        Image(uiImage: account.avatarImage)
+                            .resizable()
+                            .frame(width: 32, height: 32)
+                            .cornerRadius(5)
                         VStack(alignment: .leading) {
                             Text(account.followersCount.asAbbreviatedCountString())
                                 .font(.title2)


### PR DESCRIPTION
Warnings with just f268bcd3e: 282
Adding 557c2f870 & df8eb942f: 261
Adding a3b36f710 & 887e619d0: 245

There are a bunch more things that need to be sorted out around Sendable, but hoepfully we can chip away at them slowly (and also hopefully Apple will mark more APIs as Sendable too)