### PR TITLE
IOS-70: Improve StatusMetricView Accessibility

### DIFF
--- a/Mastodon/Scene/Share/View/TableviewCell/StatusThreadRootTableViewCell.swift
+++ b/Mastodon/Scene/Share/View/TableviewCell/StatusThreadRootTableViewCell.swift
@@ -112,8 +112,8 @@ extension StatusThreadRootTableViewCell {
                 statusView.mediaGridContainerView,
                 statusView.pollTableView,
                 statusView.pollStatusStackView,
-                statusView.actionToolbarContainer
-                // statusMetricView is intentionally excluded
+                statusView.actionToolbarContainer,
+                statusView.statusMetricView,
             ]
             
             if statusView.viewModel.isContentReveal {

--- a/MastodonSDK/Sources/MastodonAsset/Assets.xcassets/Colors/Label/tertiary.colorset/Contents.json
+++ b/MastodonSDK/Sources/MastodonAsset/Assets.xcassets/Colors/Label/tertiary.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.300",
+          "blue" : "0.737",
+          "green" : "0.765",
+          "red" : "0.765"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusMetricRowView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusMetricRowView.swift
@@ -51,6 +51,8 @@ public final class StatusMetricRowView: UIButton {
         addSubview(contentStack)
         addSubview(chevron)
 
+        accessibilityTraits.insert(.button)
+
         setupConstraints()
     }
 
@@ -115,5 +117,15 @@ public final class StatusMetricRowView: UIButton {
                 backgroundColor = .clear
             }
         }
+    }
+
+    public override var accessibilityLabel: String? {
+        get { textLabel.text }
+        set {}
+    }
+
+    public override var accessibilityValue: String? {
+        get { detailLabel.text }
+        set {}
     }
 }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusMetricRowView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusMetricRowView.swift
@@ -78,6 +78,7 @@ public final class StatusMetricRowView: UIButton {
                 detailLabel.topAnchor.constraint(equalTo: textLabel.bottomAnchor, constant: 8),
                 bottomAnchor.constraint(equalTo: detailLabel.bottomAnchor, constant: 11),
 
+                chevron.leadingAnchor.constraint(greaterThanOrEqualTo: textLabel.trailingAnchor, constant: 12),
                 chevron.leadingAnchor.constraint(greaterThanOrEqualTo: detailLabel.trailingAnchor, constant: 12),
             ]
         } else {

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusMetricRowView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusMetricRowView.swift
@@ -9,7 +9,8 @@ public final class StatusMetricRowView: UIButton {
     let detailLabel: UILabel
     let chevron: UIImageView
 
-    private let contentStack: UIStackView
+    private var disposableConstraints: [NSLayoutConstraint] = []
+    private var isVerticalAxis: Bool?
 
     public init(iconImage: UIImage? = nil, text: String? = nil, detailText: String? = nil) {
 
@@ -35,39 +36,28 @@ public final class StatusMetricRowView: UIButton {
         chevron.translatesAutoresizingMaskIntoConstraints = false
         chevron.tintColor = Asset.Colors.Label.tertiary.color
 
-        contentStack = UIStackView()
-        contentStack.translatesAutoresizingMaskIntoConstraints = false
-        contentStack.distribution = .fill
-        contentStack.spacing = 8
-        contentStack.isUserInteractionEnabled = false
-        contentStack.addArrangedSubview(textLabel)
-        contentStack.addArrangedSubview(detailLabel)
-
         super.init(frame: .zero)
 
-        self.traitCollectionDidChange(nil)
-
         addSubview(icon)
-        addSubview(contentStack)
+        addSubview(textLabel)
+        addSubview(detailLabel)
         addSubview(chevron)
 
         accessibilityTraits.insert(.button)
 
         setupConstraints()
+        traitCollectionDidChange(nil)
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
+        let isVerticalAxis = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
 
-        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
-            contentStack.axis = .vertical
-            contentStack.alignment = .fill
+        if isVerticalAxis {
             detailLabel.textAlignment = .natural
         } else {
-            contentStack.axis = .horizontal
-            contentStack.alignment = .leading
             switch traitCollection.layoutDirection {
             case .leftToRight, .unspecified: detailLabel.textAlignment = .right
             case .rightToLeft: detailLabel.textAlignment = .left
@@ -75,6 +65,37 @@ public final class StatusMetricRowView: UIButton {
                 break
             }
         }
+
+        guard isVerticalAxis != self.isVerticalAxis else { return }
+        self.isVerticalAxis = isVerticalAxis
+        NSLayoutConstraint.deactivate(disposableConstraints)
+
+        if isVerticalAxis {
+            disposableConstraints = [
+                textLabel.topAnchor.constraint(equalTo: topAnchor, constant: 11),
+
+                detailLabel.leadingAnchor.constraint(equalTo: textLabel.leadingAnchor),
+                detailLabel.topAnchor.constraint(equalTo: textLabel.bottomAnchor, constant: 8),
+                bottomAnchor.constraint(equalTo: detailLabel.bottomAnchor, constant: 11),
+
+                chevron.leadingAnchor.constraint(greaterThanOrEqualTo: detailLabel.trailingAnchor, constant: 12),
+            ]
+        } else {
+            disposableConstraints = [
+                textLabel.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: 11),
+                textLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+                bottomAnchor.constraint(greaterThanOrEqualTo: textLabel.bottomAnchor, constant: 11),
+
+                detailLabel.leadingAnchor.constraint(greaterThanOrEqualTo: textLabel.trailingAnchor, constant: 8),
+
+                detailLabel.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: 11),
+                detailLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+                bottomAnchor.constraint(greaterThanOrEqualTo: detailLabel.bottomAnchor, constant: 11),
+
+                chevron.leadingAnchor.constraint(equalTo: detailLabel.trailingAnchor, constant: 12),
+            ]
+        }
+        NSLayoutConstraint.activate(disposableConstraints)
     }
 
     var margin: CGFloat = 0 {
@@ -86,19 +107,15 @@ public final class StatusMetricRowView: UIButton {
     private func setupConstraints() {
         icon.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         chevron.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        chevron.setContentCompressionResistancePriority(.required, for: .horizontal)
         let constraints = [
             icon.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: 10),
             icon.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
             icon.centerYAnchor.constraint(equalTo: centerYAnchor),
-            contentStack.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 16),
+            textLabel.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 16),
             icon.widthAnchor.constraint(greaterThanOrEqualToConstant: 24),
             icon.heightAnchor.constraint(greaterThanOrEqualToConstant: 24),
             bottomAnchor.constraint(greaterThanOrEqualTo: icon.bottomAnchor, constant: 10),
-
-            contentStack.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: 11),
-            contentStack.centerYAnchor.constraint(equalTo: centerYAnchor),
-            bottomAnchor.constraint(greaterThanOrEqualTo: contentStack.bottomAnchor, constant: 11),
-            chevron.leadingAnchor.constraint(equalTo: contentStack.trailingAnchor, constant: 12),
 
             chevron.centerYAnchor.constraint(equalTo: centerYAnchor),
             layoutMarginsGuide.trailingAnchor.constraint(equalTo: chevron.trailingAnchor),

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -614,14 +614,14 @@ extension StatusView.ViewModel {
         $reblogCount
             .sink { count in
                 statusView.statusMetricView.reblogButton.isHidden = count == 0
-                statusView.statusMetricView.reblogButton.detailLabel.text = "\(count)"
+                statusView.statusMetricView.reblogButton.detailLabel.text = count.formatted()
             }
             .store(in: &disposeBag)
         
         $favoriteCount
             .sink { count in
                 statusView.statusMetricView.favoriteButton.isHidden = count == 0
-                statusView.statusMetricView.favoriteButton.detailLabel.text = "\(count)"
+                statusView.statusMetricView.favoriteButton.detailLabel.text = count.formatted()
             }
             .store(in: &disposeBag)
 


### PR DESCRIPTION
- swap from the `UIStackView` back to using manual AutoLayout (it was basically impossible to get the correct behavior out of the stack view, but it wasn’t too bad to do it manually)
- Add a color for the chevron in dark  mode so it isn’t completely invisible
- Make the `StatusMetricView` accessible via VoiceOver