### PR TITLE
Fix #902: Uploaded video get's distorted because aspect ratio is not maintained

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentViewModel.swift
@@ -145,7 +145,10 @@ final public class AttachmentViewModel: NSObject, ObservableObject, Identifiable
                 case .video(let fileURL, let mimeType):
                     self.output = output
                     self.update(uploadState: .compressing)
-                    let compressedFileURL = try await compressVideo(url: fileURL)
+                    guard let compressedFileURL = try await compressVideo(url: fileURL) else {
+                        assertionFailure("Unable to compress video")
+                        return
+                    }
                     output = .video(compressedFileURL, mimeType: mimeType)
                     try? FileManager.default.removeItem(at: fileURL)    // remove old file
                 }


### PR DESCRIPTION
# Rationale

Calculates the desired transcoded video size based on the current video orientation and aspect ratio.

Currently a fixed size of either `1280x720` or `720x1280` px is being used, this leads to distorted videos if the input is not in 16:9 (or 9:16 respectively) aspect ratio.

Fixes #902.