### PR TITLE
Fixes #942 - Tapping home button or Pull to Refresh does not reload

### DIFF
--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel+LoadLatestState.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel+LoadLatestState.swift
@@ -51,7 +51,7 @@ extension HomeTimelineViewModel {
 extension HomeTimelineViewModel.LoadLatestState {
     class Initial: HomeTimelineViewModel.LoadLatestState {
         override func isValidNextState(_ stateClass: AnyClass) -> Bool {
-            return stateClass == Loading.self
+            return stateClass == Loading.self || stateClass == LoadingManually.self
         }
     }
     
@@ -83,7 +83,7 @@ extension HomeTimelineViewModel.LoadLatestState {
     
     class Idle: HomeTimelineViewModel.LoadLatestState {
         override func isValidNextState(_ stateClass: AnyClass) -> Bool {
-            return stateClass == Loading.self
+            return stateClass == Loading.self || stateClass == LoadingManually.self
         }
     }
 


### PR DESCRIPTION
# Rationale

When introducing the haptic feedback, I made a distinction between manual and automated (event based) timeline reload. Unfortunately I partially broke the reload state machine there. This PR fixes this.