### PR TITLE
Don’t assertionFailure() when tapping on non-status cells

### DIFF
--- a/Mastodon/Protocol/Provider/DataSourceProvider+NotificationTableViewCellDelegate.swift
+++ b/Mastodon/Protocol/Provider/DataSourceProvider+NotificationTableViewCellDelegate.swift
@@ -522,6 +522,7 @@ extension NotificationTableViewCellDelegate where Self: DataSourceProvider & Aut
         Task {
             let source = DataSourceItem.Source(tableViewCell: cell, indexPath: nil)
             guard let item = await item(from: source) else {
+                assertionFailure()
                 return
             }
             switch item {

--- a/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
+++ b/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
@@ -681,6 +681,7 @@ extension StatusTableViewCellDelegate where Self: DataSourceProvider & AuthConte
         Task {
             let source = DataSourceItem.Source(tableViewCell: cell, indexPath: nil)
             guard let item = await item(from: source) else {
+                assertionFailure()
                 return
             }
             switch item {

--- a/Mastodon/Scene/Thread/ThreadViewController+DataSourceProvider.swift
+++ b/Mastodon/Scene/Thread/ThreadViewController+DataSourceProvider.swift
@@ -24,7 +24,6 @@ extension ThreadViewController: DataSourceProvider {
         case .thread(let thread):
             return .status(record: thread.record)
         default:
-            assertionFailure()
             return nil
         }
     }


### PR DESCRIPTION
I had noticed the app crashing when I touched the activity indicator. This is the reason why. Since it’s an `assertionFailure()` this does not affect production builds. That said, it is annoying since I spend most of my time on a debug build.

I looked at all of the callers of this function and many of them call `assertionFailure` if it returns `nil`. I’ve added `assertionFailure` calls to a couple of places where it makes sense, but now tapping on a non-status cell should no longer cause a crash in debug builds.