### PR TITLE
IOS-97: Improve labelling of username field on Create Account screen

### DIFF
--- a/Mastodon/Scene/Onboarding/Register/MastodonRegisterView.swift
+++ b/Mastodon/Scene/Onboarding/Register/MastodonRegisterView.swift
@@ -27,16 +27,19 @@ struct MastodonRegisterView: View {
                     .modifier(FormTextFieldModifier(validateState: viewModel.displayNameValidateState))
                 HStack {
                     Text("@")
+                        .accessibilityHidden(true)
                     TextField(L10n.Scene.Register.Input.Username.placeholder.localizedCapitalized, text: $viewModel.username)
                         .textContentType(.username)
                         .autocapitalization(.none)
                         .disableAutocorrection(true)
                         .keyboardType(.asciiCapable)
+                        .accessibilityLabel(viewModel.accessibilityLabelUsernameField)
                     Text("@\(viewModel.domain)")
                         .lineLimit(1)
                         .truncationMode(.middle)
                         .measureWidth { usernameRightViewWidth = $0 }
                         .frame(width: min(300.0, usernameRightViewWidth), alignment: .trailing)
+                        .accessibilityHidden(true)
                 }
                 .modifier(FormTextFieldModifier(validateState: viewModel.usernameValidateState))
                 .environment(\.layoutDirection, .leftToRight)   // force LTR

--- a/Mastodon/Scene/Onboarding/Register/MastodonRegisterViewModel.swift
+++ b/Mastodon/Scene/Onboarding/Register/MastodonRegisterViewModel.swift
@@ -285,3 +285,10 @@ extension MastodonRegisterViewModel {
         return attributeString
     }
 }
+
+extension MastodonRegisterViewModel {
+    var accessibilityLabelUsernameField: String {
+        let username = username.isEmpty ? L10n.Scene.Register.Input.Username.placeholder : username
+        return "@\(username)@\(domain)"
+    }
+}


### PR DESCRIPTION
# Rationale

The username field on create account will now read the full handle and the @ and @domain.tld labels will be hidden from a11y.