### PR TITLE
IOS-96: Label Privacy Policy links as links/buttons in the onboarding

### DIFF
--- a/Mastodon/Scene/Onboarding/Privacy/PrivacyTableViewController.swift
+++ b/Mastodon/Scene/Onboarding/Privacy/PrivacyTableViewController.swift
@@ -115,6 +115,7 @@ extension PrivacyTableViewController: UITableViewDataSource {
         var contentConfiguration = cell.defaultContentConfiguration()
         contentConfiguration.textProperties.color = Asset.Colors.Brand.blurple.color
         contentConfiguration.text = row.title
+        cell.accessibilityTraits = [.button, .link]
 
         cell.contentConfiguration = contentConfiguration
 


### PR DESCRIPTION
# Rationale

Label Privacy Policy links as links/buttons in the onboarding.