### PR TITLE
IOS-94: Improve accessibility of the onboarding intro

### DIFF
--- a/Localization/app.json
+++ b/Localization/app.json
@@ -277,6 +277,11 @@
                 "title": "How do I pick a server?",
                 "description": "Different people choose different servers for any number of reasons. art.example is a great place for artists, while glasgow.example might be a good pick for Scots.\n\nYou can’t go wrong with any of our recommend servers, so regardless of which one you pick (or if you enter your own in the server search bar), you’ll never miss a beat anywhere.",
               },
+                "a11y": {
+                    "what_is_mastodon": {
+                        "title": "What is Mastodon?"
+                    }
+                }
             }
         },
         "login": {

--- a/Mastodon/Scene/Onboarding/Welcome/View/Pages/WelcomeContentCollectionViewCell.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/View/Pages/WelcomeContentCollectionViewCell.swift
@@ -68,7 +68,6 @@ class WelcomeContentCollectionViewCell: UICollectionViewCell {
     }
     
     private func updateAccessibility() {
-        accessibilityElements = [titleView, label]
         accessibilityLabel = "\(titleView.accessibilityLabel ?? ""), \(label.accessibilityLabel ?? "")"
         isAccessibilityElement = true
     }

--- a/Mastodon/Scene/Onboarding/Welcome/View/Pages/WelcomeContentCollectionViewCell.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/View/Pages/WelcomeContentCollectionViewCell.swift
@@ -66,9 +66,17 @@ class WelcomeContentCollectionViewCell: UICollectionViewCell {
         
         NSLayoutConstraint.activate(constraints)
     }
+    
+    private func updateAccessibility() {
+        accessibilityElements = [titleView, label]
+        accessibilityLabel = "\(titleView.accessibilityLabel ?? ""), \(label.accessibilityLabel ?? "")"
+        isAccessibilityElement = true
+    }
 
     func update(with page: WelcomeContentPage) {
         titleView.attributedText = page.title
+        titleView.accessibilityLabel = page.accessibilityLabel
         label.text = page.content
+        updateAccessibility()
     }
 }

--- a/Mastodon/Scene/Onboarding/Welcome/View/Pages/WelcomeContentPage.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/View/Pages/WelcomeContentPage.swift
@@ -49,6 +49,17 @@ enum WelcomeContentPage: CaseIterable {
         }
     }
     
+    var accessibilityLabel: String {
+        switch self {
+        case .whatIsMastodon:
+            return "\(L10n.Scene.Welcome.Education.WhatIsMastodon.title) Mastodon?"
+        case .mastodonIsLikeThat:
+            return L10n.Scene.Welcome.Education.MastodonIsLikeThat.title
+        case .howDoIPickAServer:
+            return L10n.Scene.Welcome.Education.HowDoIPickAServer.title
+        }
+    }
+    
     var content: String {
         switch self {
         case .whatIsMastodon:

--- a/Mastodon/Scene/Onboarding/Welcome/View/Pages/WelcomeContentPage.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/View/Pages/WelcomeContentPage.swift
@@ -52,7 +52,7 @@ enum WelcomeContentPage: CaseIterable {
     var accessibilityLabel: String {
         switch self {
         case .whatIsMastodon:
-            return "\(L10n.Scene.Welcome.Education.WhatIsMastodon.title) Mastodon?"
+            return L10n.Scene.Welcome.Education.A11y.WhatIsMastodon.title
         case .mastodonIsLikeThat:
             return L10n.Scene.Welcome.Education.MastodonIsLikeThat.title
         case .howDoIPickAServer:

--- a/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
+++ b/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
@@ -1498,6 +1498,12 @@ public enum L10n {
       /// back in your hands.
       public static let slogan = L10n.tr("Localizable", "Scene.Welcome.Slogan", fallback: "Social networking\nback in your hands.")
       public enum Education {
+        public enum A11y {
+          public enum WhatIsMastodon {
+            /// What is Mastodon?
+            public static let title = L10n.tr("Localizable", "Scene.Welcome.Education.A11y.WhatIsMastodon.title", fallback: "What is Mastodon?")
+          }
+        }
         public enum HowDoIPickAServer {
           /// Different people choose different servers for any number of reasons. art.example is a great place for artists, while glasgow.example might be a good pick for Scots.
           /// 

--- a/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
+++ b/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
@@ -521,6 +521,7 @@ back in your hands.";
 "Scene.Welcome.Education.WhatIsMastodon.description" = "Imagine you have an email address that ends with @example.com.
 
 You can still send and receive emails from anyone, even if their email ends in @gmail.com or @icloud.com or @example.com.";
+"Scene.Welcome.Education.A11y.WhatIsMastodon.title" = "What is Mastodon?";
 "Scene.Welcome.Education.MastodonIsLikeThat.title" = "Mastodon is like that";
 "Scene.Welcome.Education.MastodonIsLikeThat.description" = "Your handle might be @gothgirl654@example.social, but you can still follow, reblog, and chat with @fallout5ever@example.online.";
 "Scene.Welcome.Education.HowDoIPickAServer.title" = "How do I pick a server?";


### PR DESCRIPTION
* Fix title of the first page
* Merge accessibility elements for heading and content
* Maybe set an explicit set of accessibilityChildren so that it’s easier to swipe through the onboarding