### PR TITLE
IOS-71: Read persons account name when going through statuses

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -727,23 +727,27 @@ extension StatusView.ViewModel {
     }
     
     private func bindAccessibility(statusView: StatusView) {
-        let shortAuthorAccessibilityLabel = Publishers.CombineLatest3(
+        let shortAuthorAccessibilityLabel = Publishers.CombineLatest4(
             $header,
             $authorName,
+            $authorUsername,
             $timestampText
         )
-        .map { header, authorName, timestamp -> String? in
+        .map { header, authorName, authorUsername, timestamp -> String? in
             var strings: [String?] = []
             
             switch header {
             case .none:
                 strings.append(authorName?.string)
+                strings.append(authorUsername)
             case .reply(let info):
                 strings.append(authorName?.string)
+                strings.append(authorUsername)
                 strings.append(info.header.string)
             case .repost(let info):
                 strings.append(info.header.string)
                 strings.append(authorName?.string)
+                strings.append(authorUsername)
             }
 
             if statusView.style != .editHistory {


### PR DESCRIPTION
# Rationale

The account handle is not read when using voice-over on statuses. Unfortunately using `accessibilityCustomContent`, as defined per ticket, didn't work out quite well because there is a lot of hand-crafting on the accessibility elements going on, to me this seems like the most reasonable solution to achieve this functionality.