### PR TITLE
IOS-69: Label this “re-blog” otherwise it sounds like “reh-blog”

### DIFF
--- a/Localization/Localizable.stringsdict
+++ b/Localization/Localizable.stringsdict
@@ -231,6 +231,28 @@
 			<string>%ld reblogs</string>
 		</dict>
 	</dict>
+		<key>plural.count.reblog_a11y</key>
+    	<dict>
+    		<key>NSStringLocalizedFormatKey</key>
+    		<string>%#@reblog_count@</string>
+    		<key>reblog_count</key>
+    		<dict>
+    			<key>NSStringFormatSpecTypeKey</key>
+    			<string>NSStringPluralRuleType</string>
+    			<key>NSStringFormatValueTypeKey</key>
+    			<string>ld</string>
+    			<key>zero</key>
+    			<string>0 re-blogs</string>
+    			<key>one</key>
+    			<string>1 re-blog</string>
+    			<key>few</key>
+    			<string>%ld re-blogs</string>
+    			<key>many</key>
+    			<string>%ld re-blogs</string>
+    			<key>other</key>
+    			<string>%ld re-blogs</string>
+    		</dict>
+    	</dict>
     <key>plural.count.reply</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Localization/app.json
+++ b/Localization/app.json
@@ -171,7 +171,11 @@
                     "show_gif": "Show GIF",
                     "show_video_player": "Show video player",
                     "share_link_in_post": "Share Link in Post",
-                    "tap_then_hold_to_show_menu": "Tap then hold to show menu"
+                    "tap_then_hold_to_show_menu": "Tap then hold to show menu",
+                    "a11y_labels": {
+                        "reblog": "Re-blog",
+                        "unreblog": "Undo re-blog"
+                    }
                 },
                 "tag": {
                     "url": "URL",

--- a/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
+++ b/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
@@ -349,6 +349,12 @@ public enum L10n {
           public static let unfavorite = L10n.tr("Localizable", "Common.Controls.Status.Actions.Unfavorite", fallback: "Unfavorite")
           /// Undo reblog
           public static let unreblog = L10n.tr("Localizable", "Common.Controls.Status.Actions.Unreblog", fallback: "Undo reblog")
+          public enum A11yLabels {
+            /// Re-blog
+            public static let reblog = L10n.tr("Localizable", "Common.Controls.Status.Actions.A11yLabels.Reblog", fallback: "Re-blog")
+            /// Undo re-blog
+            public static let unreblog = L10n.tr("Localizable", "Common.Controls.Status.Actions.A11yLabels.Unreblog", fallback: "Undo re-blog")
+          }
         }
         public enum Buttons {
           /// Last edit %@
@@ -1702,6 +1708,10 @@ public enum L10n {
       /// Plural format key: "%#@reblog_count@"
       public static func reblog(_ p1: Int) -> String {
         return L10n.tr("Localizable", "plural.count.reblog", p1, fallback: "Plural format key: \"%#@reblog_count@\"")
+      }
+      /// Plural format key: "%#@reblog_count@"
+      public static func reblogA11y(_ p1: Int) -> String {
+        return L10n.tr("Localizable", "plural.count.reblog_a11y", p1, fallback: "Plural format key: \"%#@reblog_count@\"")
       }
       /// Plural format key: "%#@reply_count@"
       public static func reply(_ p1: Int) -> String {

--- a/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
+++ b/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
@@ -114,6 +114,8 @@ Please check your internet connection.";
 "Common.Controls.Status.Actions.TapThenHoldToShowMenu" = "Tap then hold to show menu";
 "Common.Controls.Status.Actions.Unfavorite" = "Unfavorite";
 "Common.Controls.Status.Actions.Unreblog" = "Undo reblog";
+"Common.Controls.Status.Actions.A11yLabels.Reblog" = "Re-blog";
+"Common.Controls.Status.Actions.A11yLabels.Unreblog" = "Undo re-blog";
 "Common.Controls.Status.ContentWarning" = "Content Warning";
 "Common.Controls.Status.LinkViaUser" = "%@ via %@";
 "Common.Controls.Status.LoadEmbed" = "Load Embed";

--- a/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.stringsdict
+++ b/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.stringsdict
@@ -231,6 +231,28 @@
 			<string>%ld reblogs</string>
 		</dict>
 	</dict>
+    <key>plural.count.reblog_a11y</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@reblog_count@</string>
+        <key>reblog_count</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>ld</string>
+            <key>zero</key>
+            <string>0 re-blogs</string>
+            <key>one</key>
+            <string>1 re-blog</string>
+            <key>few</key>
+            <string>%ld re-blogs</string>
+            <key>many</key>
+            <string>%ld re-blogs</string>
+            <key>other</key>
+            <string>%ld re-blogs</string>
+        </dict>
+    </dict>
     <key>plural.count.reply</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/MastodonSDK/Sources/MastodonLocalization/Resources/en.lproj/Localizable.stringsdict
+++ b/MastodonSDK/Sources/MastodonLocalization/Resources/en.lproj/Localizable.stringsdict
@@ -173,6 +173,28 @@
         <string>%ld reblogs</string>
       </dict>
     </dict>
+    <key>plural.count.reblog_a11y</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@reblog_count@</string>
+        <key>reblog_count</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>ld</string>
+            <key>zero</key>
+            <string>0 re-blogs</string>
+            <key>one</key>
+            <string>1 re-blog</string>
+            <key>few</key>
+            <string>%ld re-blogs</string>
+            <key>many</key>
+            <string>%ld re-blogs</string>
+            <key>other</key>
+            <string>%ld re-blogs</string>
+        </dict>
+    </dict>
     <key>plural.count.reply</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>

--- a/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Control/ActionToolbarContainer.swift
@@ -227,7 +227,7 @@ extension ActionToolbarContainer {
     public func configureReblog(count: Int, isEnabled: Bool, isHighlighted: Bool) {
         let title = ActionToolbarContainer.title(from: count)
         reblogButton.setTitle(title, for: .normal)
-        reblogButton.accessibilityValue = L10n.Plural.Count.reblog(count)
+        reblogButton.accessibilityValue = L10n.Plural.Count.reblogA11y(count)
         reblogButton.isEnabled = isEnabled
         reblogButton.setImage(ActionToolbarContainer.reblogImage, for: .normal)
         let tintColor = isHighlighted ? Asset.Colors.successGreen.color : Asset.Colors.Button.actionToolbar.color
@@ -237,10 +237,10 @@ extension ActionToolbarContainer {
         
         if isHighlighted {
             reblogButton.accessibilityTraits.insert(.selected)
-            reblogButton.accessibilityLabel = L10n.Common.Controls.Status.Actions.unreblog
+            reblogButton.accessibilityLabel = L10n.Common.Controls.Status.Actions.A11yLabels.unreblog
         } else {
             reblogButton.accessibilityTraits.remove(.selected)
-            reblogButton.accessibilityLabel = L10n.Common.Controls.Status.Actions.reblog
+            reblogButton.accessibilityLabel = L10n.Common.Controls.Status.Actions.A11yLabels.reblog
         }
         reblogButton.accessibilityCustomActions = [
             UIAccessibilityCustomAction(name: "Show All Reblogs") { [weak self] action in


### PR DESCRIPTION
# Rationale

The reblog button in `ActionToolbarContainer` is read as "reh-blog" instead of "re-blog" which sounds a bit odd in english. I've chosen to introduce a localizable key purely used for A11y to make this sound nicer.

# Warning

We need to make sure to pull new strings in before releasing due to the updated `Localizable.stringsdict` with new pluralisations.