### PR TITLE
IOS-110: Fix Cannot switch accounts when large content viewer is enabled

### DIFF
--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -26,6 +26,8 @@ class MainTabBarController: UITabBarController {
     
     var authContext: AuthContext?
     
+    private let largeContentViewerInteraction = UILargeContentViewerInteraction()
+    
     let composeButttonShadowBackgroundContainer = ShadowBackgroundContainer()
     let composeButton: UIButton = {
         let button = UIButton()
@@ -180,6 +182,8 @@ class MainTabBarController: UITabBarController {
         self.coordinator = coordinator
         self.authContext = authContext
         super.init(nibName: nil, bundle: nil)
+        tabBar.addInteraction(largeContentViewerInteraction)
+        
     }
     
     required init?(coder: NSCoder) {
@@ -349,6 +353,7 @@ extension MainTabBarController {
 
         let tabBarLongPressGestureRecognizer = UILongPressGestureRecognizer()
         tabBarLongPressGestureRecognizer.addTarget(self, action: #selector(MainTabBarController.tabBarLongPressGestureRecognizerHandler(_:)))
+        tabBarLongPressGestureRecognizer.delegate = self
         tabBar.addGestureRecognizer(tabBarLongPressGestureRecognizer)
 
         // todo: reconsider the "double tap to change account" feature -> https://github.com/mastodon/mastodon-ios/issues/628
@@ -843,4 +848,10 @@ extension MainTabBarController {
         _ = coordinator.present(scene: .compose(viewModel: composeViewModel), from: nil, transition: .modal(animated: true, completion: nil))
     }
     
+}
+
+extension MainTabBarController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        true
+    }
 }


### PR DESCRIPTION
# Rationale

when enabling large text, and further increasing size to use the large content viewer, it's long-press gesture interferes with the long-press for the account switcher.

This PR allows simultaneous gestures so the large content HUD shows up and the account switcher will open up as well.