### PR TITLE
IOS-109: Fix Large content viewer does not appear when pressing and holding the Compose button

### DIFF
--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -370,6 +370,9 @@ extension MainTabBarController {
         
         updateTabBarDisplay()
         
+        composeButton.addInteraction(UILargeContentViewerInteraction())
+        composeButton.showsLargeContentViewer = true
+        composeButton.largeContentTitle = L10n.Common.Controls.Actions.compose
         composeButton.addTarget(self, action: #selector(MainTabBarController.composeButtonDidPressed(_:)), for: .touchUpInside)
         
         #if DEBUG


### PR DESCRIPTION
# Rationale

Added `UILargeContentViewerInteraction` to compose button.