### PR TITLE
IOS-123: Open profiles and statuses in app

### DIFF
--- a/Mastodon/Mastodon.entitlements
+++ b/Mastodon/Mastodon.entitlements
@@ -4,6 +4,11 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:mastodon.social</string>
+		<string>applinks:mastodon.online</string>
+	</array>
 	<key>com.apple.developer.siri</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>

--- a/Mastodon/Supporting Files/SceneDelegate.swift
+++ b/Mastodon/Supporting Files/SceneDelegate.swift
@@ -104,13 +104,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         #endif
     }
 
-    func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
-    }
-
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
@@ -135,22 +128,63 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
 
-    func sceneWillResignActive(_ scene: UIScene) {
-        // Called when the scene will move from an active state to an inactive state.
-        // This may occur due to temporary interruptions (ex. an incoming phone call).
+  func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+    guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+        let incomingURL = userActivity.webpageURL,
+        let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true) else {
+        return
     }
 
-    func sceneWillEnterForeground(_ scene: UIScene) {
-        // Called as the scene transitions from the background to the foreground.
-        // Use this method to undo the changes made on entering the background.
+    guard let path = components.path, let authContext = coordinator?.authContext else {
+        return
     }
 
-    func sceneDidEnterBackground(_ scene: UIScene) {
-        // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
-        // to restore the scene back to its current state.
+    let pathElements = path.split(separator: "/")
+
+    let profile: String?
+    if let profileInPath = pathElements[safe: 0] {
+      profile = String(profileInPath)
+    } else {
+      profile = nil
     }
 
+    let statusID: String?
+    if let statusIDInPath = pathElements[safe: 1] {
+      statusID = String(statusIDInPath)
+    } else {
+      statusID = nil
+    }
+
+    switch (profile, statusID) {
+      case (profile, nil):
+        guard let profile else { return }
+
+        let profileViewModel = RemoteProfileViewModel(
+          context: AppContext.shared,
+          authContext: authContext,
+          acct: profile
+        )
+        self.coordinator?.present(
+          scene: .profile(viewModel: profileViewModel),
+          from: nil,
+          transition: .show
+        )
+
+      case (profile, statusID):
+        guard let statusID else { return }
+        let threadViewModel = RemoteThreadViewModel(
+          context: AppContext.shared,
+          authContext: authContext,
+          statusID: statusID
+        )
+        coordinator?.present(scene: .thread(viewModel: threadViewModel), from: nil, transition: .show)
+
+      case (_, _):
+        break
+        // do nothing
+    }
+
+  }
 }
 
 extension SceneDelegate {
@@ -298,3 +332,4 @@ extension SceneDelegate {
         }
     }
 }
+

--- a/Mastodon/Supporting Files/SceneDelegate.swift
+++ b/Mastodon/Supporting Files/SceneDelegate.swift
@@ -71,6 +71,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if let urlContext = connectionOptions.urlContexts.first {
             handleUrl(context: urlContext)
         }
+
+        if let userActivity = connectionOptions.userActivities.first {
+            handleUniversalLink(userActivity: userActivity)
+        }
         
         #if SNAPSHOT
         // speedup animation
@@ -129,6 +133,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        handleUniversalLink(userActivity: userActivity)
+    }
+
+    private func handleUniversalLink(userActivity: NSUserActivity) {
         guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
               let incomingURL = userActivity.webpageURL,
               let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true) else {
@@ -167,11 +175,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     from: nil,
                     transition: .show
                 )
-                
+
             case (profile, statusID):
                 Task {
                     guard let statusOnMyInstance = try await AppContext.shared.apiService.search(query: .init(q: incomingURL.absoluteString, resolve: true), authenticationBox: authContext.mastodonAuthenticationBox).value.statuses.first else { return }
-                    
+
                     let threadViewModel = RemoteThreadViewModel(
                         context: AppContext.shared,
                         authContext: authContext,
@@ -179,12 +187,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     )
                     coordinator?.present(scene: .thread(viewModel: threadViewModel), from: nil, transition: .show)
                 }
-                
+
             case (_, _):
                 break
                 // do nothing
         }
-        
+
     }
 }
 


### PR DESCRIPTION
# Rationale

When users visit `mastodon.social`/`mastodon.online`, they should be able to open the statuses and profiles from there in the app. For now, only `mastodon.online`-links work, as `mastodon.social` is (ATM) missing the `apple-app-site-association`-file.

## Videos 


https://user-images.githubusercontent.com/2580019/225764765-2ad2124d-1329-4e24-9a8e-7712c589a6f5.mp4

https://user-images.githubusercontent.com/2580019/225764781-38f4bdf9-2db2-44dd-802f-eed565513ae9.mp4

