### PR TITLE
IOS-131: Remove blurry background, make pageControl background promintent, remove inset

### DIFF
--- a/Mastodon/Scene/Onboarding/Welcome/View/Pages/WelcomeContentCollectionViewCell.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/View/Pages/WelcomeContentCollectionViewCell.swift
@@ -15,7 +15,6 @@ class WelcomeContentCollectionViewCell: UICollectionViewCell {
     private let contentStackView: UIStackView
     private let titleView: UILabel
     private let label: UILabel
-    private let blurryBackgroundView: UIVisualEffectView
 
     override init(frame: CGRect) {
         titleView = UILabel()
@@ -36,15 +35,9 @@ class WelcomeContentCollectionViewCell: UICollectionViewCell {
         contentStackView.alignment = .leading
         contentStackView.spacing = 8
 
-        blurryBackgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterialLight))
-        blurryBackgroundView.translatesAutoresizingMaskIntoConstraints = false
-        blurryBackgroundView.applyCornerRadius(radius: 8)
-
-        blurryBackgroundView.contentView.addSubview(contentStackView)
-        
         super.init(frame: frame)
 
-        addSubview(blurryBackgroundView)
+        addSubview(contentStackView)
         
         setupConstraints()
     }
@@ -53,15 +46,11 @@ class WelcomeContentCollectionViewCell: UICollectionViewCell {
     
     private func setupConstraints() {
         let constraints = [
-            blurryBackgroundView.topAnchor.constraint(equalTo: topAnchor),
-            blurryBackgroundView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-            trailingAnchor.constraint(equalTo: blurryBackgroundView.trailingAnchor, constant: 16),
-            bottomAnchor.constraint(greaterThanOrEqualTo: blurryBackgroundView.bottomAnchor),
-
-            contentStackView.topAnchor.constraint(equalTo: blurryBackgroundView.contentView.topAnchor, constant: 8),
-            contentStackView.leadingAnchor.constraint(equalTo: blurryBackgroundView.contentView.leadingAnchor, constant: 8),
-            blurryBackgroundView.contentView.trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor),
-            blurryBackgroundView.contentView.bottomAnchor.constraint(equalTo: contentStackView.bottomAnchor),
+            contentStackView.topAnchor.constraint(equalTo: topAnchor),
+            contentStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            contentStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor, constant: 16),
+            bottomAnchor.constraint(greaterThanOrEqualTo: contentStackView.bottomAnchor),
         ]
         
         NSLayoutConstraint.activate(constraints)

--- a/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
@@ -78,6 +78,7 @@ final class WelcomeViewController: UIViewController, NeedsDependency {
 
     private(set) var pageControl: UIPageControl = {
         let pageControl = UIPageControl(frame: .zero)
+        pageControl.backgroundStyle = .prominent
         pageControl.translatesAutoresizingMaskIntoConstraints = false
         return pageControl
     }()
@@ -91,7 +92,7 @@ extension WelcomeViewController {
         definesPresentationContext = true
         preferredContentSize = CGSize(width: 547, height: 678)
         
-        navigationController?.navigationBar.prefersLargeTitles = true
+        navigationController?.navigationBar.prefersLargeTitles = false
         view.overrideUserInterfaceStyle = .light
         
         setupOnboardingAppearance()
@@ -149,7 +150,7 @@ extension WelcomeViewController {
         scrollView.delegate = self
         
         NSLayoutConstraint.activate([
-            pageCollectionView.topAnchor.constraint(equalTo: view.topAnchor, constant: computedTopAnchorInset),
+            pageCollectionView.topAnchor.constraint(equalTo: view.topAnchor),
             pageCollectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             view.trailingAnchor.constraint(equalTo: pageCollectionView.trailingAnchor),
             pageControl.topAnchor.constraint(equalTo: pageCollectionView.bottomAnchor, constant: 16),


### PR DESCRIPTION
# ToDos

- [x] Welcome screen page dots are obscured by artwork. Set a prominent background as always
- [x] Text should not be on a blur view, should be closer to the top (roughly 80pt)
- [x] Create account button should be title case
  * I updated the string for `en`  in Crowdin
