### PR TITLE
Port the media layout algorithm from the Android app

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/Helper/MediaLayoutHelper.swift
+++ b/MastodonSDK/Sources/MastodonUI/Helper/MediaLayoutHelper.swift
@@ -30,7 +30,7 @@ class MediaLayoutHelper {
 	static let maxHeight: Float = 1777
 	static let minHeight: Float = 563
 	static let gap: Float = 1.5
-	static let maxRatio: Float = Float(maxWidth) / Float(maxHeight)
+	static let maxRatio = maxWidth / maxHeight
 	
 	public static func generateMediaLayout(attachments: [MastodonAttachment]) -> MediaLayoutResult? {
 		if attachments.count<2 {
@@ -42,7 +42,7 @@ class MediaLayoutHelper {
 		var allAreSquare = true
 		for att in attachments {
 			let ratio: Float = Float(att.size.width/att.size.height)
-			if ratio<=1.2 {
+			if ratio <= 1.2 {
 				allAreWide = false
 				if ratio<0.8 {
 					allAreSquare = false
@@ -282,7 +282,7 @@ class MediaLayoutHelper {
 				columnSizes.append(offset - gridLineOffsets[i]) // i is already offset by one here
 			}
 			
-			for (row, _) in rowTiles.enumerated() {
+			for row in 0..<rowTiles.count {
 				var columnOffset: Int = 0
 				for (tile, _) in rowTiles[row].enumerated() {
 					let startColumn = columnOffset

--- a/MastodonSDK/Sources/MastodonUI/Helper/MediaLayoutHelper.swift
+++ b/MastodonSDK/Sources/MastodonUI/Helper/MediaLayoutHelper.swift
@@ -10,305 +10,305 @@ import MastodonSDK
 import CoreDataStack
 
 public struct MediaLayoutResult {
-	let width: Int
-	let height: Int
-	let columnSizes: [Int]
-	let rowSizes: [Int]
-	let tiles: [Tile]
-	
-	public struct Tile {
-		var colSpan: Int
-		let rowSpan: Int
-		var startCol: Int
-		let startRow: Int
-		var width: Int = 0
-	}
+    let width: Int
+    let height: Int
+    let columnSizes: [Int]
+    let rowSizes: [Int]
+    let tiles: [Tile]
+    
+    public struct Tile {
+        var colSpan: Int
+        let rowSpan: Int
+        var startCol: Int
+        let startRow: Int
+        var width: Int = 0
+    }
 }
 
 class MediaLayoutHelper {
-	static let maxWidth: Float = 1000
-	static let maxHeight: Float = 1777
-	static let minHeight: Float = 563
-	static let gap: Float = 1.5
-	static let maxRatio = maxWidth / maxHeight
-	
-	public static func generateMediaLayout(attachments: [MastodonAttachment]) -> MediaLayoutResult? {
-		if attachments.count<2 {
-			return nil
-		}
-		
-		var ratios: [Float] = []
-		var allAreWide = true
-		var allAreSquare = true
-		for att in attachments {
-			let ratio: Float = Float(att.size.width/att.size.height)
-			if ratio <= 1.2 {
-				allAreWide = false
-				if ratio<0.8 {
-					allAreSquare = false
-				}
-			} else {
-				allAreSquare = false
-			}
-			ratios.append(ratio)
-		}
-		
-		let avgRatio: Float = ratios.reduce(0.0, +) / Float(ratios.count)
-		
-		switch attachments.count {
-		case 2:
-			if allAreWide && avgRatio>1.4*maxRatio && (ratios[1]-ratios[0])<0.2 {
-				// Two wide attachments, one above the other
-				let h = Int(max(min(maxWidth/ratios[0], min(maxWidth/ratios[1], (maxHeight-gap)/2.0)), minHeight/2.0).rounded())
-				
-				return MediaLayoutResult(width: Int(maxWidth),
-								  height: Int((Float(h)*2.0+gap).rounded()),
-								  columnSizes: [Int(maxWidth)],
-								  rowSizes: [h, h],
-								  tiles: [
-									MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
-									MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1)
-								  ])
-			} else if allAreWide || allAreSquare {
-				// Next to each other, same ratio
-				let w: Float = (maxWidth-gap) / 2.0
-				let h: Float = max(min(w/ratios[0], min(w/ratios[1], maxHeight)), minHeight)
-				
-				let wInt: Int = Int(w.rounded())
-				let hInt: Int = Int(h.rounded())
-				
-				return MediaLayoutResult(width: Int(maxWidth),
-										 height: hInt,
-										 columnSizes: [wInt, Int(maxWidth)-wInt],
-										 rowSizes: [hInt],
-										 tiles: [
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0)
-										 ])
-			} else {
-				// Next to each other, different ratios
-				let w0: Float = ((maxWidth - gap) / ratios[1] / (1.0 / ratios[0] + 1.0 / ratios[1]))
-				let w1: Float = maxWidth - w0 - gap
-				let h: Float = max(min(maxHeight, min(w0/ratios[0], w1/ratios[1])), minHeight)
-				
-				let w0Int = Int(w0.rounded())
-				let w1Int = Int(w1.rounded())
-				let hInt = Int(h.rounded())
-				
-				return MediaLayoutResult(width: Int((w0+w1+gap).rounded()),
-										 height: hInt,
-										 columnSizes: [w0Int, w1Int],
-										 rowSizes: [hInt],
-										 tiles: [
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0)
-										 ])
-			}
-		case 3:
-			if ratios[0]>1.2*maxRatio || avgRatio>1.5*maxRatio || allAreWide {
-				// One above two smaller ones
-				var hCover: Float = min(maxWidth/ratios[0], (maxHeight-gap)*0.66)
-				let w2: Float = (maxWidth-gap)/2.0
-				var h: Float = min(maxHeight-hCover-gap, min(w2/ratios[1], w2/ratios[2]))
-				if hCover+h < minHeight {
-					let prevTotalHeight = hCover+h
-					hCover = minHeight*(hCover/prevTotalHeight)
-					h = minHeight*(h/prevTotalHeight)
-				}
-				
-				return MediaLayoutResult(width: Int(maxWidth),
-										 height: Int((hCover+h+gap).rounded()),
-										 columnSizes: [Int(w2.rounded()), Int(maxWidth-w2.rounded())],
-										 rowSizes: [Int(hCover.rounded()), Int(h.rounded())],
-										 tiles: [
-											MediaLayoutResult.Tile(colSpan: 2, rowSpan: 1, startCol: 0, startRow: 0),
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1),
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1)
-										 ])
-			} else {
-				// One on the left, two smaller ones on the right
-				let height: Float = min(maxHeight, maxWidth*0.66/avgRatio)
-				let wCover: Float = min(height*ratios[0], (maxWidth-gap)*0.66)
-				let h1: Float = ratios[1]*(height-gap)/(ratios[2]+ratios[1])
-				let h0: Float = height-h1-gap
-				let w: Float = min(maxWidth-wCover-gap, h1*ratios[2], h0*ratios[1])
-				
-				return MediaLayoutResult(width: Int((wCover+w+gap).rounded()),
-										 height: Int(height.rounded()),
-										 columnSizes: [Int(wCover.rounded()), Int(w.rounded())],
-										 rowSizes: [Int(h0.rounded()), Int(h1.rounded())],
-										 tiles: [
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 2, startCol: 0, startRow: 0),
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0),
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1)
-										 ])
-			}
-		case 4:
-			if ratios[0]>1.2*maxRatio || avgRatio>1.5*maxRatio || allAreWide {
-				// One above three smaller ones
-				var hCover: Float = min(maxWidth/ratios[0], (maxHeight-gap)*0.66)
-				var h: Float = (maxWidth-2.0*gap)/(ratios[1]+ratios[2]+ratios[3])
-				let w0: Float = h*ratios[1]
-				let w1: Float = h*ratios[2]
-				h = min(maxHeight-hCover-gap, h)
-				if hCover+h<minHeight {
-					let prevTotalHeight = hCover+h
-					hCover = minHeight*(hCover/prevTotalHeight)
-					h = minHeight*(h/prevTotalHeight)
-				}
-				
-				return MediaLayoutResult(width: Int(maxWidth),
-										 height: Int((hCover+h+gap).rounded()),
-										 columnSizes: [Int(w0.rounded()), Int(w1.rounded()), Int(maxWidth-w0.rounded()-w1.rounded())],
-										 rowSizes: [Int(hCover.rounded()), Int(h.rounded())],
-										 tiles: [
-											MediaLayoutResult.Tile(colSpan: 3, rowSpan: 1, startCol: 0, startRow: 0),
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1),
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1),
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 2, startRow: 1)
-										 ])
-			} else {
-				// One on the left, three smaller ones on the right
-				let height: Float = min(maxHeight, maxWidth*0.66/avgRatio)
-				let wCover: Float = min(height*ratios[0], (maxWidth-gap)*0.66)
-				var w: Float = (height-2.0*gap)/(1.0/ratios[1]+1.0/ratios[2]+1.0/ratios[3])
-				let h0: Float = w/ratios[1]
-				let h1: Float = w/ratios[2]
-				let h2: Float = w/ratios[3]+gap
-				w = min(maxWidth-wCover-gap, w)
-				
-				return MediaLayoutResult(width: Int((wCover+gap+w).rounded()),
-										 height: Int(height.rounded()),
-										 columnSizes: [Int(wCover.rounded()), Int(w.rounded())],
-										 rowSizes: [Int(h0.rounded()), Int(h1.rounded()), Int(h2.rounded())],
-										 tiles: [
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 3, startCol: 0, startRow: 0),
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0),
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1),
-											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 2)
-										 ])
-			}
-		default:
-			let cnt = attachments.count
-			var ratiosCropped: [Float] = []
-			if avgRatio>1.1 {
-				for ratio in ratios {
-					ratiosCropped.append(max(1.0, ratio))
-				}
-			} else {
-				for ratio in ratios {
-					ratiosCropped.append(min(1.0, ratio))
-				}
-			}
-			
-			var tries: [[Int]: [Float]] = [:]
-			
-			// One line
-			tries[[attachments.count]] = [calculateMultiThumbsHeight(ratios: ratiosCropped, width: maxWidth, margin: gap)]
-			
-			// Two lines
-			for firstLine in 1...cnt-1 {
-				tries[[firstLine, cnt-firstLine]] = [
-					calculateMultiThumbsHeight(ratios: Array(ratiosCropped[..<firstLine]), width: maxWidth, margin: gap),
-					calculateMultiThumbsHeight(ratios: Array(ratiosCropped[firstLine...]), width: maxWidth, margin: gap)
-				]
-			}
-			
-			// Three lines
-			for firstLine in 1...cnt-2 {
-				for secondLine in 1...cnt-firstLine-1 {
-					tries[[firstLine, secondLine, cnt-firstLine-secondLine]] = [
-						calculateMultiThumbsHeight(ratios: Array(ratiosCropped[..<firstLine]), width: maxWidth, margin: gap),
-						calculateMultiThumbsHeight(ratios: Array(ratiosCropped[firstLine..<firstLine+secondLine]), width: maxWidth, margin: gap),
-						calculateMultiThumbsHeight(ratios: Array(ratiosCropped[(firstLine+secondLine)...]), width: maxWidth, margin: gap)
-					]
-				}
-			}
-			
-			let realMaxHeight = min(maxWidth, maxHeight)
-			
-			var optConf: [Int] = []
-			var optDiff: Float = Float.greatestFiniteMagnitude
-			
-			for (conf, heights) in tries {
-				let confH: Float = heights.reduce(gap*Float(heights.count-1), +)
-				var confDiff = abs(confH-realMaxHeight)
-				if conf.count>1 && (conf[0]>conf[1] || (conf.count>2 && conf[1]>conf[2])) {
-					confDiff *= 1.1
-				}
-				if confDiff<optDiff {
-					optConf = conf
-					optDiff = confDiff
-				}
-			}
-			
-			var thumbsRemain: [MastodonAttachment] = Array(attachments)
-			var ratiosRemain: [Float] = Array(ratiosCropped)
-			let optHeights = tries[optConf]!
-			var totalHeight: Float = 0.0
-			var rowSizes: [Int] = []
-			var gridLineOffsets: [Int] = []
-			var rowTiles: [[MediaLayoutResult.Tile]] = []
-			
-			for (i, lineChunksNum) in optConf.enumerated() {
-				var lineThumbs: [MastodonAttachment] = []
-				for _ in 0..<lineChunksNum {
-					lineThumbs.append(thumbsRemain.removeFirst())
-				}
-				let lineHeight = optHeights[i]
-				totalHeight += lineHeight
-				rowSizes.append(Int(lineHeight.rounded()))
-				var totalWidth: Int = 0
-				var row: [MediaLayoutResult.Tile] = []
-				for (j, _) in lineThumbs.enumerated() {
-					let thumbRatio = ratiosRemain.removeFirst()
-					let w: Float = j==lineThumbs.count-1 ? (maxWidth-Float(totalWidth)) : (thumbRatio*lineHeight)
-					totalWidth += Int(w.rounded())
-					if j<lineThumbs.count-1 && !gridLineOffsets.contains(totalWidth) {
-						gridLineOffsets.append(totalWidth)
-					}
-					var tile = MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: i)
-					tile.width = Int(w.rounded())
-					row.append(tile)
-				}
-				rowTiles.append(row)
-			}
-			
-			gridLineOffsets = gridLineOffsets.sorted()
-			gridLineOffsets.append(Int(maxWidth))
-			
-			var columnSizes: [Int] = [gridLineOffsets[0]]
-			for (i, offset) in gridLineOffsets[1...].enumerated() {
-				columnSizes.append(offset - gridLineOffsets[i]) // i is already offset by one here
-			}
-			
-			for row in 0..<rowTiles.count {
-				var columnOffset: Int = 0
-				for (tile, _) in rowTiles[row].enumerated() {
-					let startColumn = columnOffset
-					rowTiles[row][tile].startCol = startColumn
-					var width: Int = 0
-					rowTiles[row][tile].colSpan = 0
-					for i in startColumn..<columnSizes.count {
-						width += columnSizes[i]
-						rowTiles[row][tile].colSpan += 1
-						if width == rowTiles[row][tile].width {
-							break
-						}
-					}
-					columnOffset += rowTiles[row][tile].colSpan
-				}
-			}
-			
-			return MediaLayoutResult(width: Int(maxWidth),
-									 height: Int((totalHeight+gap*Float(optHeights.count-1)).rounded()),
-									 columnSizes: columnSizes,
-									 rowSizes: rowSizes,
-									 tiles: rowTiles.reduce([], +))
-		}
-	}
-	
-	private static func calculateMultiThumbsHeight(ratios: [Float], width: Float, margin: Float) -> Float {
-		return (width-(Float(ratios.count)-1.0)*margin)/ratios.reduce(0.0, +)
-	}
+    static let maxWidth: Float = 1000
+    static let maxHeight: Float = 1777
+    static let minHeight: Float = 563
+    static let gap: Float = 1.5
+    static let maxRatio = maxWidth / maxHeight
+    
+    public static func generateMediaLayout(attachments: [MastodonAttachment]) -> MediaLayoutResult? {
+        if attachments.count<2 {
+            return nil
+        }
+        
+        var ratios: [Float] = []
+        var allAreWide = true
+        var allAreSquare = true
+        for att in attachments {
+            let ratio: Float = Float(att.size.width/att.size.height)
+            if ratio <= 1.2 {
+                allAreWide = false
+                if ratio<0.8 {
+                    allAreSquare = false
+                }
+            } else {
+                allAreSquare = false
+            }
+            ratios.append(ratio)
+        }
+        
+        let avgRatio: Float = ratios.reduce(0.0, +) / Float(ratios.count)
+        
+        switch attachments.count {
+        case 2:
+            if allAreWide && avgRatio>1.4*maxRatio && (ratios[1]-ratios[0])<0.2 {
+                // Two wide attachments, one above the other
+                let h = Int(max(min(maxWidth/ratios[0], min(maxWidth/ratios[1], (maxHeight-gap)/2.0)), minHeight/2.0).rounded())
+                
+                return MediaLayoutResult(width: Int(maxWidth),
+                                         height: Int((Float(h)*2.0+gap).rounded()),
+                                         columnSizes: [Int(maxWidth)],
+                                         rowSizes: [h, h],
+                                         tiles: [
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1)
+                                         ])
+            } else if allAreWide || allAreSquare {
+                // Next to each other, same ratio
+                let w: Float = (maxWidth-gap) / 2.0
+                let h: Float = max(min(w/ratios[0], min(w/ratios[1], maxHeight)), minHeight)
+                
+                let wInt: Int = Int(w.rounded())
+                let hInt: Int = Int(h.rounded())
+                
+                return MediaLayoutResult(width: Int(maxWidth),
+                                         height: hInt,
+                                         columnSizes: [wInt, Int(maxWidth)-wInt],
+                                         rowSizes: [hInt],
+                                         tiles: [
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0)
+                                         ])
+            } else {
+                // Next to each other, different ratios
+                let w0: Float = ((maxWidth - gap) / ratios[1] / (1.0 / ratios[0] + 1.0 / ratios[1]))
+                let w1: Float = maxWidth - w0 - gap
+                let h: Float = max(min(maxHeight, min(w0/ratios[0], w1/ratios[1])), minHeight)
+                
+                let w0Int = Int(w0.rounded())
+                let w1Int = Int(w1.rounded())
+                let hInt = Int(h.rounded())
+                
+                return MediaLayoutResult(width: Int((w0+w1+gap).rounded()),
+                                         height: hInt,
+                                         columnSizes: [w0Int, w1Int],
+                                         rowSizes: [hInt],
+                                         tiles: [
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0)
+                                         ])
+            }
+        case 3:
+            if ratios[0]>1.2*maxRatio || avgRatio>1.5*maxRatio || allAreWide {
+                // One above two smaller ones
+                var hCover: Float = min(maxWidth/ratios[0], (maxHeight-gap)*0.66)
+                let w2: Float = (maxWidth-gap)/2.0
+                var h: Float = min(maxHeight-hCover-gap, min(w2/ratios[1], w2/ratios[2]))
+                if hCover+h < minHeight {
+                    let prevTotalHeight = hCover+h
+                    hCover = minHeight*(hCover/prevTotalHeight)
+                    h = minHeight*(h/prevTotalHeight)
+                }
+                
+                return MediaLayoutResult(width: Int(maxWidth),
+                                         height: Int((hCover+h+gap).rounded()),
+                                         columnSizes: [Int(w2.rounded()), Int(maxWidth-w2.rounded())],
+                                         rowSizes: [Int(hCover.rounded()), Int(h.rounded())],
+                                         tiles: [
+                                            MediaLayoutResult.Tile(colSpan: 2, rowSpan: 1, startCol: 0, startRow: 0),
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1),
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1)
+                                         ])
+            } else {
+                // One on the left, two smaller ones on the right
+                let height: Float = min(maxHeight, maxWidth*0.66/avgRatio)
+                let wCover: Float = min(height*ratios[0], (maxWidth-gap)*0.66)
+                let h1: Float = ratios[1]*(height-gap)/(ratios[2]+ratios[1])
+                let h0: Float = height-h1-gap
+                let w: Float = min(maxWidth-wCover-gap, h1*ratios[2], h0*ratios[1])
+                
+                return MediaLayoutResult(width: Int((wCover+w+gap).rounded()),
+                                         height: Int(height.rounded()),
+                                         columnSizes: [Int(wCover.rounded()), Int(w.rounded())],
+                                         rowSizes: [Int(h0.rounded()), Int(h1.rounded())],
+                                         tiles: [
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 2, startCol: 0, startRow: 0),
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0),
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1)
+                                         ])
+            }
+        case 4:
+            if ratios[0]>1.2*maxRatio || avgRatio>1.5*maxRatio || allAreWide {
+                // One above three smaller ones
+                var hCover: Float = min(maxWidth/ratios[0], (maxHeight-gap)*0.66)
+                var h: Float = (maxWidth-2.0*gap)/(ratios[1]+ratios[2]+ratios[3])
+                let w0: Float = h*ratios[1]
+                let w1: Float = h*ratios[2]
+                h = min(maxHeight-hCover-gap, h)
+                if hCover+h<minHeight {
+                    let prevTotalHeight = hCover+h
+                    hCover = minHeight*(hCover/prevTotalHeight)
+                    h = minHeight*(h/prevTotalHeight)
+                }
+                
+                return MediaLayoutResult(width: Int(maxWidth),
+                                         height: Int((hCover+h+gap).rounded()),
+                                         columnSizes: [Int(w0.rounded()), Int(w1.rounded()), Int(maxWidth-w0.rounded()-w1.rounded())],
+                                         rowSizes: [Int(hCover.rounded()), Int(h.rounded())],
+                                         tiles: [
+                                            MediaLayoutResult.Tile(colSpan: 3, rowSpan: 1, startCol: 0, startRow: 0),
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1),
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1),
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 2, startRow: 1)
+                                         ])
+            } else {
+                // One on the left, three smaller ones on the right
+                let height: Float = min(maxHeight, maxWidth*0.66/avgRatio)
+                let wCover: Float = min(height*ratios[0], (maxWidth-gap)*0.66)
+                var w: Float = (height-2.0*gap)/(1.0/ratios[1]+1.0/ratios[2]+1.0/ratios[3])
+                let h0: Float = w/ratios[1]
+                let h1: Float = w/ratios[2]
+                let h2: Float = w/ratios[3]+gap
+                w = min(maxWidth-wCover-gap, w)
+                
+                return MediaLayoutResult(width: Int((wCover+gap+w).rounded()),
+                                         height: Int(height.rounded()),
+                                         columnSizes: [Int(wCover.rounded()), Int(w.rounded())],
+                                         rowSizes: [Int(h0.rounded()), Int(h1.rounded()), Int(h2.rounded())],
+                                         tiles: [
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 3, startCol: 0, startRow: 0),
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0),
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1),
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 2)
+                                         ])
+            }
+        default:
+            let cnt = attachments.count
+            var ratiosCropped: [Float] = []
+            if avgRatio>1.1 {
+                for ratio in ratios {
+                    ratiosCropped.append(max(1.0, ratio))
+                }
+            } else {
+                for ratio in ratios {
+                    ratiosCropped.append(min(1.0, ratio))
+                }
+            }
+            
+            var tries: [[Int]: [Float]] = [:]
+            
+            // One line
+            tries[[attachments.count]] = [calculateMultiThumbsHeight(ratios: ratiosCropped, width: maxWidth, margin: gap)]
+            
+            // Two lines
+            for firstLine in 1...cnt-1 {
+                tries[[firstLine, cnt-firstLine]] = [
+                    calculateMultiThumbsHeight(ratios: Array(ratiosCropped[..<firstLine]), width: maxWidth, margin: gap),
+                    calculateMultiThumbsHeight(ratios: Array(ratiosCropped[firstLine...]), width: maxWidth, margin: gap)
+                ]
+            }
+            
+            // Three lines
+            for firstLine in 1...cnt-2 {
+                for secondLine in 1...cnt-firstLine-1 {
+                    tries[[firstLine, secondLine, cnt-firstLine-secondLine]] = [
+                        calculateMultiThumbsHeight(ratios: Array(ratiosCropped[..<firstLine]), width: maxWidth, margin: gap),
+                        calculateMultiThumbsHeight(ratios: Array(ratiosCropped[firstLine..<firstLine+secondLine]), width: maxWidth, margin: gap),
+                        calculateMultiThumbsHeight(ratios: Array(ratiosCropped[(firstLine+secondLine)...]), width: maxWidth, margin: gap)
+                    ]
+                }
+            }
+            
+            let realMaxHeight = min(maxWidth, maxHeight)
+            
+            var optConf: [Int] = []
+            var optDiff: Float = Float.greatestFiniteMagnitude
+            
+            for (conf, heights) in tries {
+                let confH: Float = heights.reduce(gap*Float(heights.count-1), +)
+                var confDiff = abs(confH-realMaxHeight)
+                if conf.count>1 && (conf[0]>conf[1] || (conf.count>2 && conf[1]>conf[2])) {
+                    confDiff *= 1.1
+                }
+                if confDiff<optDiff {
+                    optConf = conf
+                    optDiff = confDiff
+                }
+            }
+            
+            var thumbsRemain: [MastodonAttachment] = Array(attachments)
+            var ratiosRemain: [Float] = Array(ratiosCropped)
+            let optHeights = tries[optConf]!
+            var totalHeight: Float = 0.0
+            var rowSizes: [Int] = []
+            var gridLineOffsets: [Int] = []
+            var rowTiles: [[MediaLayoutResult.Tile]] = []
+            
+            for (i, lineChunksNum) in optConf.enumerated() {
+                var lineThumbs: [MastodonAttachment] = []
+                for _ in 0..<lineChunksNum {
+                    lineThumbs.append(thumbsRemain.removeFirst())
+                }
+                let lineHeight = optHeights[i]
+                totalHeight += lineHeight
+                rowSizes.append(Int(lineHeight.rounded()))
+                var totalWidth: Int = 0
+                var row: [MediaLayoutResult.Tile] = []
+                for (j, _) in lineThumbs.enumerated() {
+                    let thumbRatio = ratiosRemain.removeFirst()
+                    let w: Float = j==lineThumbs.count-1 ? (maxWidth-Float(totalWidth)) : (thumbRatio*lineHeight)
+                    totalWidth += Int(w.rounded())
+                    if j<lineThumbs.count-1 && !gridLineOffsets.contains(totalWidth) {
+                        gridLineOffsets.append(totalWidth)
+                    }
+                    var tile = MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: i)
+                    tile.width = Int(w.rounded())
+                    row.append(tile)
+                }
+                rowTiles.append(row)
+            }
+            
+            gridLineOffsets = gridLineOffsets.sorted()
+            gridLineOffsets.append(Int(maxWidth))
+            
+            var columnSizes: [Int] = [gridLineOffsets[0]]
+            for (i, offset) in gridLineOffsets[1...].enumerated() {
+                columnSizes.append(offset - gridLineOffsets[i]) // i is already offset by one here
+            }
+            
+            for row in 0..<rowTiles.count {
+                var columnOffset: Int = 0
+                for (tile, _) in rowTiles[row].enumerated() {
+                    let startColumn = columnOffset
+                    rowTiles[row][tile].startCol = startColumn
+                    var width: Int = 0
+                    rowTiles[row][tile].colSpan = 0
+                    for i in startColumn..<columnSizes.count {
+                        width += columnSizes[i]
+                        rowTiles[row][tile].colSpan += 1
+                        if width == rowTiles[row][tile].width {
+                            break
+                        }
+                    }
+                    columnOffset += rowTiles[row][tile].colSpan
+                }
+            }
+            
+            return MediaLayoutResult(width: Int(maxWidth),
+                                     height: Int((totalHeight+gap*Float(optHeights.count-1)).rounded()),
+                                     columnSizes: columnSizes,
+                                     rowSizes: rowSizes,
+                                     tiles: rowTiles.reduce([], +))
+        }
+    }
+    
+    private static func calculateMultiThumbsHeight(ratios: [Float], width: Float, margin: Float) -> Float {
+        return (width-(Float(ratios.count)-1.0)*margin)/ratios.reduce(0.0, +)
+    }
 }

--- a/MastodonSDK/Sources/MastodonUI/Helper/MediaLayoutHelper.swift
+++ b/MastodonSDK/Sources/MastodonUI/Helper/MediaLayoutHelper.swift
@@ -41,7 +41,7 @@ class MediaLayoutHelper {
         var allAreWide = true
         var allAreSquare = true
         for att in attachments {
-            let ratio: CGFloat = CGFloat(att.size.width / att.size.height)
+            let ratio: CGFloat = max(0.45, CGFloat(att.size.width / att.size.height))
             if ratio <= 1.2 {
                 allAreWide = false
                 if ratio < 0.8 {

--- a/MastodonSDK/Sources/MastodonUI/Helper/MediaLayoutHelper.swift
+++ b/MastodonSDK/Sources/MastodonUI/Helper/MediaLayoutHelper.swift
@@ -1,6 +1,6 @@
 //
 //  MediaLayoutHelper.swift
-//  
+//
 //
 //  Created by Grishka on 25.03.2023.
 //
@@ -15,7 +15,7 @@ public struct MediaLayoutResult {
     let columnSizes: [Int]
     let rowSizes: [Int]
     let tiles: [Tile]
-    
+
     public struct Tile {
         var colSpan: Int
         let rowSpan: Int
@@ -26,25 +26,25 @@ public struct MediaLayoutResult {
 }
 
 class MediaLayoutHelper {
-    static let maxWidth: Float = 1000
-    static let maxHeight: Float = 1777
-    static let minHeight: Float = 563
-    static let gap: Float = 1.5
+    static let maxWidth: CGFloat = 1000
+    static let maxHeight: CGFloat = 1777
+    static let minHeight: CGFloat = 563
+    static let gap: CGFloat = 1.5
     static let maxRatio = maxWidth / maxHeight
-    
+
     public static func generateMediaLayout(attachments: [MastodonAttachment]) -> MediaLayoutResult? {
-        if attachments.count<2 {
+        if attachments.count < 2 {
             return nil
         }
-        
-        var ratios: [Float] = []
+
+        var ratios: [CGFloat] = []
         var allAreWide = true
         var allAreSquare = true
         for att in attachments {
-            let ratio: Float = Float(att.size.width/att.size.height)
+            let ratio: CGFloat = CGFloat(att.size.width / att.size.height)
             if ratio <= 1.2 {
                 allAreWide = false
-                if ratio<0.8 {
+                if ratio < 0.8 {
                     allAreSquare = false
                 }
             } else {
@@ -52,146 +52,146 @@ class MediaLayoutHelper {
             }
             ratios.append(ratio)
         }
-        
-        let avgRatio: Float = ratios.reduce(0.0, +) / Float(ratios.count)
-        
+
+        let avgRatio: CGFloat = ratios.reduce(0.0, +) / CGFloat(ratios.count)
+
         switch attachments.count {
         case 2:
-            if allAreWide && avgRatio>1.4*maxRatio && (ratios[1]-ratios[0])<0.2 {
+            if allAreWide && avgRatio > 1.4 * maxRatio && (ratios[1] - ratios[0]) < 0.2 {
                 // Two wide attachments, one above the other
-                let h = Int(max(min(maxWidth/ratios[0], min(maxWidth/ratios[1], (maxHeight-gap)/2.0)), minHeight/2.0).rounded())
-                
+                let h = Int(max(min(maxWidth / ratios[0], min(maxWidth / ratios[1], (maxHeight - gap) / 2.0)), minHeight / 2.0).rounded())
+
                 return MediaLayoutResult(width: Int(maxWidth),
-                                         height: Int((Float(h)*2.0+gap).rounded()),
-                                         columnSizes: [Int(maxWidth)],
-                                         rowSizes: [h, h],
-                                         tiles: [
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1)
-                                         ])
+                    height: Int((CGFloat(h) * 2.0 + gap).rounded()),
+                    columnSizes: [Int(maxWidth)],
+                    rowSizes: [h, h],
+                    tiles: [
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1)
+                    ])
             } else if allAreWide || allAreSquare {
                 // Next to each other, same ratio
-                let w: Float = (maxWidth-gap) / 2.0
-                let h: Float = max(min(w/ratios[0], min(w/ratios[1], maxHeight)), minHeight)
-                
+                let w: CGFloat = (maxWidth - gap) / 2.0
+                let h: CGFloat = max(min(w / ratios[0], min(w / ratios[1], maxHeight)), minHeight)
+
                 let wInt: Int = Int(w.rounded())
                 let hInt: Int = Int(h.rounded())
-                
+
                 return MediaLayoutResult(width: Int(maxWidth),
-                                         height: hInt,
-                                         columnSizes: [wInt, Int(maxWidth)-wInt],
-                                         rowSizes: [hInt],
-                                         tiles: [
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0)
-                                         ])
+                    height: hInt,
+                    columnSizes: [wInt, Int(maxWidth) - wInt],
+                    rowSizes: [hInt],
+                    tiles: [
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0)
+                    ])
             } else {
                 // Next to each other, different ratios
-                let w0: Float = ((maxWidth - gap) / ratios[1] / (1.0 / ratios[0] + 1.0 / ratios[1]))
-                let w1: Float = maxWidth - w0 - gap
-                let h: Float = max(min(maxHeight, min(w0/ratios[0], w1/ratios[1])), minHeight)
-                
+                let w0: CGFloat = ((maxWidth - gap) / ratios[1] / (1.0 / ratios[0] + 1.0 / ratios[1]))
+                let w1: CGFloat = maxWidth - w0 - gap
+                let h: CGFloat = max(min(maxHeight, min(w0 / ratios[0], w1 / ratios[1])), minHeight)
+
                 let w0Int = Int(w0.rounded())
                 let w1Int = Int(w1.rounded())
                 let hInt = Int(h.rounded())
-                
-                return MediaLayoutResult(width: Int((w0+w1+gap).rounded()),
-                                         height: hInt,
-                                         columnSizes: [w0Int, w1Int],
-                                         rowSizes: [hInt],
-                                         tiles: [
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0)
-                                         ])
+
+                return MediaLayoutResult(width: Int((w0 + w1 + gap).rounded()),
+                    height: hInt,
+                    columnSizes: [w0Int, w1Int],
+                    rowSizes: [hInt],
+                    tiles: [
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0)
+                    ])
             }
         case 3:
-            if ratios[0]>1.2*maxRatio || avgRatio>1.5*maxRatio || allAreWide {
+            if ratios[0] > 1.2 * maxRatio || avgRatio > 1.5 * maxRatio || allAreWide {
                 // One above two smaller ones
-                var hCover: Float = min(maxWidth/ratios[0], (maxHeight-gap)*0.66)
-                let w2: Float = (maxWidth-gap)/2.0
-                var h: Float = min(maxHeight-hCover-gap, min(w2/ratios[1], w2/ratios[2]))
-                if hCover+h < minHeight {
-                    let prevTotalHeight = hCover+h
-                    hCover = minHeight*(hCover/prevTotalHeight)
-                    h = minHeight*(h/prevTotalHeight)
+                var hCover: CGFloat = min(maxWidth / ratios[0], (maxHeight - gap) * 0.66)
+                let w2: CGFloat = (maxWidth - gap) / 2.0
+                var h: CGFloat = min(maxHeight - hCover - gap, min(w2 / ratios[1], w2 / ratios[2]))
+                if hCover + h < minHeight {
+                    let prevTotalHeight = hCover + h
+                    hCover = minHeight * (hCover / prevTotalHeight)
+                    h = minHeight * (h / prevTotalHeight)
                 }
-                
+
                 return MediaLayoutResult(width: Int(maxWidth),
-                                         height: Int((hCover+h+gap).rounded()),
-                                         columnSizes: [Int(w2.rounded()), Int(maxWidth-w2.rounded())],
-                                         rowSizes: [Int(hCover.rounded()), Int(h.rounded())],
-                                         tiles: [
-                                            MediaLayoutResult.Tile(colSpan: 2, rowSpan: 1, startCol: 0, startRow: 0),
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1),
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1)
-                                         ])
+                    height: Int((hCover + h + gap).rounded()),
+                    columnSizes: [Int(w2.rounded()), Int(maxWidth - w2.rounded())],
+                    rowSizes: [Int(hCover.rounded()), Int(h.rounded())],
+                    tiles: [
+                        MediaLayoutResult.Tile(colSpan: 2, rowSpan: 1, startCol: 0, startRow: 0),
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1),
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1)
+                    ])
             } else {
                 // One on the left, two smaller ones on the right
-                let height: Float = min(maxHeight, maxWidth*0.66/avgRatio)
-                let wCover: Float = min(height*ratios[0], (maxWidth-gap)*0.66)
-                let h1: Float = ratios[1]*(height-gap)/(ratios[2]+ratios[1])
-                let h0: Float = height-h1-gap
-                let w: Float = min(maxWidth-wCover-gap, h1*ratios[2], h0*ratios[1])
-                
-                return MediaLayoutResult(width: Int((wCover+w+gap).rounded()),
-                                         height: Int(height.rounded()),
-                                         columnSizes: [Int(wCover.rounded()), Int(w.rounded())],
-                                         rowSizes: [Int(h0.rounded()), Int(h1.rounded())],
-                                         tiles: [
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 2, startCol: 0, startRow: 0),
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0),
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1)
-                                         ])
+                let height: CGFloat = min(maxHeight, maxWidth * 0.66 / avgRatio)
+                let wCover: CGFloat = min(height * ratios[0], (maxWidth - gap) * 0.66)
+                let h1: CGFloat = ratios[1] * (height - gap) / (ratios[2] + ratios[1])
+                let h0: CGFloat = height - h1 - gap
+                let w: CGFloat = min(maxWidth - wCover - gap, h1 * ratios[2], h0 * ratios[1])
+
+                return MediaLayoutResult(width: Int((wCover + w + gap).rounded()),
+                    height: Int(height.rounded()),
+                    columnSizes: [Int(wCover.rounded()), Int(w.rounded())],
+                    rowSizes: [Int(h0.rounded()), Int(h1.rounded())],
+                    tiles: [
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 2, startCol: 0, startRow: 0),
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0),
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1)
+                    ])
             }
         case 4:
-            if ratios[0]>1.2*maxRatio || avgRatio>1.5*maxRatio || allAreWide {
+            if ratios[0] > 1.2 * maxRatio || avgRatio > 1.5 * maxRatio || allAreWide {
                 // One above three smaller ones
-                var hCover: Float = min(maxWidth/ratios[0], (maxHeight-gap)*0.66)
-                var h: Float = (maxWidth-2.0*gap)/(ratios[1]+ratios[2]+ratios[3])
-                let w0: Float = h*ratios[1]
-                let w1: Float = h*ratios[2]
-                h = min(maxHeight-hCover-gap, h)
-                if hCover+h<minHeight {
-                    let prevTotalHeight = hCover+h
-                    hCover = minHeight*(hCover/prevTotalHeight)
-                    h = minHeight*(h/prevTotalHeight)
+                var hCover: CGFloat = min(maxWidth / ratios[0], (maxHeight - gap) * 0.66)
+                var h: CGFloat = (maxWidth - 2.0 * gap) / (ratios[1] + ratios[2] + ratios[3])
+                let w0: CGFloat = h * ratios[1]
+                let w1: CGFloat = h * ratios[2]
+                h = min(maxHeight - hCover - gap, h)
+                if hCover + h < minHeight {
+                    let prevTotalHeight = hCover + h
+                    hCover = minHeight * (hCover / prevTotalHeight)
+                    h = minHeight * (h / prevTotalHeight)
                 }
-                
+
                 return MediaLayoutResult(width: Int(maxWidth),
-                                         height: Int((hCover+h+gap).rounded()),
-                                         columnSizes: [Int(w0.rounded()), Int(w1.rounded()), Int(maxWidth-w0.rounded()-w1.rounded())],
-                                         rowSizes: [Int(hCover.rounded()), Int(h.rounded())],
-                                         tiles: [
-                                            MediaLayoutResult.Tile(colSpan: 3, rowSpan: 1, startCol: 0, startRow: 0),
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1),
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1),
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 2, startRow: 1)
-                                         ])
+                    height: Int((hCover + h + gap).rounded()),
+                    columnSizes: [Int(w0.rounded()), Int(w1.rounded()), Int(maxWidth - w0.rounded() - w1.rounded())],
+                    rowSizes: [Int(hCover.rounded()), Int(h.rounded())],
+                    tiles: [
+                        MediaLayoutResult.Tile(colSpan: 3, rowSpan: 1, startCol: 0, startRow: 0),
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1),
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1),
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 2, startRow: 1)
+                    ])
             } else {
                 // One on the left, three smaller ones on the right
-                let height: Float = min(maxHeight, maxWidth*0.66/avgRatio)
-                let wCover: Float = min(height*ratios[0], (maxWidth-gap)*0.66)
-                var w: Float = (height-2.0*gap)/(1.0/ratios[1]+1.0/ratios[2]+1.0/ratios[3])
-                let h0: Float = w/ratios[1]
-                let h1: Float = w/ratios[2]
-                let h2: Float = w/ratios[3]+gap
-                w = min(maxWidth-wCover-gap, w)
-                
-                return MediaLayoutResult(width: Int((wCover+gap+w).rounded()),
-                                         height: Int(height.rounded()),
-                                         columnSizes: [Int(wCover.rounded()), Int(w.rounded())],
-                                         rowSizes: [Int(h0.rounded()), Int(h1.rounded()), Int(h2.rounded())],
-                                         tiles: [
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 3, startCol: 0, startRow: 0),
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0),
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1),
-                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 2)
-                                         ])
+                let height: CGFloat = min(maxHeight, maxWidth * 0.66 / avgRatio)
+                let wCover: CGFloat = min(height * ratios[0], (maxWidth - gap) * 0.66)
+                var w: CGFloat = (height - 2.0 * gap) / (1.0 / ratios[1] + 1.0 / ratios[2] + 1.0 / ratios[3])
+                let h0: CGFloat = w / ratios[1]
+                let h1: CGFloat = w / ratios[2]
+                let h2: CGFloat = w / ratios[3] + gap
+                w = min(maxWidth - wCover - gap, w)
+
+                return MediaLayoutResult(width: Int((wCover + gap + w).rounded()),
+                    height: Int(height.rounded()),
+                    columnSizes: [Int(wCover.rounded()), Int(w.rounded())],
+                    rowSizes: [Int(h0.rounded()), Int(h1.rounded()), Int(h2.rounded())],
+                    tiles: [
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 3, startCol: 0, startRow: 0),
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0),
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1),
+                        MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 2)
+                    ])
             }
         default:
             let cnt = attachments.count
-            var ratiosCropped: [Float] = []
-            if avgRatio>1.1 {
+            var ratiosCropped: [CGFloat] = []
+            if avgRatio > 1.1 {
                 for ratio in ratios {
                     ratiosCropped.append(max(1.0, ratio))
                 }
@@ -200,56 +200,56 @@ class MediaLayoutHelper {
                     ratiosCropped.append(min(1.0, ratio))
                 }
             }
-            
-            var tries: [[Int]: [Float]] = [:]
-            
+
+            var tries: [[Int]: [CGFloat]] = [:]
+
             // One line
             tries[[attachments.count]] = [calculateMultiThumbsHeight(ratios: ratiosCropped, width: maxWidth, margin: gap)]
-            
+
             // Two lines
-            for firstLine in 1...cnt-1 {
-                tries[[firstLine, cnt-firstLine]] = [
+            for firstLine in 1...cnt - 1 {
+                tries[[firstLine, cnt - firstLine]] = [
                     calculateMultiThumbsHeight(ratios: Array(ratiosCropped[..<firstLine]), width: maxWidth, margin: gap),
                     calculateMultiThumbsHeight(ratios: Array(ratiosCropped[firstLine...]), width: maxWidth, margin: gap)
                 ]
             }
-            
+
             // Three lines
-            for firstLine in 1...cnt-2 {
-                for secondLine in 1...cnt-firstLine-1 {
-                    tries[[firstLine, secondLine, cnt-firstLine-secondLine]] = [
+            for firstLine in 1...cnt - 2 {
+                for secondLine in 1...cnt - firstLine-1 {
+                    tries[[firstLine, secondLine, cnt - firstLine - secondLine]] = [
                         calculateMultiThumbsHeight(ratios: Array(ratiosCropped[..<firstLine]), width: maxWidth, margin: gap),
-                        calculateMultiThumbsHeight(ratios: Array(ratiosCropped[firstLine..<firstLine+secondLine]), width: maxWidth, margin: gap),
-                        calculateMultiThumbsHeight(ratios: Array(ratiosCropped[(firstLine+secondLine)...]), width: maxWidth, margin: gap)
+                        calculateMultiThumbsHeight(ratios: Array(ratiosCropped[firstLine..<firstLine + secondLine]), width: maxWidth, margin: gap),
+                        calculateMultiThumbsHeight(ratios: Array(ratiosCropped[(firstLine + secondLine)...]), width: maxWidth, margin: gap)
                     ]
                 }
             }
-            
+
             let realMaxHeight = min(maxWidth, maxHeight)
-            
+
             var optConf: [Int] = []
-            var optDiff: Float = Float.greatestFiniteMagnitude
-            
+            var optDiff: CGFloat = CGFloat.greatestFiniteMagnitude
+
             for (conf, heights) in tries {
-                let confH: Float = heights.reduce(gap*Float(heights.count-1), +)
-                var confDiff = abs(confH-realMaxHeight)
-                if conf.count>1 && (conf[0]>conf[1] || (conf.count>2 && conf[1]>conf[2])) {
+                let confH: CGFloat = heights.reduce(gap * CGFloat(heights.count - 1), +)
+                var confDiff = abs(confH - realMaxHeight)
+                if conf.count > 1 && (conf[0] > conf[1] || (conf.count > 2 && conf[1] > conf[2])) {
                     confDiff *= 1.1
                 }
-                if confDiff<optDiff {
+                if confDiff < optDiff {
                     optConf = conf
                     optDiff = confDiff
                 }
             }
-            
+
             var thumbsRemain: [MastodonAttachment] = Array(attachments)
-            var ratiosRemain: [Float] = Array(ratiosCropped)
+            var ratiosRemain: [CGFloat] = Array(ratiosCropped)
             let optHeights = tries[optConf]!
-            var totalHeight: Float = 0.0
+            var totalHeight: CGFloat = 0.0
             var rowSizes: [Int] = []
             var gridLineOffsets: [Int] = []
             var rowTiles: [[MediaLayoutResult.Tile]] = []
-            
+
             for (i, lineChunksNum) in optConf.enumerated() {
                 var lineThumbs: [MastodonAttachment] = []
                 for _ in 0..<lineChunksNum {
@@ -262,9 +262,9 @@ class MediaLayoutHelper {
                 var row: [MediaLayoutResult.Tile] = []
                 for (j, _) in lineThumbs.enumerated() {
                     let thumbRatio = ratiosRemain.removeFirst()
-                    let w: Float = j==lineThumbs.count-1 ? (maxWidth-Float(totalWidth)) : (thumbRatio*lineHeight)
+                    let w: CGFloat = j == lineThumbs.count - 1 ? (maxWidth - CGFloat(totalWidth)) : (thumbRatio * lineHeight)
                     totalWidth += Int(w.rounded())
-                    if j<lineThumbs.count-1 && !gridLineOffsets.contains(totalWidth) {
+                    if j < lineThumbs.count - 1 && !gridLineOffsets.contains(totalWidth) {
                         gridLineOffsets.append(totalWidth)
                     }
                     var tile = MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: i)
@@ -273,15 +273,15 @@ class MediaLayoutHelper {
                 }
                 rowTiles.append(row)
             }
-            
+
             gridLineOffsets = gridLineOffsets.sorted()
             gridLineOffsets.append(Int(maxWidth))
-            
+
             var columnSizes: [Int] = [gridLineOffsets[0]]
             for (i, offset) in gridLineOffsets[1...].enumerated() {
                 columnSizes.append(offset - gridLineOffsets[i]) // i is already offset by one here
             }
-            
+
             for row in 0..<rowTiles.count {
                 var columnOffset: Int = 0
                 for (tile, _) in rowTiles[row].enumerated() {
@@ -299,16 +299,16 @@ class MediaLayoutHelper {
                     columnOffset += rowTiles[row][tile].colSpan
                 }
             }
-            
+
             return MediaLayoutResult(width: Int(maxWidth),
-                                     height: Int((totalHeight+gap*Float(optHeights.count-1)).rounded()),
-                                     columnSizes: columnSizes,
-                                     rowSizes: rowSizes,
-                                     tiles: rowTiles.reduce([], +))
+                height: Int((totalHeight + gap * CGFloat(optHeights.count - 1)).rounded()),
+                columnSizes: columnSizes,
+                rowSizes: rowSizes,
+                tiles: rowTiles.reduce([], +))
         }
     }
-    
-    private static func calculateMultiThumbsHeight(ratios: [Float], width: Float, margin: Float) -> Float {
-        return (width-(Float(ratios.count)-1.0)*margin)/ratios.reduce(0.0, +)
+
+    private static func calculateMultiThumbsHeight(ratios: [CGFloat], width: CGFloat, margin: CGFloat) -> CGFloat {
+        return (width - (CGFloat(ratios.count) - 1.0) * margin) / ratios.reduce(0.0, +)
     }
 }

--- a/MastodonSDK/Sources/MastodonUI/Helper/MediaLayoutHelper.swift
+++ b/MastodonSDK/Sources/MastodonUI/Helper/MediaLayoutHelper.swift
@@ -1,0 +1,314 @@
+//
+//  MediaLayoutHelper.swift
+//  
+//
+//  Created by Grishka on 25.03.2023.
+//
+
+import Foundation
+import MastodonSDK
+import CoreDataStack
+
+public struct MediaLayoutResult {
+	let width: Int
+	let height: Int
+	let columnSizes: [Int]
+	let rowSizes: [Int]
+	let tiles: [Tile]
+	
+	public struct Tile {
+		var colSpan: Int
+		let rowSpan: Int
+		var startCol: Int
+		let startRow: Int
+		var width: Int = 0
+	}
+}
+
+class MediaLayoutHelper {
+	static let maxWidth: Float = 1000
+	static let maxHeight: Float = 1777
+	static let minHeight: Float = 563
+	static let gap: Float = 1.5
+	static let maxRatio: Float = Float(maxWidth) / Float(maxHeight)
+	
+	public static func generateMediaLayout(attachments: [MastodonAttachment]) -> MediaLayoutResult? {
+		if attachments.count<2 {
+			return nil
+		}
+		
+		var ratios: [Float] = []
+		var allAreWide = true
+		var allAreSquare = true
+		for att in attachments {
+			let ratio: Float = Float(att.size.width/att.size.height)
+			if ratio<=1.2 {
+				allAreWide = false
+				if ratio<0.8 {
+					allAreSquare = false
+				}
+			} else {
+				allAreSquare = false
+			}
+			ratios.append(ratio)
+		}
+		
+		let avgRatio: Float = ratios.reduce(0.0, +) / Float(ratios.count)
+		
+		switch attachments.count {
+		case 2:
+			if allAreWide && avgRatio>1.4*maxRatio && (ratios[1]-ratios[0])<0.2 {
+				// Two wide attachments, one above the other
+				let h = Int(max(min(maxWidth/ratios[0], min(maxWidth/ratios[1], (maxHeight-gap)/2.0)), minHeight/2.0).rounded())
+				
+				return MediaLayoutResult(width: Int(maxWidth),
+								  height: Int((Float(h)*2.0+gap).rounded()),
+								  columnSizes: [Int(maxWidth)],
+								  rowSizes: [h, h],
+								  tiles: [
+									MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
+									MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1)
+								  ])
+			} else if allAreWide || allAreSquare {
+				// Next to each other, same ratio
+				let w: Float = (maxWidth-gap) / 2.0
+				let h: Float = max(min(w/ratios[0], min(w/ratios[1], maxHeight)), minHeight)
+				
+				let wInt: Int = Int(w.rounded())
+				let hInt: Int = Int(h.rounded())
+				
+				return MediaLayoutResult(width: Int(maxWidth),
+										 height: hInt,
+										 columnSizes: [wInt, Int(maxWidth)-wInt],
+										 rowSizes: [hInt],
+										 tiles: [
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0)
+										 ])
+			} else {
+				// Next to each other, different ratios
+				let w0: Float = ((maxWidth - gap) / ratios[1] / (1.0 / ratios[0] + 1.0 / ratios[1]))
+				let w1: Float = maxWidth - w0 - gap
+				let h: Float = max(min(maxHeight, min(w0/ratios[0], w1/ratios[1])), minHeight)
+				
+				let w0Int = Int(w0.rounded())
+				let w1Int = Int(w1.rounded())
+				let hInt = Int(h.rounded())
+				
+				return MediaLayoutResult(width: Int((w0+w1+gap).rounded()),
+										 height: hInt,
+										 columnSizes: [w0Int, w1Int],
+										 rowSizes: [hInt],
+										 tiles: [
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0)
+										 ])
+			}
+		case 3:
+			if ratios[0]>1.2*maxRatio || avgRatio>1.5*maxRatio || allAreWide {
+				// One above two smaller ones
+				var hCover: Float = min(maxWidth/ratios[0], (maxHeight-gap)*0.66)
+				let w2: Float = (maxWidth-gap)/2.0
+				var h: Float = min(maxHeight-hCover-gap, min(w2/ratios[1], w2/ratios[2]))
+				if hCover+h < minHeight {
+					let prevTotalHeight = hCover+h
+					hCover = minHeight*(hCover/prevTotalHeight)
+					h = minHeight*(h/prevTotalHeight)
+				}
+				
+				return MediaLayoutResult(width: Int(maxWidth),
+										 height: Int((hCover+h+gap).rounded()),
+										 columnSizes: [Int(w2.rounded()), Int(maxWidth-w2.rounded())],
+										 rowSizes: [Int(hCover.rounded()), Int(h.rounded())],
+										 tiles: [
+											MediaLayoutResult.Tile(colSpan: 2, rowSpan: 1, startCol: 0, startRow: 0),
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1),
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1)
+										 ])
+			} else {
+				// One on the left, two smaller ones on the right
+				let height: Float = min(maxHeight, maxWidth*0.66/avgRatio)
+				let wCover: Float = min(height*ratios[0], (maxWidth-gap)*0.66)
+				let h1: Float = ratios[1]*(height-gap)/(ratios[2]+ratios[1])
+				let h0: Float = height-h1-gap
+				let w: Float = min(maxWidth-wCover-gap, h1*ratios[2], h0*ratios[1])
+				
+				return MediaLayoutResult(width: Int((wCover+w+gap).rounded()),
+										 height: Int(height.rounded()),
+										 columnSizes: [Int(wCover.rounded()), Int(w.rounded())],
+										 rowSizes: [Int(h0.rounded()), Int(h1.rounded())],
+										 tiles: [
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 2, startCol: 0, startRow: 0),
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0),
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1)
+										 ])
+			}
+		case 4:
+			if ratios[0]>1.2*maxRatio || avgRatio>1.5*maxRatio || allAreWide {
+				// One above three smaller ones
+				var hCover: Float = min(maxWidth/ratios[0], (maxHeight-gap)*0.66)
+				var h: Float = (maxWidth-2.0*gap)/(ratios[1]+ratios[2]+ratios[3])
+				let w0: Float = h*ratios[1]
+				let w1: Float = h*ratios[2]
+				h = min(maxHeight-hCover-gap, h)
+				if hCover+h<minHeight {
+					let prevTotalHeight = hCover+h
+					hCover = minHeight*(hCover/prevTotalHeight)
+					h = minHeight*(h/prevTotalHeight)
+				}
+				
+				return MediaLayoutResult(width: Int(maxWidth),
+										 height: Int((hCover+h+gap).rounded()),
+										 columnSizes: [Int(w0.rounded()), Int(w1.rounded()), Int(maxWidth-w0.rounded()-w1.rounded())],
+										 rowSizes: [Int(hCover.rounded()), Int(h.rounded())],
+										 tiles: [
+											MediaLayoutResult.Tile(colSpan: 3, rowSpan: 1, startCol: 0, startRow: 0),
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1),
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1),
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 2, startRow: 1)
+										 ])
+			} else {
+				// One on the left, three smaller ones on the right
+				let height: Float = min(maxHeight, maxWidth*0.66/avgRatio)
+				let wCover: Float = min(height*ratios[0], (maxWidth-gap)*0.66)
+				var w: Float = (height-2.0*gap)/(1.0/ratios[1]+1.0/ratios[2]+1.0/ratios[3])
+				let h0: Float = w/ratios[1]
+				let h1: Float = w/ratios[2]
+				let h2: Float = w/ratios[3]+gap
+				w = min(maxWidth-wCover-gap, w)
+				
+				return MediaLayoutResult(width: Int((wCover+gap+w).rounded()),
+										 height: Int(height.rounded()),
+										 columnSizes: [Int(wCover.rounded()), Int(w.rounded())],
+										 rowSizes: [Int(h0.rounded()), Int(h1.rounded()), Int(h2.rounded())],
+										 tiles: [
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 3, startCol: 0, startRow: 0),
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 0),
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 1),
+											MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 1, startRow: 2)
+										 ])
+			}
+		default:
+			let cnt = attachments.count
+			var ratiosCropped: [Float] = []
+			if avgRatio>1.1 {
+				for ratio in ratios {
+					ratiosCropped.append(max(1.0, ratio))
+				}
+			} else {
+				for ratio in ratios {
+					ratiosCropped.append(min(1.0, ratio))
+				}
+			}
+			
+			var tries: [[Int]: [Float]] = [:]
+			
+			// One line
+			tries[[attachments.count]] = [calculateMultiThumbsHeight(ratios: ratiosCropped, width: maxWidth, margin: gap)]
+			
+			// Two lines
+			for firstLine in 1...cnt-1 {
+				tries[[firstLine, cnt-firstLine]] = [
+					calculateMultiThumbsHeight(ratios: Array(ratiosCropped[..<firstLine]), width: maxWidth, margin: gap),
+					calculateMultiThumbsHeight(ratios: Array(ratiosCropped[firstLine...]), width: maxWidth, margin: gap)
+				]
+			}
+			
+			// Three lines
+			for firstLine in 1...cnt-2 {
+				for secondLine in 1...cnt-firstLine-1 {
+					tries[[firstLine, secondLine, cnt-firstLine-secondLine]] = [
+						calculateMultiThumbsHeight(ratios: Array(ratiosCropped[..<firstLine]), width: maxWidth, margin: gap),
+						calculateMultiThumbsHeight(ratios: Array(ratiosCropped[firstLine..<firstLine+secondLine]), width: maxWidth, margin: gap),
+						calculateMultiThumbsHeight(ratios: Array(ratiosCropped[(firstLine+secondLine)...]), width: maxWidth, margin: gap)
+					]
+				}
+			}
+			
+			let realMaxHeight = min(maxWidth, maxHeight)
+			
+			var optConf: [Int] = []
+			var optDiff: Float = Float.greatestFiniteMagnitude
+			
+			for (conf, heights) in tries {
+				let confH: Float = heights.reduce(gap*Float(heights.count-1), +)
+				var confDiff = abs(confH-realMaxHeight)
+				if conf.count>1 && (conf[0]>conf[1] || (conf.count>2 && conf[1]>conf[2])) {
+					confDiff *= 1.1
+				}
+				if confDiff<optDiff {
+					optConf = conf
+					optDiff = confDiff
+				}
+			}
+			
+			var thumbsRemain: [MastodonAttachment] = Array(attachments)
+			var ratiosRemain: [Float] = Array(ratiosCropped)
+			let optHeights = tries[optConf]!
+			var totalHeight: Float = 0.0
+			var rowSizes: [Int] = []
+			var gridLineOffsets: [Int] = []
+			var rowTiles: [[MediaLayoutResult.Tile]] = []
+			
+			for (i, lineChunksNum) in optConf.enumerated() {
+				var lineThumbs: [MastodonAttachment] = []
+				for _ in 0..<lineChunksNum {
+					lineThumbs.append(thumbsRemain.removeFirst())
+				}
+				let lineHeight = optHeights[i]
+				totalHeight += lineHeight
+				rowSizes.append(Int(lineHeight.rounded()))
+				var totalWidth: Int = 0
+				var row: [MediaLayoutResult.Tile] = []
+				for (j, _) in lineThumbs.enumerated() {
+					let thumbRatio = ratiosRemain.removeFirst()
+					let w: Float = j==lineThumbs.count-1 ? (maxWidth-Float(totalWidth)) : (thumbRatio*lineHeight)
+					totalWidth += Int(w.rounded())
+					if j<lineThumbs.count-1 && !gridLineOffsets.contains(totalWidth) {
+						gridLineOffsets.append(totalWidth)
+					}
+					var tile = MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: i)
+					tile.width = Int(w.rounded())
+					row.append(tile)
+				}
+				rowTiles.append(row)
+			}
+			
+			gridLineOffsets = gridLineOffsets.sorted()
+			gridLineOffsets.append(Int(maxWidth))
+			
+			var columnSizes: [Int] = [gridLineOffsets[0]]
+			for (i, offset) in gridLineOffsets[1...].enumerated() {
+				columnSizes.append(offset - gridLineOffsets[i]) // i is already offset by one here
+			}
+			
+			for (row, _) in rowTiles.enumerated() {
+				var columnOffset: Int = 0
+				for (tile, _) in rowTiles[row].enumerated() {
+					let startColumn = columnOffset
+					rowTiles[row][tile].startCol = startColumn
+					var width: Int = 0
+					rowTiles[row][tile].colSpan = 0
+					for i in startColumn..<columnSizes.count {
+						width += columnSizes[i]
+						rowTiles[row][tile].colSpan += 1
+						if width == rowTiles[row][tile].width {
+							break
+						}
+					}
+					columnOffset += rowTiles[row][tile].colSpan
+				}
+			}
+			
+			return MediaLayoutResult(width: Int(maxWidth),
+									 height: Int((totalHeight+gap*Float(optHeights.count-1)).rounded()),
+									 columnSizes: columnSizes,
+									 rowSizes: rowSizes,
+									 tiles: rowTiles.reduce([], +))
+		}
+	}
+	
+	private static func calculateMultiThumbsHeight(ratios: [Float], width: Float, margin: Float) -> Float {
+		return (width-(Float(ratios.count)-1.0)*margin)/ratios.reduce(0.0, +)
+	}
+}

--- a/MastodonSDK/Sources/MastodonUI/Helper/MediaLayoutHelper.swift
+++ b/MastodonSDK/Sources/MastodonUI/Helper/MediaLayoutHelper.swift
@@ -57,7 +57,7 @@ class MediaLayoutHelper {
 
         switch attachments.count {
         case 2:
-            if allAreWide && avgRatio > 1.4 * maxRatio && (ratios[1] - ratios[0]) < 0.2 {
+			if allAreWide && avgRatio > 1.4 * maxRatio && abs(ratios[1] - ratios[0]) < 0.2 {
                 // Two wide attachments, one above the other
                 let h = Int(max(min(maxWidth / ratios[0], min(maxWidth / ratios[1], (maxHeight - gap) / 2.0)), minHeight / 2.0).rounded())
 
@@ -69,7 +69,26 @@ class MediaLayoutHelper {
                         MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
                         MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1)
                     ])
-            } else if allAreWide || allAreSquare {
+            } else if allAreWide {
+                // two wide photos, one above the other, different ratios
+                var h0 = maxWidth / ratios[0]
+                var h1 = maxWidth / ratios[1]
+                if h0 + h1 < minHeight {
+                    let prevTotalHeight = h0 + h1
+                    h0 = minHeight * (h0 / prevTotalHeight)
+                    h1 = minHeight * (h1 / prevTotalHeight)
+                }
+                let h0Int = Int(h0.rounded())
+                let h1Int = Int(h1.rounded())
+                return MediaLayoutResult(width: Int(maxWidth),
+                                         height: h0Int + h1Int + Int(gap),
+                                         columnSizes: [Int(maxWidth)],
+                                         rowSizes: [h0Int, h1Int],
+                                         tiles: [
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 0),
+                                            MediaLayoutResult.Tile(colSpan: 1, rowSpan: 1, startCol: 0, startRow: 1)
+                                         ])
+            } else if allAreSquare {
                 // Next to each other, same ratio
                 let w: CGFloat = (maxWidth - gap) / 2.0
                 let h: CGFloat = max(min(w / ratios[0], min(w / ratios[1], maxHeight)), minHeight)

--- a/MastodonSDK/Sources/MastodonUI/View/Container/MediaGridContainerView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Container/MediaGridContainerView.swift
@@ -229,7 +229,7 @@ extension MediaGridContainerView {
 
 class GridLayoutView : UIView {
 	private var layout: MediaLayoutResult?
-	private var measuredHeight = 0
+	private(set) var measuredHeight = 0
 	
 	private static let maxWidth = 400
 	private static let gap = 2

--- a/MastodonSDK/Sources/MastodonUI/View/Container/MediaGridContainerView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Container/MediaGridContainerView.swift
@@ -66,7 +66,7 @@ public final class MediaGridContainerView: UIView {
         }
         set { }
     }
-
+    
 }
 
 extension MediaGridContainerView {
@@ -83,7 +83,7 @@ extension MediaGridContainerView {
         let mediaView = _mediaViews[index]
         delegate?.mediaGridContainerView(self, didTapMediaView: mediaView, at: index)
     }
-
+    
     @objc private func sensitiveToggleButtonDidPressed(_ sender: UIButton) {
         logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public)")
         delegate?.mediaGridContainerView(self, mediaSensitiveButtonDidPressed: sender)
@@ -91,7 +91,7 @@ extension MediaGridContainerView {
 }
 
 extension MediaGridContainerView {
-
+    
     public func dequeueMediaView(adaptiveLayout layout: AdaptiveLayout) -> MediaView {
         prepareForReuse()
         
@@ -129,7 +129,7 @@ extension MediaGridContainerView {
         
         removeConstraints(constraints)
     }
-
+    
 }
 
 extension MediaGridContainerView {
@@ -183,12 +183,12 @@ extension MediaGridContainerView {
         
         let count: Int
         let maxSize: CGSize
-		let layout: MediaLayoutResult
+        let layout: MediaLayoutResult
         
-		init(count: Int, maxSize: CGSize, layout: MediaLayoutResult) {
+        init(count: Int, maxSize: CGSize, layout: MediaLayoutResult) {
             self.count = min(count, 10)
             self.maxSize = maxSize
-			self.layout = layout
+            self.layout = layout
         }
         
         private func createStackView(axis: NSLayoutConstraint.Axis) -> UIStackView {
@@ -202,23 +202,23 @@ extension MediaGridContainerView {
         
         public func layout(in view: UIView, mediaViews: [MediaView]) {
             let count = mediaViews.count
-			
-			if count<2 || count>maxCount {
-				assertionFailure("unexpected attachment count \(count)")
-				return
-			}
-			
-			let layoutView = GridLayoutView()
-			layoutView.translatesAutoresizingMaskIntoConstraints = false
-			view.addSubview(layoutView)
-			layoutView.pinToParent()
-			for mediaView in mediaViews {
-				layoutView.addSubview(mediaView)
-			}
-			layoutView.prepare(layout: layout, maxSize: maxSize)
+            
+            if count<2 || count>maxCount {
+                assertionFailure("unexpected attachment count \(count)")
+                return
+            }
+            
+            let layoutView = GridLayoutView()
+            layoutView.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview(layoutView)
+            layoutView.pinToParent()
+            for mediaView in mediaViews {
+                layoutView.addSubview(mediaView)
+            }
+            layoutView.prepare(layout: layout, maxSize: maxSize)
             
             let containerWidth = maxSize.width
-			let containerHeight = CGFloat(layoutView.getMeasuredHeight())
+            let containerHeight = CGFloat(layoutView.getMeasuredHeight())
             NSLayoutConstraint.activate([
                 view.widthAnchor.constraint(equalToConstant: containerWidth).priority(.required - 1),
                 view.heightAnchor.constraint(equalToConstant: containerHeight).priority(.required - 1),
@@ -228,69 +228,69 @@ extension MediaGridContainerView {
 }
 
 class GridLayoutView : UIView {
-	private var layout: MediaLayoutResult?
-	private(set) var measuredHeight = 0
-	
-	private static let maxWidth = 400
-	private static let gap = 2
-	
-	public func prepare(layout: MediaLayoutResult, maxSize: CGSize) {
-		self.layout = layout
-		let width: Float = min(Float(maxSize.width), Float(GridLayoutView.maxWidth))
-		let height: Float = (width*Float(layout.height)/MediaLayoutHelper.maxWidth)
-		measuredHeight = Int(height.rounded())
-	}
-	
-	public func getMeasuredHeight() -> Int {
-		return measuredHeight
-	}
-	
-	override func layoutSubviews() {
-		guard let layout = layout else { return }
-		var width: Int = min(GridLayoutView.maxWidth, Int(frame.width))
-		let height: Int = Int(frame.height)
-		if layout.width<Int(MediaLayoutHelper.maxWidth) {
-			width = Int((Float(width)*(Float(layout.width)/MediaLayoutHelper.maxWidth)).rounded())
-		}
-		
-		var columnStarts: [Int] = []
-		var columnEnds: [Int] = []
-		var rowStarts: [Int] = []
-		var rowEnds: [Int] = []
-		var offset: Int = 0
-		
-		for colSize in layout.columnSizes {
-			columnStarts.append(offset)
-			offset += Int((Float(colSize)/Float(layout.width)*Float(width)).rounded())
-			columnEnds.append(offset)
-			offset += GridLayoutView.gap
-		}
-		columnEnds.append(width)
-		offset = 0
-		for rowSize in layout.rowSizes {
-			rowStarts.append(offset)
-			offset += Int((Float(rowSize)/Float(layout.height)*Float(height)).rounded())
-			rowEnds.append(offset)
-			offset += GridLayoutView.gap
-		}
-		rowEnds.append(height)
-		
-		var xOffset: Int = 0
-		if Int(frame.width)>width {
-			xOffset = Int((Float(frame.width)/2.0-Float(width)/2.0).rounded())
-		}
-		
-		for (i, view) in subviews.enumerated() {
-			if i>=layout.tiles.count {
-				break // TODO make sure any additional subviews are only added at the end
-			}
-			let tile = layout.tiles[i]
-			let colSpan = max(1, tile.colSpan) - 1
-			let rowSpan = max(1, tile.rowSpan) - 1
-			let x = columnStarts[tile.startCol]
-			let y = rowStarts[tile.startRow]
-			view.frame = CGRect(x: x+xOffset, y: y, width: columnEnds[tile.startCol+colSpan]-x, height: rowEnds[tile.startRow+rowSpan]-y)
-		}
-	}
+    private var layout: MediaLayoutResult?
+    private(set) var measuredHeight = 0
+    
+    private static let maxWidth = 400
+    private static let gap = 2
+    
+    public func prepare(layout: MediaLayoutResult, maxSize: CGSize) {
+        self.layout = layout
+        let width: Float = min(Float(maxSize.width), Float(GridLayoutView.maxWidth))
+        let height: Float = (width*Float(layout.height)/MediaLayoutHelper.maxWidth)
+        measuredHeight = Int(height.rounded())
+    }
+    
+    public func getMeasuredHeight() -> Int {
+        return measuredHeight
+    }
+    
+    override func layoutSubviews() {
+        guard let layout = layout else { return }
+        var width: Int = min(GridLayoutView.maxWidth, Int(frame.width))
+        let height: Int = Int(frame.height)
+        if layout.width<Int(MediaLayoutHelper.maxWidth) {
+            width = Int((Float(width)*(Float(layout.width)/MediaLayoutHelper.maxWidth)).rounded())
+        }
+        
+        var columnStarts: [Int] = []
+        var columnEnds: [Int] = []
+        var rowStarts: [Int] = []
+        var rowEnds: [Int] = []
+        var offset: Int = 0
+        
+        for colSize in layout.columnSizes {
+            columnStarts.append(offset)
+            offset += Int((Float(colSize)/Float(layout.width)*Float(width)).rounded())
+            columnEnds.append(offset)
+            offset += GridLayoutView.gap
+        }
+        columnEnds.append(width)
+        offset = 0
+        for rowSize in layout.rowSizes {
+            rowStarts.append(offset)
+            offset += Int((Float(rowSize)/Float(layout.height)*Float(height)).rounded())
+            rowEnds.append(offset)
+            offset += GridLayoutView.gap
+        }
+        rowEnds.append(height)
+        
+        var xOffset: Int = 0
+        if Int(frame.width)>width {
+            xOffset = Int((Float(frame.width)/2.0-Float(width)/2.0).rounded())
+        }
+        
+        for (i, view) in subviews.enumerated() {
+            if i>=layout.tiles.count {
+                break // TODO make sure any additional subviews are only added at the end
+            }
+            let tile = layout.tiles[i]
+            let colSpan = max(1, tile.colSpan) - 1
+            let rowSpan = max(1, tile.rowSpan) - 1
+            let x = columnStarts[tile.startCol]
+            let y = rowStarts[tile.startRow]
+            view.frame = CGRect(x: x+xOffset, y: y, width: columnEnds[tile.startCol+colSpan]-x, height: rowEnds[tile.startRow+rowSpan]-y)
+        }
+    }
 }
 

--- a/MastodonSDK/Sources/MastodonUI/View/Container/MediaGridContainerView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Container/MediaGridContainerView.swift
@@ -19,9 +19,9 @@ public final class MediaGridContainerView: UIView {
     
     static let sensitiveToggleButtonSize = CGSize(width: 34, height: 34)
     public static let maxCount = 10
-    
+
     let logger = Logger(subsystem: "MediaGridContainerView", category: "UI")
-    
+
     public weak var delegate: MediaGridContainerViewDelegate?
     public private(set) lazy var viewModel: ViewModel = {
         let viewModel = ViewModel()
@@ -83,7 +83,7 @@ extension MediaGridContainerView {
         let mediaView = _mediaViews[index]
         delegate?.mediaGridContainerView(self, didTapMediaView: mediaView, at: index)
     }
-    
+
     @objc private func sensitiveToggleButtonDidPressed(_ sender: UIButton) {
         logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public)")
         delegate?.mediaGridContainerView(self, mediaSensitiveButtonDidPressed: sender)
@@ -91,7 +91,7 @@ extension MediaGridContainerView {
 }
 
 extension MediaGridContainerView {
-    
+
     public func dequeueMediaView(adaptiveLayout layout: AdaptiveLayout) -> MediaView {
         prepareForReuse()
         
@@ -129,7 +129,7 @@ extension MediaGridContainerView {
         
         removeConstraints(constraints)
     }
-    
+
 }
 
 extension MediaGridContainerView {

--- a/MastodonSDK/Sources/MastodonUI/View/Container/MediaGridContainerView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Container/MediaGridContainerView.swift
@@ -210,6 +210,7 @@ extension MediaGridContainerView {
             view.addSubview(layoutView)
             layoutView.pinToParent()
             for mediaView in mediaViews {
+                mediaView.translatesAutoresizingMaskIntoConstraints = true
                 layoutView.addSubview(mediaView)
             }
             layoutView.prepare(layout: layout, maxSize: maxSize)
@@ -239,6 +240,7 @@ class GridLayoutView: UIView {
     }
 
     override func layoutSubviews() {
+        super.layoutSubviews()
         guard let layout = layout else { return }
         var width: Int = min(GridLayoutView.maxWidth, Int(frame.width))
         let height: Int = Int(frame.height)
@@ -273,17 +275,25 @@ class GridLayoutView: UIView {
             xOffset = Int((CGFloat(frame.width) / 2.0 - CGFloat(width) / 2.0).rounded())
         }
 
-        for (i, view) in subviews.enumerated() {
-            if i >= layout.tiles.count {
-                break // TODO make sure any additional subviews are only added at the end
+        var i: Int = 0
+        for view in subviews {
+            if let mediaView = view as? MediaView {
+                if i >= layout.tiles.count {
+                    break
+                }
+                let tile = layout.tiles[i]
+                let colSpan = max(1, tile.colSpan) - 1
+                let rowSpan = max(1, tile.rowSpan) - 1
+                let x = columnStarts[tile.startCol]
+                let y = rowStarts[tile.startRow]
+                mediaView.layer.removeAllAnimations()
+                mediaView.container.layer.removeAllAnimations()
+                mediaView.imageView.layer.removeAllAnimations()
+                mediaView.frame = CGRect(x: x + xOffset, y: y, width: columnEnds[tile.startCol + colSpan] - x, height: rowEnds[tile.startRow + rowSpan] - y)
+                mediaView.setNeedsLayout()
+                mediaView.layoutIfNeeded()
+                i = i + 1
             }
-            let tile = layout.tiles[i]
-            let colSpan = max(1, tile.colSpan) - 1
-            let rowSpan = max(1, tile.rowSpan) - 1
-            let x = columnStarts[tile.startCol]
-            let y = rowStarts[tile.startRow]
-            view.frame = CGRect(x: x + xOffset, y: y, width: columnEnds[tile.startCol + colSpan] - x, height: rowEnds[tile.startRow + rowSpan] - y)
-            view.setNeedsLayout()
         }
     }
 }

--- a/MastodonSDK/Sources/MastodonUI/View/Container/MediaGridContainerView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Container/MediaGridContainerView.swift
@@ -216,62 +216,6 @@ extension MediaGridContainerView {
 				layoutView.addSubview(mediaView)
 			}
 			layoutView.prepare(layout: layout, maxSize: maxSize)
-			
-            /*switch count {
-            case 1:
-                assertionFailure("should use Adaptive Layout")
-                containerVerticalStackView.addArrangedSubview(mediaViews[0])
-            case 2:
-                let horizontalStackView = createStackView(axis: .horizontal)
-                containerVerticalStackView.addArrangedSubview(horizontalStackView)
-                horizontalStackView.addArrangedSubview(mediaViews[0])
-                horizontalStackView.addArrangedSubview(mediaViews[1])
-            case 3:
-                let horizontalStackView = createStackView(axis: .horizontal)
-                containerVerticalStackView.addArrangedSubview(horizontalStackView)
-                horizontalStackView.addArrangedSubview(mediaViews[0])
-                
-                let verticalStackView = createStackView(axis: .vertical)
-                horizontalStackView.addArrangedSubview(verticalStackView)
-                verticalStackView.addArrangedSubview(mediaViews[1])
-                verticalStackView.addArrangedSubview(mediaViews[2])
-            case 4:
-                let topHorizontalStackView = createStackView(axis: .horizontal)
-                containerVerticalStackView.addArrangedSubview(topHorizontalStackView)
-                topHorizontalStackView.addArrangedSubview(mediaViews[0])
-                topHorizontalStackView.addArrangedSubview(mediaViews[1])
-                
-                let bottomHorizontalStackView = createStackView(axis: .horizontal)
-                containerVerticalStackView.addArrangedSubview(bottomHorizontalStackView)
-                bottomHorizontalStackView.addArrangedSubview(mediaViews[2])
-                bottomHorizontalStackView.addArrangedSubview(mediaViews[3])
-            case 5...9:
-                let topHorizontalStackView = createStackView(axis: .horizontal)
-                containerVerticalStackView.addArrangedSubview(topHorizontalStackView)
-                topHorizontalStackView.addArrangedSubview(mediaViews[0])
-                topHorizontalStackView.addArrangedSubview(mediaViews[1])
-                topHorizontalStackView.addArrangedSubview(mediaViews[2])
-                
-                func mediaViewOrPlaceholderView(at index: Int) -> UIView {
-                    return index < mediaViews.count ? mediaViews[index] : UIView()
-                }
-                let middleHorizontalStackView = createStackView(axis: .horizontal)
-                containerVerticalStackView.addArrangedSubview(middleHorizontalStackView)
-                middleHorizontalStackView.addArrangedSubview(mediaViews[3])
-                middleHorizontalStackView.addArrangedSubview(mediaViews[4])
-                middleHorizontalStackView.addArrangedSubview(mediaViewOrPlaceholderView(at: 5))
-                
-                if count > 6 {
-                    let bottomHorizontalStackView = createStackView(axis: .horizontal)
-                    containerVerticalStackView.addArrangedSubview(bottomHorizontalStackView)
-                    bottomHorizontalStackView.addArrangedSubview(mediaViewOrPlaceholderView(at: 6))
-                    bottomHorizontalStackView.addArrangedSubview(mediaViewOrPlaceholderView(at: 7))
-                    bottomHorizontalStackView.addArrangedSubview(mediaViewOrPlaceholderView(at: 8))
-                }
-            default:
-                assertionFailure()
-                return
-            }*/
             
             let containerWidth = maxSize.width
 			let containerHeight = CGFloat(layoutView.getMeasuredHeight())

--- a/MastodonSDK/Sources/MastodonUI/View/Container/MediaLayoutView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Container/MediaLayoutView.swift
@@ -1,0 +1,8 @@
+//
+//  MediaLayoutView.swift
+//  
+//
+//  Created by Grishka on 27.03.2023.
+//
+
+import Foundation

--- a/MastodonSDK/Sources/MastodonUI/View/Container/MediaLayoutView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Container/MediaLayoutView.swift
@@ -1,8 +1,0 @@
-//
-//  MediaLayoutView.swift
-//  
-//
-//  Created by Grishka on 27.03.2023.
-//
-
-import Foundation

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
@@ -389,6 +389,7 @@ extension StatusView {
         
         let configurations = MediaView.configuration(status: status)
         viewModel.mediaViewConfigurations = configurations
+		viewModel.mediaLayout = MediaLayoutHelper.generateMediaLayout(attachments: status.attachments)
     }
     
     private func configurePollHistory(statusEdit: StatusEdit) {

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -24,13 +24,13 @@ extension StatusView {
         var disposeBag = Set<AnyCancellable>()
         var observations = Set<NSKeyValueObservation>()
         public var objects = Set<NSManagedObject>()
-        
+
         let logger = Logger(subsystem: "StatusView", category: "ViewModel")
         
         public var context: AppContext?
         public var authContext: AuthContext?
         public var originalStatus: Status?
-        
+
         // Header
         @Published public var header: Header = .none
         
@@ -50,7 +50,7 @@ extension StatusView {
         @Published public var isCurrentlyTranslating = false
         @Published public var translatedFromLanguage: String?
         @Published public var translatedUsingProvider: String?
-        
+
         @Published public var timestamp: Date?
         public var timestampFormatter: ((_ date: Date, _ isEdited: Bool) -> String)?
         @Published public var timestampText = ""
@@ -79,10 +79,10 @@ extension StatusView {
         @Published public var voteCount = 0
         @Published public var expireAt: Date?
         @Published public var expired: Bool = false
-        
+
         // Card
         @Published public var card: Card?
-        
+
         // Visibility
         @Published public var visibility: MastodonVisibility = .public
         
@@ -103,7 +103,7 @@ extension StatusView {
         @Published public var replyCount: Int = 0
         @Published public var reblogCount: Int = 0
         @Published public var favoriteCount: Int = 0
-        
+
         @Published public var statusEdits: [StatusEdit] = []
         @Published public var editedAt: Date? = nil
         
@@ -111,10 +111,10 @@ extension StatusView {
         @Published public var activeFilters: [Mastodon.Entity.Filter] = []
         @Published public var filterContext: Mastodon.Entity.Filter.Context?
         @Published public var isFiltered = false
-        
+
         @Published public var groupedAccessibilityLabel = ""
         @Published public var contentAccessibilityLabel = ""
-        
+
         let timestampUpdatePublisher = Timer.publish(every: 1.0, on: .main, in: .common)
             .autoconnect()
             .share()
@@ -306,7 +306,7 @@ extension StatusView.ViewModel {
                 statusView.spoilerOverlayView.spoilerMetaLabel.configure(content: spoilerContent)
                 // statusView.spoilerBannerView.label.configure(content: spoilerContent)
                 // statusView.setSpoilerBannerViewHidden(isHidden: !isContentReveal)
-                
+
             } else {
                 statusView.spoilerOverlayView.spoilerMetaLabel.reset()
                 // statusView.spoilerBannerView.label.reset()
@@ -343,7 +343,7 @@ extension StatusView.ViewModel {
                 statusView.contentMetaText.textView.accessibilityTraits = [.staticText]
                 statusView.contentMetaText.textView.accessibilityElementsHidden = false
                 statusView.contentMetaText.textView.isHidden = false
-                
+
             } else {
                 statusView.contentMetaText.reset()
                 statusView.contentMetaText.textView.accessibilityLabel = ""
@@ -358,7 +358,7 @@ extension StatusView.ViewModel {
             self.logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): isContentReveal: \(isContentReveal)")
         }
         .store(in: &disposeBag)
-        
+
         $isMediaSensitive
             .sink { isSensitive in
                 guard isSensitive else { return }
@@ -375,7 +375,7 @@ extension StatusView.ViewModel {
                 statusView.authorView.contentSensitiveeToggleButton.setImage(image, for: .normal)
             }
             .store(in: &disposeBag)
-        
+
         $isCurrentlyTranslating
             .receive(on: DispatchQueue.main)
             .sink { isTranslating in
@@ -523,7 +523,7 @@ extension StatusView.ViewModel {
                 statusView.pollVoteActivityIndicatorView.isHidden = true
                 return
             }
-            
+
             statusView.pollVoteButton.isHidden = isVoting
             statusView.pollVoteActivityIndicatorView.isHidden = !isVoting
             statusView.pollVoteActivityIndicatorView.startAnimating()
@@ -533,7 +533,7 @@ extension StatusView.ViewModel {
             .assign(to: \.isEnabled, on: statusView.pollVoteButton)
             .store(in: &disposeBag)
     }
-    
+
     private func bindCard(statusView: StatusView) {
         $card.sink { card in
             guard let card = card else { return }
@@ -615,14 +615,14 @@ extension StatusView.ViewModel {
                 }
                 return formatter.string(from: timestamp)
             }()
-            
+
             let text: String
             if let applicationName {
                 text = L10n.Common.Controls.Status.postedViaApplication(dateString, applicationName)
             } else {
                 text = dateString
             }
-            
+
             statusView.statusMetricView.dateLabel.text = text
         }
         .store(in: &disposeBag)
@@ -640,7 +640,7 @@ extension StatusView.ViewModel {
                 statusView.statusMetricView.favoriteButton.detailLabel.text = count.formatted()
             }
             .store(in: &disposeBag)
-        
+
         $editedAt
             .sink { editedAt in
                 if let editedAt {
@@ -778,7 +778,7 @@ extension StatusView.ViewModel {
             .map { timestampText, longTimestamp in
                 "\(timestampText). \(longTimestamp)"
             }
-        
+
         Publishers.CombineLatest4(
             $header,
             $authorName,
@@ -814,7 +814,7 @@ extension StatusView.ViewModel {
                 // TODO: replace with "Tap to reveal"
                 strings.append(L10n.Common.Controls.Status.mediaContentWarning)
             }
-            
+
             if isContentReveal {
                 strings.append(content?.string)
             }
@@ -843,7 +843,7 @@ extension StatusView.ViewModel {
                 let count = configurations.count
                 return L10n.Plural.Count.media(count)
             }
-        
+
         let replyLabel = $replyCount
             .map { [L10n.Common.Controls.Actions.reply, L10n.Plural.Count.reply($0)] }
             .map { $0.joined(separator: ", ") }
@@ -856,7 +856,7 @@ extension StatusView.ViewModel {
                 ]
             }
             .map { $0.joined(separator: ", ") }
-        
+
         let favoriteLabel = Publishers.CombineLatest($isFavorite, $favoriteCount)
             .map { isFavorite, favoriteCount in
                 [
@@ -865,7 +865,7 @@ extension StatusView.ViewModel {
                 ]
             }
             .map { $0.joined(separator: ", ") }
-        
+
         Publishers.CombineLatest4(replyLabel, reblogLabel, $isReblogEnabled, favoriteLabel)
             .map { replyLabel, reblogLabel, canReblog, favoriteLabel in
                 let toolbar = statusView.actionToolbarContainer
@@ -886,7 +886,7 @@ extension StatusView.ViewModel {
             }
             .assign(to: \.toolbarActions, on: statusView)
             .store(in: &disposeBag)
-        
+
         let translatedFromLabel = Publishers.CombineLatest($translatedFromLanguage, $translatedUsingProvider)
             .map { (language, provider) -> String? in
                 if let language {
@@ -897,7 +897,7 @@ extension StatusView.ViewModel {
                 }
                 return nil
             }
-        
+
         translatedFromLabel
             .receive(on: DispatchQueue.main)
             .sink { label in
@@ -919,11 +919,11 @@ extension StatusView.ViewModel {
         )
         .map { author, content, translated, media in
             var labels: [String?] = [content, translated, media]
-            
+
             if statusView.style != .notification {
                 labels.insert(author, at: 0)
             }
-            
+
             return labels
                 .compactMap { $0 }
                 .joined(separator: ", ")
@@ -935,7 +935,7 @@ extension StatusView.ViewModel {
                 statusView.accessibilityLabel = accessibilityLabel
             }
             .store(in: &disposeBag)
-        
+
         Publishers.CombineLatest(
             $content,
             $isContentReveal.removeDuplicates()


### PR DESCRIPTION
As discussed, I tried to port the media layout algorithm from the Android app. Android sources: [the layout algorithm itself](https://github.com/mastodon/mastodon-android/blob/7b0a3f0f96af27aac39c60a2ff095472656ea689/mastodon/src/main/java/org/joinmastodon/android/ui/PhotoLayoutHelper.java) and [the custom ViewGroup](https://github.com/mastodon/mastodon-android/blob/7b0a3f0f96af27aac39c60a2ff095472656ea689/mastodon/src/main/java/org/joinmastodon/android/ui/views/MediaGridLayout.java) that actually puts the views on the screen. This new layout algorithm works with up to 10 media attachments.

![IMG_0876](https://user-images.githubusercontent.com/1478258/227818856-3abeda72-2a7d-4582-bcd1-dae8ec2d27a8.jpeg)

I'm not familiar with Swift and UIKit, and definitely not with ReactiveSwift that permeates the entire codebase of the app. I might have done something stupid.

This PR isn't quite ready for merging. There's something inside `MediaView` that doesn't respect its frame and won't crop vertically, resulting in overlapping views:
![IMG_0874](https://user-images.githubusercontent.com/1478258/227819294-914d1a36-956e-4ec1-8927-d5ae83a16553.jpeg)
![IMG_0875](https://user-images.githubusercontent.com/1478258/227819298-8f490a3d-26e3-405d-af5a-0689868c0551.jpeg)

There's also a bug I don't know how to fix because I don't know where to hook into either the app or UIKit to re-run the layout with new `maxSize` when the view size changes. Android would automatically measure and then lay out the view subtree when the dimensions of its parent `ViewGroup` change, but iOS apparently doesn't do that? To reproduce, open an attachment, rotate the device to landscape orientation, then close the attachment.