### PR TITLE
IOS-132: Server picker VQA improvements

### DIFF
--- a/Mastodon/Scene/Onboarding/PickServer/CollectionViewCell/PickServerCategoryCollectionViewCell.swift
+++ b/Mastodon/Scene/Onboarding/PickServer/CollectionViewCell/PickServerCategoryCollectionViewCell.swift
@@ -62,7 +62,7 @@ class PickServerCategoryCollectionViewCell: UICollectionViewCell {
 
         layer.borderColor = UIColor.black.cgColor
         layer.borderWidth = 1.0
-        applyCornerRadius(radius: 15)
+        applyCornerRadius(radius: 18)
 
         contentView.addSubview(container)
         contentView.addSubview(menuButton)

--- a/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewController.swift
+++ b/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewController.swift
@@ -141,6 +141,13 @@ extension MastodonPickServerViewController {
             )
         }
         .store(in: &disposeBag)
+        
+        viewModel.scrollToTop
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.tableView.scroll(to: .top, animated: false)
+            }
+            .store(in: &disposeBag)
 
         authenticationViewModel
             .authenticated

--- a/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewController.swift
+++ b/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewController.swift
@@ -378,6 +378,13 @@ extension MastodonPickServerViewController: UITableViewDelegate {
         guard case let .server(server, _) = item else { return }
         tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
         viewModel.selectedServer.send(server)
+        
+        // Briefly highlight selected cell
+        guard let cell = tableView.cellForRow(at: indexPath) else { return }
+        cell.backgroundColor = Asset.Colors.selectionHighlight.color
+        UIView.animate(withDuration: 0.3, animations: {
+            cell.backgroundColor = .none
+        })
     }
 
     func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {

--- a/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewModel.swift
+++ b/Mastodon/Scene/Onboarding/PickServer/MastodonPickServerViewModel.swift
@@ -47,6 +47,7 @@ class MastodonPickServerViewModel: NSObject {
     let unindexedServers = CurrentValueSubject<[Mastodon.Entity.Server]?, Never>([])    // set nil when loading
     let viewWillAppear = PassthroughSubject<Void, Never>()
     let viewDidAppear = CurrentValueSubject<Void, Never>(Void())
+    let scrollToTop = PassthroughSubject<Void, Never>()
     @Published var additionalTableViewInsets: UIEdgeInsets = .zero
     
     // output
@@ -125,7 +126,7 @@ extension MastodonPickServerViewModel {
                 (selectedLanguage, manualApprovalRequired)
             }
         )
-        .map { indexedServers, selectCategoryItem, searchText, filters -> [Mastodon.Entity.Server] in
+        .map { [weak self] indexedServers, selectCategoryItem, searchText, filters -> [Mastodon.Entity.Server] in
             var indexedServers = indexedServers
 
             var _indexedServers: [Mastodon.Entity.Server] = []
@@ -151,6 +152,7 @@ extension MastodonPickServerViewModel {
             case .language(_), .signupSpeed(_):
                 return MastodonPickServerViewModel.filterServers(servers: indexedServers, language: filters.selectedLanguage, manualApprovalRequired: filters.manualApprovalRequired, category: nil, searchText: searchText)
             case .category(let category):
+                self?.scrollToTop.send()
                 return MastodonPickServerViewModel.filterServers(servers: indexedServers, language: filters.selectedLanguage, manualApprovalRequired: filters.manualApprovalRequired, category: category.category.rawValue, searchText: searchText)
             }
         }

--- a/Mastodon/Scene/Onboarding/PickServer/View/OnboardingNextView.swift
+++ b/Mastodon/Scene/Onboarding/PickServer/View/OnboardingNextView.swift
@@ -28,6 +28,7 @@ final class OnboardingNextView: UIView {
         button.layer.cornerRadius = 14
         button.backgroundColor = Asset.Colors.Brand.blurple.color
         button.setTitle(L10n.Common.Controls.Actions.next, for: .normal)
+        button.titleLabel?.font = UIFontMetrics(forTextStyle: .body).scaledFont(for: .systemFont(ofSize: 16, weight: .bold))
         return button
     }()
 

--- a/Mastodon/Scene/Onboarding/PickServer/View/PickServerServerSectionTableHeaderView.swift
+++ b/Mastodon/Scene/Onboarding/PickServer/View/PickServerServerSectionTableHeaderView.swift
@@ -18,7 +18,7 @@ protocol PickServerServerSectionTableHeaderViewDelegate: AnyObject {
 
 final class PickServerServerSectionTableHeaderView: UIView {
     
-    static let collectionViewHeight: CGFloat = 30
+    static let collectionViewHeight: CGFloat = 36
     static let spacing: CGFloat = 16
     
     static let height: CGFloat = collectionViewHeight + spacing


### PR DESCRIPTION
# Rationale

- [x] Should be an inline nav bar & “Pick server“ should be title case
- [x] Chips should be larger — increase padding
- [ ] Remove stroke on selected chip in light mode.
  - I'm not seeing any stroke there currently
- [x] “Next” button should be bold
- [x] Language picker
  - [x] What is “be” and why does it not follow suit with other languages
    - Needs to be fixed with response of https://api.joinmastodon.org/languages
- [x] Picking categories doesn’t scroll you all the way to the top of the list, cuts off the first server in the category
- [ ] Full back swipe when there should only be edge back swipe on this screen
  - Tbd as this is somewhat a custom global behavior
- [x] No touch down state on server cells, can’t tell you’re tapping on a server until you let go