### PR TITLE
Enable missing parallax-effect (IOS-134)

### DIFF
--- a/Mastodon/Scene/Onboarding/Welcome/View/WelcomeIllustrationView.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/View/WelcomeIllustrationView.swift
@@ -130,11 +130,6 @@ extension WelcomeIllustrationView {
     }
     
     func setup() {
-        
-        // set illustration
-        guard superview == nil else {
-            return
-        }
         contentMode = .scaleAspectFit
         
         cloudBaseImageView.addMotionEffect(

--- a/Mastodon/Scene/Onboarding/Welcome/View/WelcomeIllustrationView.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/View/WelcomeIllustrationView.swift
@@ -13,12 +13,10 @@ import MastodonLocalization
 
 fileprivate extension CGFloat {
     static let cloudsStartPosition = -20.0
+    static let centerHillStartPosition = 20.0
     static let airplaneStartPosition = -178.0
     static let leftHillStartPosition = 30.0
     static let rightHillStartPosition = -125.0
-    static let leftHillSpeed = 6.0
-    static let centerHillSpeed = 40.0
-    static let rightHillSpeed = 6.0
 }
 
 final class WelcomeIllustrationView: UIView {
@@ -61,7 +59,6 @@ final class WelcomeIllustrationView: UIView {
         let imageView = UIImageView(image: Asset.Scene.Welcome.Illustration.cloudBase.image)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.contentMode = .scaleAspectFill
-//        imageView.alpha = 0.3
         return imageView
     }()
     
@@ -115,9 +112,9 @@ extension WelcomeIllustrationView {
 
         addSubview(centerHillImageView)
         NSLayoutConstraint.activate([
-            leftAnchor.constraint(equalTo: centerHillImageView.leftAnchor),
+            leftAnchor.constraint(equalTo: centerHillImageView.leftAnchor, constant: .centerHillStartPosition),
             bottomAnchor.constraint(equalTo: centerHillImageView.bottomAnchor),
-            rightAnchor.constraint(equalTo: centerHillImageView.rightAnchor),
+            centerHillImageView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 1.1),
         ])
 
         NSLayoutConstraint.activate([

--- a/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
@@ -219,23 +219,10 @@ extension WelcomeViewController {
         setupIllustrationLayout()
     }
     
-
-    override func viewSafeAreaInsetsDidChange() {
-        super.viewSafeAreaInsetsDidChange()
-        
-        var overlap: CGFloat = 5
-        // shift illustration down for non-notch phone
-        if view.safeAreaInsets.bottom == 0 {
-            overlap += 56
-        }
-    }
-    
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         
         view.layoutIfNeeded()
-        
-        setupIllustrationLayout()
     }
     
     private var computedTopAnchorInset: CGFloat {

--- a/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
@@ -215,6 +215,8 @@ extension WelcomeViewController {
                 self.navigationItem.leftBarButtonItem = needsShowDismissEntry ? self.dismissBarButtonItem : nil
             }
             .store(in: &disposeBag)
+
+        setupIllustrationLayout()
     }
     
 


### PR DESCRIPTION
When implementing the updated Welcome-screen (#1005, I'd love to receive your feedback on that PR, too!), I forgot to enable the parallax-effect again. This PR fixes that.


https://user-images.githubusercontent.com/2580019/230953956-bd53f20c-1a30-4a3e-aee7-a9617b932f82.mov

(I just played the video again and noticed: Oh, there's music in the background. I guess, that Quicktime recorded the music I was listening, too 😅🙈🙉)
