### PR TITLE
Put ComposeToolbar-actions in ScrollView

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView.swift
@@ -18,8 +18,6 @@ protocol ComposeContentToolbarViewDelegate: AnyObject {
 
 struct ComposeContentToolbarView: View {
     
-    let logger = Logger(subsystem: "ComposeContentToolbarView", category: "View")
-    
     static var toolbarHeight: CGFloat { 48 }
     
     @ObservedObject var viewModel: ViewModel
@@ -32,160 +30,162 @@ struct ComposeContentToolbarView: View {
     
     var body: some View {
         HStack(spacing: .zero) {
-            ForEach(ComposeContentToolbarView.ViewModel.Action.allCases, id: \.self) { action in
-                switch action {
-                case .attachment:
-                    Menu {
-                        ForEach(ComposeContentToolbarView.ViewModel.AttachmentAction.allCases, id: \.self) { attachmentAction in
-                            Button {
-                                logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public), \(attachmentAction.title)")
-                                viewModel.delegate?.composeContentToolbarView(viewModel, attachmentMenuDidPressed: attachmentAction)
-                            } label: {
-                                Label {
-                                    Text(attachmentAction.title)
-                                } icon: {
-                                    Image(uiImage: attachmentAction.image)
+            ScrollView(.horizontal) {
+                HStack(spacing: .zero) {
+                    ForEach(ComposeContentToolbarView.ViewModel.Action.allCases, id: \.self) { action in
+                        switch action {
+                            case .attachment:
+                                Menu {
+                                    ForEach(ComposeContentToolbarView.ViewModel.AttachmentAction.allCases, id: \.self) { attachmentAction in
+                                        Button {
+                                            viewModel.delegate?.composeContentToolbarView(viewModel, attachmentMenuDidPressed: attachmentAction)
+                                        } label: {
+                                            Label {
+                                                Text(attachmentAction.title)
+                                            } icon: {
+                                                Image(uiImage: attachmentAction.image)
+                                            }
+                                        }
+                                    }
+                                } label: {
+                                    label(for: action)
+                                        .opacity(viewModel.isAttachmentButtonEnabled ? 1.0 : 0.5)
                                 }
-                            }
-                        }
-                    } label: {
-                        label(for: action)
-                            .opacity(viewModel.isAttachmentButtonEnabled ? 1.0 : 0.5)
-                    }
-                    .disabled(!viewModel.isAttachmentButtonEnabled)
-                    .frame(width: 48, height: 48)
-                case .visibility:
-                    Menu {
-                        Picker(selection: $viewModel.visibility) {
-                            ForEach(viewModel.allVisibilities, id: \.self) { visibility in
-                                Label {
-                                    Text(visibility.title)
-                                } icon: {
-                                    Image(uiImage: visibility.image)
+                                .disabled(!viewModel.isAttachmentButtonEnabled)
+                                .frame(width: 48, height: 48)
+                            case .visibility:
+                                Menu {
+                                    Picker(selection: $viewModel.visibility) {
+                                        ForEach(viewModel.allVisibilities, id: \.self) { visibility in
+                                            Label {
+                                                Text(visibility.title)
+                                            } icon: {
+                                                Image(uiImage: visibility.image)
+                                            }
+                                        }
+                                    } label: {
+                                        Text(viewModel.visibility.title)
+                                    }
+                                } label: {
+                                    label(for: viewModel.visibility.image)
+                                        .accessibilityLabel(L10n.Scene.Compose.Keyboard.selectVisibilityEntry(viewModel.visibility.title))
+                                        .opacity(viewModel.isVisibilityButtonEnabled ? 1.0 : 0.5)
                                 }
-                            }
-                        } label: {
-                            Text(viewModel.visibility.title)
-                        }
-                    } label: {
-                        label(for: viewModel.visibility.image)
-                            .accessibilityLabel(L10n.Scene.Compose.Keyboard.selectVisibilityEntry(viewModel.visibility.title))
-                            .opacity(viewModel.isVisibilityButtonEnabled ? 1.0 : 0.5)
-                    }
-                    .disabled(!viewModel.isVisibilityButtonEnabled)
-                    .frame(width: 48, height: 48)
-                case .poll:
-                    Button {
-                        logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): \(String(describing: action))")
-                        viewModel.delegate?.composeContentToolbarView(viewModel, toolbarItemDidPressed: action)
-                    } label: {
-                        label(for: action)
-                            .opacity(viewModel.isPollButtonEnabled ? 1.0 : 0.5)
-                    }
-                    .disabled(!viewModel.isPollButtonEnabled)
-                    .frame(width: 48, height: 48)
-                case .language:
-                    Menu {
-                        Section {} // workaround a bug where the “Suggested” section doesn’t appear
-                        if !viewModel.suggestedLanguages.isEmpty {
-                            Section(L10n.Scene.Compose.Language.suggested) {
-                                ForEach(viewModel.suggestedLanguages.compactMap(Language.init(id:))) { lang in
-                                    Toggle(isOn: languageBinding(for: lang.id)) {
-                                        Text(lang.label)
+                                .disabled(!viewModel.isVisibilityButtonEnabled)
+                                .frame(width: 48, height: 48)
+                            case .poll:
+                                Button {
+                                    viewModel.delegate?.composeContentToolbarView(viewModel, toolbarItemDidPressed: action)
+                                } label: {
+                                    label(for: action)
+                                        .opacity(viewModel.isPollButtonEnabled ? 1.0 : 0.5)
+                                }
+                                .disabled(!viewModel.isPollButtonEnabled)
+                                .frame(width: 48, height: 48)
+                            case .language:
+                                Menu {
+                                    Section {} // workaround a bug where the “Suggested” section doesn’t appear
+                                    if !viewModel.suggestedLanguages.isEmpty {
+                                        Section(L10n.Scene.Compose.Language.suggested) {
+                                            ForEach(viewModel.suggestedLanguages.compactMap(Language.init(id:))) { lang in
+                                                Toggle(isOn: languageBinding(for: lang.id)) {
+                                                    Text(lang.label)
+                                                }
+                                            }
+                                        }
+                                    }
+                                    let recent = viewModel.recentLanguages.filter { !viewModel.suggestedLanguages.contains($0) }
+                                    if !recent.isEmpty {
+                                        Section(L10n.Scene.Compose.Language.recent) {
+                                            ForEach(recent.compactMap(Language.init(id:))) { lang in
+                                                Toggle(isOn: languageBinding(for: lang.id)) {
+                                                    Text(lang.label)
+                                                }
+                                            }
+                                        }
+                                    }
+                                    if !(recent + viewModel.suggestedLanguages).contains(viewModel.language) {
+                                        Toggle(isOn: languageBinding(for: viewModel.language)) {
+                                            Text(Language(id: viewModel.language)?.label ?? AttributedString("\(viewModel.language)"))
+                                        }
+                                    }
+                                    Button(L10n.Scene.Compose.Language.other) {
+                                        showingLanguagePicker = true
+                                    }
+                                } label: {
+                                    let font: SwiftUI.Font = {
+                                        if #available(iOS 16, *) {
+                                            return .system(size: 11, weight: .semibold).width(viewModel.language.count == 3 ? .compressed : .standard)
+                                        } else {
+                                            return .system(size: 11, weight: .semibold)
+                                        }
+                                    }()
+                                    
+                                    Text(viewModel.language)
+                                        .font(font)
+                                        .textCase(.uppercase)
+                                        .padding(.horizontal, 4)
+                                        .minimumScaleFactor(0.5)
+                                        .frame(width: 24, height: 24, alignment: .center)
+                                        .overlay { RoundedRectangle(cornerRadius: 7).inset(by: 3).stroke(lineWidth: 1.5) }
+                                        .accessibilityLabel(L10n.Scene.Compose.Language.title)
+                                        .accessibilityValue(Text(Language(id: viewModel.language)?.label ?? AttributedString("\(viewModel.language)")))
+                                        .foregroundColor(Color(Asset.Scene.Compose.buttonTint.color))
+                                        .overlay(alignment: .topTrailing) {
+                                            Group {
+                                                if let suggested = viewModel.highConfidenceSuggestedLanguage,
+                                                   suggested != viewModel.language,
+                                                   !didChangeLanguage {
+                                                    Circle().fill(.blue)
+                                                        .frame(width: 8, height: 8)
+                                                }
+                                            }
+                                            .transition(.opacity)
+                                            .animation(.default, value: [viewModel.highConfidenceSuggestedLanguage, viewModel.language])
+                                        }
+                                    // fixes weird appearance when drawing at low opacity (eg when pressed)
+                                        .drawingGroup()
+                                }
+                                .frame(width: 48, height: 48)
+                                .popover(isPresented: $showingLanguagePicker) {
+                                    let picker = LanguagePicker { newLanguage in
+                                        viewModel.language = newLanguage
+                                        didChangeLanguage = true
+                                        showingLanguagePicker = false
+                                    }
+                                    if verticalSizeClass == .regular && horizontalSizeClass == .regular {
+                                        // explicitly size picker when it’s a popover
+                                        picker.frame(width: 400, height: 500)
+                                    } else {
+                                        picker
                                     }
                                 }
-                            }
-                        }
-                        let recent = viewModel.recentLanguages.filter { !viewModel.suggestedLanguages.contains($0) }
-                        if !recent.isEmpty {
-                            Section(L10n.Scene.Compose.Language.recent) {
-                                ForEach(recent.compactMap(Language.init(id:))) { lang in
-                                    Toggle(isOn: languageBinding(for: lang.id)) {
-                                        Text(lang.label)
-                                    }
+                            default:
+                                Button {
+                                    viewModel.delegate?.composeContentToolbarView(viewModel, toolbarItemDidPressed: action)
+                                } label: {
+                                    label(for: action)
                                 }
-                            }
-                        }
-                        if !(recent + viewModel.suggestedLanguages).contains(viewModel.language) {
-                            Toggle(isOn: languageBinding(for: viewModel.language)) {
-                                Text(Language(id: viewModel.language)?.label ?? AttributedString("\(viewModel.language)"))
-                            }
-                        }
-                        Button(L10n.Scene.Compose.Language.other) {
-                            showingLanguagePicker = true
-                        }
-                    } label: {
-                        let font: SwiftUI.Font = {
-                            if #available(iOS 16, *) {
-                                return .system(size: 11, weight: .semibold).width(viewModel.language.count == 3 ? .compressed : .standard)
-                            } else {
-                                return .system(size: 11, weight: .semibold)
-                            }
-                        }()
-
-                        Text(viewModel.language)
-                            .font(font)
-                            .textCase(.uppercase)
-                            .padding(.horizontal, 4)
-                            .minimumScaleFactor(0.5)
-                            .frame(width: 24, height: 24, alignment: .center)
-                            .overlay { RoundedRectangle(cornerRadius: 7).inset(by: 3).stroke(lineWidth: 1.5) }
-                            .accessibilityLabel(L10n.Scene.Compose.Language.title)
-                            .accessibilityValue(Text(Language(id: viewModel.language)?.label ?? AttributedString("\(viewModel.language)")))
-                            .foregroundColor(Color(Asset.Scene.Compose.buttonTint.color))
-                            .overlay(alignment: .topTrailing) {
-                                Group {
-                                    if let suggested = viewModel.highConfidenceSuggestedLanguage,
-                                       suggested != viewModel.language,
-                                       !didChangeLanguage {
-                                        Circle().fill(.blue)
-                                            .frame(width: 8, height: 8)
-                                    }
-                                }
-                                .transition(.opacity)
-                                .animation(.default, value: [viewModel.highConfidenceSuggestedLanguage, viewModel.language])
-                            }
-                            // fixes weird appearance when drawing at low opacity (eg when pressed)
-                            .drawingGroup()
-                    }
-                    .frame(width: 48, height: 48)
-                    .popover(isPresented: $showingLanguagePicker) {
-                        let picker = LanguagePicker { newLanguage in
-                            viewModel.language = newLanguage
-                            didChangeLanguage = true
-                            showingLanguagePicker = false
-                        }
-                        if verticalSizeClass == .regular && horizontalSizeClass == .regular {
-                            // explicitly size picker when it’s a popover
-                            picker.frame(width: 400, height: 500)
-                        } else {
-                            picker
+                                .frame(width: 48, height: 48)
                         }
                     }
-                default:
-                    Button {
-                        logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): \(String(describing: action))")
-                        viewModel.delegate?.composeContentToolbarView(viewModel, toolbarItemDidPressed: action)
-                    } label: {
-                        label(for: action)
-                    }
-                    .frame(width: 48, height: 48)
                 }
             }
-            Spacer()
-            let count: Int = {
-                if viewModel.isContentWarningActive {
-                    return viewModel.contentWeightedLength + viewModel.contentWarningWeightedLength
-                } else {
-                    return viewModel.contentWeightedLength
-                }
-            }()
-            let remains = viewModel.maxTextInputLimit - count
-            let isOverflow = remains < 0
-            Text("\(remains)")
-                .foregroundColor(Color(isOverflow ? UIColor.systemRed : UIColor.secondaryLabel))
-                .font(.system(size: isOverflow ? 18 : 16, weight: isOverflow ? .medium : .regular))
-                .accessibilityLabel(L10n.A11y.Plural.Count.charactersLeft(remains))
+                Spacer()
+                let count: Int = {
+                    if viewModel.isContentWarningActive {
+                        return viewModel.contentWeightedLength + viewModel.contentWarningWeightedLength
+                    } else {
+                        return viewModel.contentWeightedLength
+                    }
+                }()
+                let remains = viewModel.maxTextInputLimit - count
+                let isOverflow = remains < 0
+                Text("\(remains)")
+                    .foregroundColor(Color(isOverflow ? UIColor.systemRed : UIColor.secondaryLabel))
+                    .font(.system(size: isOverflow ? 18 : 16, weight: isOverflow ? .medium : .regular))
+                    .accessibilityLabel(L10n.A11y.Plural.Count.charactersLeft(remains))
+
         }
         .padding(.leading, 4)       // 4 + 12 = 16
         .padding(.trailing, 16)

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView.swift
@@ -21,6 +21,7 @@ struct ComposeContentToolbarView: View {
     static var toolbarHeight: CGFloat { 48 }
     
     @ObservedObject var viewModel: ViewModel
+    let isZoomed = (UIScreen.main.scale != UIScreen.main.nativeScale)
     
     @State private var showingLanguagePicker = false
     @State private var didChangeLanguage = false
@@ -30,7 +31,7 @@ struct ComposeContentToolbarView: View {
     
     var body: some View {
         HStack(spacing: .zero) {
-            ScrollView(.horizontal) {
+            ScrollView(isZoomed ? .horizontal : []) {
                 HStack(spacing: .zero) {
                     ForEach(ComposeContentToolbarView.ViewModel.Action.allCases, id: \.self) { action in
                         switch action {
@@ -171,20 +172,21 @@ struct ComposeContentToolbarView: View {
                     }
                 }
             }
-                Spacer()
-                let count: Int = {
-                    if viewModel.isContentWarningActive {
-                        return viewModel.contentWeightedLength + viewModel.contentWarningWeightedLength
-                    } else {
-                        return viewModel.contentWeightedLength
-                    }
-                }()
-                let remains = viewModel.maxTextInputLimit - count
-                let isOverflow = remains < 0
-                Text("\(remains)")
-                    .foregroundColor(Color(isOverflow ? UIColor.systemRed : UIColor.secondaryLabel))
-                    .font(.system(size: isOverflow ? 18 : 16, weight: isOverflow ? .medium : .regular))
-                    .accessibilityLabel(L10n.A11y.Plural.Count.charactersLeft(remains))
+
+            Spacer()
+            let count: Int = {
+                if viewModel.isContentWarningActive {
+                    return viewModel.contentWeightedLength + viewModel.contentWarningWeightedLength
+                } else {
+                    return viewModel.contentWeightedLength
+                }
+            }()
+            let remains = viewModel.maxTextInputLimit - count
+            let isOverflow = remains < 0
+            Text("\(remains)")
+                .foregroundColor(Color(isOverflow ? UIColor.systemRed : UIColor.secondaryLabel))
+                .font(.system(size: isOverflow ? 18 : 16, weight: isOverflow ? .medium : .regular))
+                .accessibilityLabel(L10n.A11y.Plural.Count.charactersLeft(remains))
 
         }
         .padding(.leading, 4)       // 4 + 12 = 16


### PR DESCRIPTION
Fixes #1009.

The buttons are in a `ScrollView`, but scrolling is only enabled if zoom is enabled.
Speaking of which: This is how you change it in the simulator:

<video src="https://user-images.githubusercontent.com/2580019/231877844-ddaf719c-875b-4d80-bf3f-b392115e2c53.mp4"></video>

And this is how the result looks like for enabled zoom:

<video src="https://user-images.githubusercontent.com/2580019/231877920-84593914-30ac-474d-ae28-89a233be7142.mp4"></video>

For Default-Zoom nothing has changed, scrolling is disabled here:

<img src="https://user-images.githubusercontent.com/2580019/231878755-94a84751-2741-4402-be96-be134905b91d.png" width="300px">
