### PR TITLE
Conform an entity to `Sendable`

### DIFF
--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+FamiliarFollowers.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+FamiliarFollowers.swift
@@ -17,7 +17,7 @@ extension Mastodon.Entity {
     ///   2022/5/16
     /// # Reference
     ///  [Document](TBD)
-    public class FamiliarFollowers: Codable, Sendable {
+    public final class FamiliarFollowers: Codable, Sendable {
         public let id: Mastodon.Entity.Account.ID
         public let accounts: [Mastodon.Entity.Account]
     }


### PR DESCRIPTION
Hi,

This PR marks the `FamiliarFollowers` class as `final` to resolve the following compiler warning:

```
Non-final class 'FamiliarFollowers' cannot conform to 'Sendable'; use '@unchecked Sendable'
```