### PR TITLE
Fix new crash when closing compose VC

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewController.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewController.swift
@@ -207,8 +207,9 @@ extension ComposeContentViewController {
             self.tableView.contentInset.bottom = padding - self.view.safeAreaInsets.bottom
             self.tableView.verticalScrollIndicatorInsets.bottom = padding - self.view.safeAreaInsets.bottom
             UIView.animate(withDuration: 0.3) {
+                guard let window = self.view.window else { return }
                 // ref: https://developer.apple.com/documentation/uikit/uiresponder/1621578-keyboardframeenduserinfokey
-                let localKeyboardFrame = self.view.convert(endFrame, from: self.view.window!.screen.coordinateSpace)
+                let localKeyboardFrame = self.view.convert(endFrame, from: window.screen.coordinateSpace)
                 let intersection = self.view.bounds.intersection(localKeyboardFrame)
                 if intersection.isEmpty {
                     self.composeContentToolbarViewBottomLayoutConstraint.constant = 0


### PR DESCRIPTION
It seems that when dismissing the compose view controller, the system (sometimes? always? not sure) goes through this code path after `view.window` has been set to `nil`. I think it’s safe to skip the update in this case to avoid the crash.