### PR TITLE
IOS-148 Updates to the media badging look & feel

### DIFF
--- a/Mastodon.xcodeproj/project.pbxproj
+++ b/Mastodon.xcodeproj/project.pbxproj
@@ -130,7 +130,7 @@
 		855149CA29606D6400943D96 /* PortraitAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 855149C929606D6400943D96 /* PortraitAlertController.swift */; };
 		85904C02293BC0EB0011C817 /* ImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85904C01293BC0EB0011C817 /* ImageProvider.swift */; };
 		85904C04293BC1940011C817 /* URLActivityItemWithMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85904C03293BC1940011C817 /* URLActivityItemWithMetadata.swift */; };
-		85BC11B32932414900E191CD /* AltViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85BC11B22932414900E191CD /* AltViewController.swift */; };
+		85BC11B32932414900E191CD /* AltTextViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85BC11B22932414900E191CD /* AltTextViewController.swift */; };
 		87FFDA5D898A5C42ADCB35E7 /* Pods_Mastodon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4ABE34829701A4496C5BB64 /* Pods_Mastodon.framework */; };
 		9E44C7202967AD17004B2A72 /* MastodonSDKDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 9E44C71F2967AD17004B2A72 /* MastodonSDKDynamic */; };
 		9E44C7222967AD17004B2A72 /* MastodonSDKDynamic in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 9E44C71F2967AD17004B2A72 /* MastodonSDKDynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -755,7 +755,7 @@
 		855149C929606D6400943D96 /* PortraitAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortraitAlertController.swift; sourceTree = "<group>"; };
 		85904C01293BC0EB0011C817 /* ImageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageProvider.swift; sourceTree = "<group>"; };
 		85904C03293BC1940011C817 /* URLActivityItemWithMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLActivityItemWithMetadata.swift; sourceTree = "<group>"; };
-		85BC11B22932414900E191CD /* AltViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AltViewController.swift; sourceTree = "<group>"; };
+		85BC11B22932414900E191CD /* AltTextViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AltTextViewController.swift; sourceTree = "<group>"; };
 		8850E70A1D5FF51432E43653 /* Pods-Mastodon-MastodonUITests.asdk - release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mastodon-MastodonUITests.asdk - release.xcconfig"; path = "Target Support Files/Pods-Mastodon-MastodonUITests/Pods-Mastodon-MastodonUITests.asdk - release.xcconfig"; sourceTree = "<group>"; };
 		8E79CCBE51FBC3F7FE8CF49F /* Pods-MastodonTests.release snapshot.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MastodonTests.release snapshot.xcconfig"; path = "Target Support Files/Pods-MastodonTests/Pods-MastodonTests.release snapshot.xcconfig"; sourceTree = "<group>"; };
 		8ED8C4B1F1BA2DCFF2926BB1 /* Pods-Mastodon-NotificationService.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mastodon-NotificationService.debug.xcconfig"; path = "Target Support Files/Pods-Mastodon-NotificationService/Pods-Mastodon-NotificationService.debug.xcconfig"; sourceTree = "<group>"; };
@@ -2242,7 +2242,7 @@
 				DB6180F026391CAB0018D199 /* Image */,
 				DB6180E1263919780018D199 /* Paging */,
 				DB6180DC263918E30018D199 /* MediaPreviewViewController.swift */,
-				85BC11B22932414900E191CD /* AltViewController.swift */,
+				85BC11B22932414900E191CD /* AltTextViewController.swift */,
 				DB6180F926391F2E0018D199 /* MediaPreviewViewModel.swift */,
 			);
 			path = MediaPreview;
@@ -3900,7 +3900,7 @@
 				DB9D6BFF25E4F5940051B173 /* ProfileViewController.swift in Sources */,
 				2D4AD8A226316CD200613EFC /* SelectedAccountSection.swift in Sources */,
 				DB3EA8F1281B9EF600598866 /* DiscoveryCommunityViewModel+Diffable.swift in Sources */,
-				85BC11B32932414900E191CD /* AltViewController.swift in Sources */,
+				85BC11B32932414900E191CD /* AltTextViewController.swift in Sources */,
 				DB63F775279A997D00455B82 /* NotificationTableViewCell+ViewModel.swift in Sources */,
 				DB98EB5927B109890082E365 /* ReportSupplementaryViewController.swift in Sources */,
 				DB0617EB277EF3820030EE79 /* GradientBorderView.swift in Sources */,

--- a/Mastodon/Scene/MediaPreview/AltTextViewController.swift
+++ b/Mastodon/Scene/MediaPreview/AltTextViewController.swift
@@ -1,5 +1,5 @@
 //
-//  AltViewController.swift
+//  AltTextViewController.swift
 //  Mastodon
 //
 //  Created by Jed Fox on 2022-11-26.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-class AltViewController: UIViewController {
+class AltTextViewController: UIViewController {
     let textView = {
         let textView: UITextView
 
@@ -85,7 +85,7 @@ class AltViewController: UIViewController {
 }
 
 // MARK: UIPopoverPresentationControllerDelegate
-extension AltViewController: UIPopoverPresentationControllerDelegate {
+extension AltTextViewController: UIPopoverPresentationControllerDelegate {
     func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
         .none
     }

--- a/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
+++ b/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
@@ -186,7 +186,7 @@ extension MediaPreviewViewController {
     @objc private func altButtonPressed(_ sender: UIButton) {
         guard let alt = viewModel.altText else { return }
 
-        present(AltViewController(alt: alt, sourceView: sender), animated: true)
+        present(AltTextViewController(alt: alt, sourceView: sender), animated: true)
     }
 }
 

--- a/MastodonSDK/Sources/MastodonUI/View/Content/ExpandableMediaBadge.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/ExpandableMediaBadge.swift
@@ -1,0 +1,66 @@
+// Copyright © 2023 Mastodon gGmbH. All rights reserved.
+
+import SwiftUI
+
+struct ExpandableMediaBadge<Label: View, Content: View>: View {
+    @Binding private var isExpanded: Bool
+    private let label: Label
+    private let content: Content
+
+    @Namespace private var namespace
+
+    init(isExpanded: Binding<Bool>, @ViewBuilder content: () -> Content, @ViewBuilder label: () -> Label) {
+        self._isExpanded = isExpanded
+        self.content = content()
+        self.label = label()
+    }
+
+    var body: some View {
+        MediaBadge {
+            HStack {
+                if isExpanded {
+                    content
+                        .font(.caption)
+                        .matchedGeometryEffect(id: "background", in: namespace, properties: .position)
+                        .transition(
+                            .scale(scale: 0.2, anchor: .bottomLeading)
+                            .combined(with: .opacity)
+                        )
+                    Spacer(minLength: 0)
+                } else {
+                    label
+                        .matchedGeometryEffect(id: "background", in: namespace, properties: .position)
+                        .transition(
+                            .scale(scale: 3, anchor: .trailing)
+                            .combined(with: .opacity)
+                        )
+                }
+            }
+            .padding(.vertical, isExpanded ? (8 - 2) : 0)
+        }
+        .animation(.spring(response: 0.3), value: isExpanded)
+        // this is not accessible, but the badge UI is not shown to accessibility tools at the moment
+        .onTapGesture {
+            isExpanded.toggle()
+        }
+    }
+}
+
+extension ExpandableMediaBadge where Label == Text {
+    init(_ label: String, isExpanded: Binding<Bool>, @ViewBuilder content: () -> Content) {
+        self.init(isExpanded: isExpanded, content: content) {
+            Text(label)
+        }
+    }
+}
+
+
+struct ExpandableMediaBadge_Previews: PreviewProvider {
+    static var previews: some View {
+        ExpandableMediaBadge(isExpanded: .constant(false)) {
+            Text("Hello world!")
+        } label: {
+            Text("ALT")
+        }
+    }
+}

--- a/MastodonSDK/Sources/MastodonUI/View/Content/ExpandableMediaBadge.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/ExpandableMediaBadge.swift
@@ -39,6 +39,7 @@ struct ExpandableMediaBadge<Label: View, Content: View>: View {
                                 .scale(scale: 0.2, anchor: .bottomLeading)
                                 .combined(with: .opacity)
                             )
+                            .layoutPriority(1)
                         Spacer(minLength: 0)
                     } else {
                         label

--- a/MastodonSDK/Sources/MastodonUI/View/Content/ExpandableMediaBadge.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/ExpandableMediaBadge.swift
@@ -4,63 +4,90 @@ import SwiftUI
 
 struct ExpandableMediaBadge<Label: View, Content: View>: View {
     @Binding private var isExpanded: Bool
+    private let parentGeometry: (size: CGSize, space: AnyHashable)
     private let label: Label
     private let content: Content
 
     @Namespace private var namespace
 
-    init(isExpanded: Binding<Bool>, @ViewBuilder content: () -> Content, @ViewBuilder label: () -> Label) {
+    init(isExpanded: Binding<Bool>, in parentGeometry: (CGSize, AnyHashable), @ViewBuilder content: () -> Content, @ViewBuilder label: () -> Label) {
         self._isExpanded = isExpanded
+        self.parentGeometry = parentGeometry
         self.content = content()
         self.label = label()
     }
 
     var body: some View {
         MediaBadge {
-            HStack {
-                if isExpanded {
-                    content
-                        .font(.caption)
-                        .matchedGeometryEffect(id: "background", in: namespace, properties: .position)
-                        .transition(
-                            .scale(scale: 0.2, anchor: .bottomLeading)
-                            .combined(with: .opacity)
-                        )
-                    Spacer(minLength: 0)
-                } else {
-                    label
-                        .matchedGeometryEffect(id: "background", in: namespace, properties: .position)
-                        .transition(
-                            .scale(scale: 3, anchor: .trailing)
-                            .combined(with: .opacity)
-                        )
-                }
+            label
+        }
+        .opacity(0)
+        .overlay {
+            GeometryReader { geom in
+                Color.clear
+                    .preference(key: OffsetRect.self, value: geom.frame(in: .named(parentGeometry.space)))
             }
-            .padding(.vertical, isExpanded ? (8 - 2) : 0)
         }
-        .animation(.spring(response: 0.3), value: isExpanded)
-        // this is not accessible, but the badge UI is not shown to accessibility tools at the moment
-        .onTapGesture {
-            isExpanded.toggle()
+        .overlayPreferenceValue(OffsetRect.self, alignment: .bottomLeading) { offsetRect in
+            MediaBadge {
+                HStack {
+                    if isExpanded {
+                        content
+                            .font(.caption)
+                            .matchedGeometryEffect(id: "background", in: namespace, properties: .position)
+                            .transition(
+                                .scale(scale: 0.2, anchor: .bottomLeading)
+                                .combined(with: .opacity)
+                            )
+                        Spacer(minLength: 0)
+                    } else {
+                        label
+                            .matchedGeometryEffect(id: "background", in: namespace, properties: .position)
+                            .transition(
+                                .scale(scale: 3, anchor: .trailing)
+                                .combined(with: .opacity)
+                            )
+                    }
+                }
+                .padding(.vertical, isExpanded ? (8 - 2) : 0)
+            }
+            .frame(width: isExpanded ? parentGeometry.size.width : nil)
+            .offset(x: isExpanded ? -offsetRect.minX : 0)
+            .animation(.spring(response: 0.3), value: isExpanded)
+            // this is not accessible, but the badge UI is not shown to accessibility tools at the moment
+            .onTapGesture {
+                isExpanded.toggle()
+            }
         }
+        // necessary to keep the expanded state from underlapping the collapsed badges
+        // NOTE: if you want multiple expandable badges you will need to change this somehow. Good luck!
+        .zIndex(1)
     }
 }
 
 extension ExpandableMediaBadge where Label == Text {
-    init(_ label: String, isExpanded: Binding<Bool>, @ViewBuilder content: () -> Content) {
-        self.init(isExpanded: isExpanded, content: content) {
+    init(_ label: String, isExpanded: Binding<Bool>, in parentGeometry: (CGSize, AnyHashable), @ViewBuilder content: () -> Content) {
+        self.init(isExpanded: isExpanded, in: parentGeometry, content: content) {
             Text(label)
         }
     }
 }
 
+private struct OffsetRect: PreferenceKey {
+    static var defaultValue = CGRect.zero
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+        value = nextValue()
+    }
+}
 
 struct ExpandableMediaBadge_Previews: PreviewProvider {
     static var previews: some View {
-        ExpandableMediaBadge(isExpanded: .constant(false)) {
-            Text("Hello world!")
-        } label: {
-            Text("ALT")
-        }
+        GeometryReader { geom in
+            ExpandableMediaBadge(isExpanded: .constant(false), in: (geom.size, "preview")) {
+                Text("Hello world!")
+            } label: {
+                Text("ALT")
+            }
+        }.coordinateSpace(name: "preview")
     }
 }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaAltTextOverlay.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaAltTextOverlay.swift
@@ -11,30 +11,13 @@ struct MediaAltTextOverlay: View {
     var altDescription: String?
     
     @State private var showingAlt = false
-    @Namespace private var namespace
 
     var body: some View {
         GeometryReader { geom in
             if let altDescription {
-                MediaBadge(isExpanded: $showingAlt) {
-                    if showingAlt {
-                        Text(altDescription)
-                            .font(.caption)
-                            .matchedGeometryEffect(id: "background", in: namespace, properties: .position)
-                            .transition(
-                                .scale(scale: 0.2, anchor: .bottomLeading)
-                                .combined(with: .opacity)
-                            )
-                    } else {
-                        Text("ALT")
-                            .matchedGeometryEffect(id: "background", in: namespace, properties: .position)
-                            .transition(
-                                .scale(scale: 3, anchor: .trailing)
-                                .combined(with: .opacity)
-                            )
-                    }
+                ExpandableMediaBadge("ALT", isExpanded: $showingAlt) {
+                    Text(altDescription)
                 }
-                .animation(.spring(response: 0.3), value: showingAlt)
                 .frame(width: geom.size.width, height: geom.size.height, alignment: .bottomLeading)
             }
         }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaAltTextOverlay.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaAltTextOverlay.swift
@@ -15,30 +15,18 @@ struct MediaAltTextOverlay: View {
 
     var body: some View {
         GeometryReader { geom in
-            ZStack {
-                if let altDescription {
+            if let altDescription {
+                MediaBadge(isExpanded: $showingAlt) {
                     if showingAlt {
-                        HStack(alignment: .top) {
-                            Text(altDescription)
-                            Spacer()
-                            Button(action: { showingAlt = false }) {
-                                Image(systemName: "xmark.circle.fill")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                                    .frame(width: 20, height: 20)
-                            }
-                        }
-                        .padding(8)
-                        .matchedGeometryEffect(id: "background", in: namespace, properties: .position)
-                        .transition(
-                            .scale(scale: 0.2, anchor: .bottomLeading)
-                            .combined(with: .opacity)
-                        )
+                        Text(altDescription)
+                            .font(.caption)
+                            .matchedGeometryEffect(id: "background", in: namespace, properties: .position)
+                            .transition(
+                                .scale(scale: 0.2, anchor: .bottomLeading)
+                                .combined(with: .opacity)
+                            )
                     } else {
-                        Button("ALT") { showingAlt = true }
-                            .font(.caption.weight(.semibold))
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 3)
+                        Text("ALT")
                             .matchedGeometryEffect(id: "background", in: namespace, properties: .position)
                             .transition(
                                 .scale(scale: 3, anchor: .trailing)
@@ -46,19 +34,9 @@ struct MediaAltTextOverlay: View {
                             )
                     }
                 }
+                .animation(.spring(response: 0.3), value: showingAlt)
+                .frame(width: geom.size.width, height: geom.size.height, alignment: .bottomLeading)
             }
-            .foregroundColor(.white)
-            .tint(.white)
-            .background(Color.black.opacity(0.85))
-            .cornerRadius(4)
-            .overlay(
-                .white.opacity(0.5),
-                in: RoundedRectangle(cornerRadius: 4)
-                    .inset(by: -0.5)
-                    .stroke(lineWidth: 0.5)
-            )
-            .animation(.spring(response: 0.3), value: showingAlt)
-            .frame(width: geom.size.width, height: geom.size.height, alignment: .bottomLeading)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 8)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadge.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadge.swift
@@ -3,8 +3,14 @@
 import SwiftUI
 
 struct MediaBadge<Content: View>: View {
-    let content: Content
-    init(@ViewBuilder content: () -> Content) {
+    private var _isExpanded: Binding<Bool>?
+    private let content: Content
+    private var isExpanded: Bool {
+        _isExpanded?.wrappedValue ?? false
+    }
+
+    init(isExpanded: Binding<Bool>? = nil, @ViewBuilder content: () -> Content) {
+        self._isExpanded = isExpanded
         self.content = content()
     }
 
@@ -12,12 +18,15 @@ struct MediaBadge<Content: View>: View {
         // need the VStack (or some other kind of containing view) to
         // ensure the transition animations work properly
         // Is this a bug? Is it intended behavior? I have no clue
-        VStack {
+        HStack {
             content
+            if isExpanded {
+                Spacer(minLength: 0)
+            }
         }
         .font(.subheadline.bold())
         .padding(.horizontal, 8)
-        .padding(.vertical, 2)
+        .padding(.vertical, isExpanded ? 8 : 2)
         .foregroundColor(.white)
         .tint(.white)
         .background(Color.black.opacity(0.7))
@@ -28,6 +37,11 @@ struct MediaBadge<Content: View>: View {
                 .inset(by: -0.5)
                 .stroke(lineWidth: 0.5)
         )
+        // this is not accessible, but the badge UI is not shown to accessibility tools at the moment
+        .onTapGesture {
+            _isExpanded?.wrappedValue.toggle()
+        }
+        .accessibilityHidden(true)
     }
 
 }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadge.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadge.swift
@@ -1,0 +1,50 @@
+// Copyright © 2023 Mastodon gGmbH. All rights reserved.
+
+import SwiftUI
+
+struct MediaBadge<Content: View>: View {
+    let content: Content
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        // need the VStack (or some other kind of containing view) to
+        // ensure the transition animations work properly
+        // Is this a bug? Is it intended behavior? I have no clue
+        VStack {
+            content
+        }
+        .font(.subheadline.bold())
+        .padding(.horizontal, 8)
+        .padding(.vertical, 2)
+        .foregroundColor(.white)
+        .tint(.white)
+        .background(Color.black.opacity(0.7))
+        .cornerRadius(3)
+        .overlay(
+            .white.opacity(0.5),
+            in: RoundedRectangle(cornerRadius: 3)
+                .inset(by: -0.5)
+                .stroke(lineWidth: 0.5)
+        )
+    }
+
+}
+
+struct MediaBadge_Previews: PreviewProvider {
+    static var previews: some View {
+        MediaBadge {
+            Button("ALT") {}
+        }
+
+        MediaBadge {
+            Button("GIF") {}
+        }
+
+        MediaBadge {
+            Text("01:24")
+                .monospacedDigit()
+        }
+    }
+}

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadge.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadge.swift
@@ -23,12 +23,6 @@ struct MediaBadge<Content: View>: View {
         .tint(.white)
         .background(Color.black.opacity(0.7))
         .cornerRadius(3)
-        .overlay(
-            .white.opacity(0.5),
-            in: RoundedRectangle(cornerRadius: 3)
-                .inset(by: -0.5)
-                .stroke(lineWidth: 0.5)
-        )
         .accessibilityHidden(true)
     }
 }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadge.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadge.swift
@@ -3,14 +3,9 @@
 import SwiftUI
 
 struct MediaBadge<Content: View>: View {
-    private var _isExpanded: Binding<Bool>?
     private let content: Content
-    private var isExpanded: Bool {
-        _isExpanded?.wrappedValue ?? false
-    }
 
-    init(isExpanded: Binding<Bool>? = nil, @ViewBuilder content: () -> Content) {
-        self._isExpanded = isExpanded
+    init(@ViewBuilder content: () -> Content) {
         self.content = content()
     }
 
@@ -20,13 +15,10 @@ struct MediaBadge<Content: View>: View {
         // Is this a bug? Is it intended behavior? I have no clue
         HStack {
             content
-            if isExpanded {
-                Spacer(minLength: 0)
-            }
         }
         .font(.subheadline.bold())
         .padding(.horizontal, 8)
-        .padding(.vertical, isExpanded ? 8 : 2)
+        .padding(.vertical, 2)
         .foregroundColor(.white)
         .tint(.white)
         .background(Color.black.opacity(0.7))
@@ -37,13 +29,16 @@ struct MediaBadge<Content: View>: View {
                 .inset(by: -0.5)
                 .stroke(lineWidth: 0.5)
         )
-        // this is not accessible, but the badge UI is not shown to accessibility tools at the moment
-        .onTapGesture {
-            _isExpanded?.wrappedValue.toggle()
-        }
         .accessibilityHidden(true)
     }
+}
 
+extension MediaBadge where Content == Text {
+    init(_ text: String) {
+        self.init {
+            Text(text)
+        }
+    }
 }
 
 struct MediaBadge_Previews: PreviewProvider {

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgeOverlay.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgeOverlay.swift
@@ -10,15 +10,19 @@ struct MediaBadgeOverlay: View {
     var altDescription: String?
     
     @State private var showingAlt = false
+    @State private var space = AnyHashable(UUID())
 
     var body: some View {
         GeometryReader { geom in
-            if let altDescription {
-                ExpandableMediaBadge("ALT", isExpanded: $showingAlt) {
-                    Text(altDescription)
+            HStack(alignment: .bottom) {
+                if let altDescription {
+                    ExpandableMediaBadge("ALT", isExpanded: $showingAlt, in: (geom.size, space)) {
+                        Text(altDescription)
+                    }
                 }
-                .frame(width: geom.size.width, height: geom.size.height, alignment: .bottomLeading)
             }
+            .frame(width: geom.size.width, height: geom.size.height, alignment: .bottomLeading)
+            .coordinateSpace(name: space)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 8)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgeOverlay.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgeOverlay.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 struct MediaBadgeOverlay: View {
     var altDescription: String?
+    var isGIF = false
     
     @State private var showingAlt = false
     @State private var space = AnyHashable(UUID())
@@ -18,7 +19,11 @@ struct MediaBadgeOverlay: View {
                 if let altDescription {
                     ExpandableMediaBadge("ALT", isExpanded: $showingAlt, in: (geom.size, space)) {
                         Text(altDescription)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
+                }
+                if isGIF {
+                    MediaBadge("GIF")
                 }
             }
             .frame(width: geom.size.width, height: geom.size.height, alignment: .bottomLeading)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgeOverlay.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgeOverlay.swift
@@ -1,13 +1,12 @@
 //
-//  MediaAltTextOverlay.swift
-//  
+//  MediaBadgeOverlay.swift
 //
 //  Created by Jed Fox on 2022-12-20.
 //
 
 import SwiftUI
 
-struct MediaAltTextOverlay: View {
+struct MediaBadgeOverlay: View {
     var altDescription: String?
     
     @State private var showingAlt = false
@@ -31,7 +30,7 @@ struct MediaAltTextOverlay: View {
 
 struct MediaAltTextOverlay_Previews: PreviewProvider {
     static var previews: some View {
-        MediaAltTextOverlay(altDescription: "Hello, world!")
+        MediaBadgeOverlay(altDescription: "Hello, world!")
             .frame(height: 300)
             .background(Color.gray)
             .previewLayout(.sizeThatFits)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgeOverlay.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgeOverlay.swift
@@ -9,9 +9,20 @@ import SwiftUI
 struct MediaBadgeOverlay: View {
     var altDescription: String?
     var isGIF = false
+    var videoDuration: TimeInterval?
     
     @State private var showingAlt = false
     @State private var space = AnyHashable(UUID())
+
+    // Date.ComponentsFormatStyle does not allow force-enabling minutes unit
+    static let formatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.minute, .second]
+        formatter.unitsStyle = .positional
+        formatter.zeroFormattingBehavior = []
+        formatter.formattingContext = .standalone
+        return formatter
+    }()
 
     var body: some View {
         GeometryReader { geom in
@@ -24,6 +35,9 @@ struct MediaBadgeOverlay: View {
                 }
                 if isGIF {
                     MediaBadge("GIF")
+                }
+                if let videoDuration, let format = Self.formatter.string(from: videoDuration) {
+                    MediaBadge(format)
                 }
             }
             .frame(width: geom.size.width, height: geom.size.height, alignment: .bottomLeading)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgesContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgesContainer.swift
@@ -39,6 +39,7 @@ struct MediaBadgesContainer: View {
                 }
                 if let videoDuration, let format = Self.formatter.string(from: videoDuration) {
                     MediaBadge(format)
+                        .monospacedDigit()
                 }
             }
             .frame(width: geom.size.width, height: geom.size.height, alignment: .bottomLeading)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgesContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgesContainer.swift
@@ -44,7 +44,8 @@ struct MediaBadgesContainer: View {
             .frame(width: geom.size.width, height: geom.size.height, alignment: .bottomLeading)
             .coordinateSpace(name: space)
         }
-        .padding(8)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
         .onChange(of: altDescription) { _ in
             showingAlt = false
         }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgesContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgesContainer.swift
@@ -1,12 +1,12 @@
 //
-//  MediaBadgeOverlay.swift
+//  MediaBadgesContainer.swift
 //
 //  Created by Jed Fox on 2022-12-20.
 //
 
 import SwiftUI
 
-struct MediaBadgeOverlay: View {
+struct MediaBadgesContainer: View {
     var altDescription: String?
     var isGIF = false
     var videoDuration: TimeInterval?
@@ -53,7 +53,7 @@ struct MediaBadgeOverlay: View {
 
 struct MediaAltTextOverlay_Previews: PreviewProvider {
     static var previews: some View {
-        MediaBadgeOverlay(altDescription: "Hello, world!")
+        MediaBadgesContainer(altDescription: "Hello, world!")
             .frame(height: 300)
             .background(Color.gray)
             .previewLayout(.sizeThatFits)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgesContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgesContainer.swift
@@ -9,7 +9,8 @@ import SwiftUI
 struct MediaBadgesContainer: View {
     var altDescription: String?
     var isGIF = false
-    var videoDuration: TimeInterval?
+    var showDuration = false
+    var mediaDuration: TimeInterval?
     
     @State private var showingAlt = false
     @State private var space = AnyHashable(UUID())
@@ -37,9 +38,13 @@ struct MediaBadgesContainer: View {
                 if isGIF {
                     MediaBadge("GIF")
                 }
-                if let videoDuration, let format = Self.formatter.string(from: videoDuration) {
-                    MediaBadge(format)
-                        .monospacedDigit()
+                if showDuration {
+                    if let mediaDuration, let format = Self.formatter.string(from: mediaDuration) {
+                        MediaBadge(format)
+                            .monospacedDigit()
+                    } else {
+                        MediaBadge("--:--")
+                    }
                 }
             }
             .frame(width: geom.size.width, height: geom.size.height, alignment: .bottomLeading)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgesContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgesContainer.swift
@@ -30,6 +30,7 @@ struct MediaBadgesContainer: View {
                 if let altDescription {
                     ExpandableMediaBadge("ALT", isExpanded: $showingAlt, in: (geom.size, space)) {
                         Text(altDescription)
+                            .frame(maxHeight: geom.size.height - 16)
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgesContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaBadgesContainer.swift
@@ -26,7 +26,7 @@ struct MediaBadgesContainer: View {
 
     var body: some View {
         GeometryReader { geom in
-            HStack(alignment: .bottom) {
+            HStack(alignment: .bottom, spacing: 2) {
                 if let altDescription {
                     ExpandableMediaBadge("ALT", isExpanded: $showingAlt, in: (geom.size, space)) {
                         Text(altDescription)
@@ -44,8 +44,7 @@ struct MediaBadgesContainer: View {
             .frame(width: geom.size.width, height: geom.size.height, alignment: .bottomLeading)
             .coordinateSpace(name: space)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 8)
+        .padding(8)
         .onChange(of: altDescription) { _ in
             showingAlt = false
         }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -194,6 +194,8 @@ extension MediaView {
     }
     
     private func bindVideo(configuration: Configuration, info: Configuration.VideoInfo) {
+        badgeViewController.rootView.videoDuration = info.durationMS.map { Double($0) / 1000 }
+
         let imageInfo = Configuration.ImageInfo(
             aspectRadio: info.aspectRadio,
             assetURL: info.previewURL,
@@ -284,6 +286,7 @@ extension MediaView {
         
         badgeViewController.rootView.altDescription = nil
         badgeViewController.rootView.isGIF = false
+        badgeViewController.rootView.videoDuration = nil
 
         // reset configuration
         configuration = nil

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -83,8 +83,8 @@ public final class MediaView: UIView {
         return label
     }()
     
-    let altViewController: UIHostingController<MediaAltTextOverlay> = {
-        let vc = UIHostingController(rootView: MediaAltTextOverlay())
+    let badgeViewController: UIHostingController<MediaBadgeOverlay> = {
+        let vc = UIHostingController(rootView: MediaBadgeOverlay())
         vc.view.backgroundColor = .clear
         return vc
     }()
@@ -231,7 +231,7 @@ extension MediaView {
             accessibilityLabel = altDescription
         }
 
-        altViewController.rootView.altDescription = altDescription
+        badgeViewController.rootView.altDescription = altDescription
     }
 
     private func layoutBlurhash() {
@@ -263,9 +263,9 @@ extension MediaView {
     }
     
     private func layoutAlt() {
-        altViewController.view.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(altViewController.view)
-        altViewController.view.pinToParent()
+        badgeViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(badgeViewController.view)
+        badgeViewController.view.pinToParent()
     }
     
     public func prepareForReuse() {
@@ -303,7 +303,7 @@ extension MediaView {
         container.removeFromSuperview()
         container.removeConstraints(container.constraints)
         
-        altViewController.rootView.altDescription = nil
+        badgeViewController.rootView.altDescription = nil
 
         // reset configuration
         configuration = nil

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -167,6 +167,9 @@ extension MediaView {
     }
     
     private func bindGIF(configuration: Configuration, info: Configuration.VideoInfo) {
+        badgeViewController.rootView.mediaDuration = info.durationMS.map { Double($0) / 1000 }
+        badgeViewController.rootView.showDuration = false
+
         guard let player = setupGIFPlayer(info: info) else { return }
         setupPlayerLooper(player: player)
         playerViewController.player = player
@@ -194,7 +197,8 @@ extension MediaView {
     }
     
     private func bindVideo(configuration: Configuration, info: Configuration.VideoInfo) {
-        badgeViewController.rootView.videoDuration = info.durationMS.map { Double($0) / 1000 }
+        badgeViewController.rootView.mediaDuration = info.durationMS.map { Double($0) / 1000 }
+        badgeViewController.rootView.showDuration = true
 
         let imageInfo = Configuration.ImageInfo(
             aspectRadio: info.aspectRadio,
@@ -286,7 +290,8 @@ extension MediaView {
         
         badgeViewController.rootView.altDescription = nil
         badgeViewController.rootView.isGIF = false
-        badgeViewController.rootView.videoDuration = nil
+        badgeViewController.rootView.showDuration = false
+        badgeViewController.rootView.mediaDuration = nil
 
         // reset configuration
         configuration = nil

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -66,8 +66,8 @@ public final class MediaView: UIView {
         return wrapper
     }()
     
-    let badgeViewController: UIHostingController<MediaBadgeOverlay> = {
-        let vc = UIHostingController(rootView: MediaBadgeOverlay())
+    let badgeViewController: UIHostingController<MediaBadgesContainer> = {
+        let vc = UIHostingController(rootView: MediaBadgesContainer())
         vc.view.backgroundColor = .clear
         return vc
     }()

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -66,23 +66,6 @@ public final class MediaView: UIView {
         return wrapper
     }()
     
-    private(set) lazy var indicatorBlurEffectView: UIVisualEffectView = {
-        let effectView = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
-        effectView.layer.masksToBounds = true
-        effectView.layer.cornerCurve = .continuous
-        effectView.layer.cornerRadius = 4
-        return effectView
-    }()
-    private(set) lazy var indicatorVibrancyEffectView = UIVisualEffectView(
-        effect: UIVibrancyEffect(blurEffect: UIBlurEffect(style: .systemUltraThinMaterial))
-    )
-    private(set) lazy var playerIndicatorLabel: UILabel = {
-        let label = UILabel()
-        label.font = .preferredFont(forTextStyle: .caption1)
-        label.textColor = .secondaryLabel
-        return label
-    }()
-    
     let badgeViewController: UIHostingController<MediaBadgeOverlay> = {
         let vc = UIHostingController(rootView: MediaBadgeOverlay())
         vc.view.backgroundColor = .clear
@@ -179,10 +162,7 @@ extension MediaView {
         playerViewController.view.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(playerViewController.view)
         playerViewController.view.pinToParent()
-        
-        setupIndicatorViewHierarchy()
-        playerIndicatorLabel.attributedText = NSAttributedString(string: "GIF")
-        
+
         layoutAlt()
     }
     
@@ -194,6 +174,8 @@ extension MediaView {
         
         // auto play for GIF
         player.play()
+
+        badgeViewController.rootView.isGIF = true
 
         bindAlt(configuration: configuration, altDescription: info.altDescription)
     }
@@ -295,15 +277,13 @@ extension MediaView {
         blurhashImageView.removeFromSuperview()
         blurhashImageView.removeConstraints(blurhashImageView.constraints)
         blurhashImageView.image = nil
-        
-        // reset indicator
-        indicatorBlurEffectView.removeFromSuperview()
-        
+
         // reset container
         container.removeFromSuperview()
         container.removeConstraints(container.constraints)
         
         badgeViewController.rootView.altDescription = nil
+        badgeViewController.rootView.isGIF = false
 
         // reset configuration
         configuration = nil
@@ -332,37 +312,5 @@ extension MediaView {
         container.translatesAutoresizingMaskIntoConstraints = false
         addSubview(container)
         container.pinToParent()
-    }
-
-    private func setupIndicatorViewHierarchy() {
-        let blurEffectView = indicatorBlurEffectView
-        let vibrancyEffectView = indicatorVibrancyEffectView
-        
-        assert(playerViewController.contentOverlayView != nil)
-        if let contentOverlayView = playerViewController.contentOverlayView {
-            blurEffectView.translatesAutoresizingMaskIntoConstraints = false
-            contentOverlayView.addSubview(indicatorBlurEffectView)
-            NSLayoutConstraint.activate([
-                contentOverlayView.trailingAnchor.constraint(equalTo: blurEffectView.trailingAnchor, constant: 16),
-                contentOverlayView.bottomAnchor.constraint(equalTo: blurEffectView.bottomAnchor, constant: 8),
-            ])
-        }
-
-        if vibrancyEffectView.superview == nil {
-            vibrancyEffectView.translatesAutoresizingMaskIntoConstraints = false
-            blurEffectView.contentView.addSubview(vibrancyEffectView)
-            vibrancyEffectView.pinToParent()
-        }
-        
-        if playerIndicatorLabel.superview == nil {
-            playerIndicatorLabel.translatesAutoresizingMaskIntoConstraints = false
-            vibrancyEffectView.contentView.addSubview(playerIndicatorLabel)
-            NSLayoutConstraint.activate([
-                playerIndicatorLabel.topAnchor.constraint(equalTo: vibrancyEffectView.contentView.topAnchor),
-                playerIndicatorLabel.leadingAnchor.constraint(equalTo: vibrancyEffectView.contentView.leadingAnchor, constant: 3),
-                vibrancyEffectView.contentView.trailingAnchor.constraint(equalTo: playerIndicatorLabel.trailingAnchor, constant: 3),
-                playerIndicatorLabel.bottomAnchor.constraint(equalTo: vibrancyEffectView.contentView.bottomAnchor),
-            ])
-        }
     }
 }


### PR DESCRIPTION
Individual badges

- [x] Badges are not fixed size; they are labels with padding and a background color
- [x] 8pt horizontal padding, 2pt vertical padding
- [x] Label font: `.font(.subheadline).bold()`
  - [x] Set label to use monospacedDigits [for duration only]
- [x] Label foreground color: always white
- [x] Badge background color: black, 0.7 alpha

Expanded badge state
- [x] Expanded width should take as much space as possible minus the 8pt insets on both horizontal edges
- [x] Badge expands with an animation on tap
- [x] Expands outwards on top of any other badges (if applicable) rather than pushing out other badges
- [x] Tapping anywhere ~~aside from the translation button~~ collapses the badge
- [x] 8pt padding, all edges
- [x] Label font: `.font(.caption1) `

Translation: [not implemented]

Group of badges

- [x] 2pt spacing between badges
- [x] Inset 16pt from leading edge of media container, 8pt from bottom
- [x] If there are multiple badges to display, the order (LTR) should be:
  - ALT
  - GIF
  - Video duration timestamp (MM:SS)

<details><summary>Screenshots</summary>

<img width=390 src=https://user-images.githubusercontent.com/25517624/232264583-e59e43a7-b54e-4d8c-b9ab-60cd7a1d72f9.png> <img width=390 src=https://user-images.githubusercontent.com/25517624/232264623-d8d13b65-9062-4783-b424-cc0bc1a160c5.jpg > <img width=390 src=https://user-images.githubusercontent.com/25517624/232264439-0082aabd-4106-4afc-b5ba-2565c669a9f7.jpg> <img width=390 src=https://user-images.githubusercontent.com/25517624/232264440-08341742-454f-4a14-89e4-737fc68cde23.jpg> <img width=390 src=https://user-images.githubusercontent.com/25517624/232264441-2421cdf3-15cd-4a92-9f9c-473af3b4d34f.jpg> <img width=390 src=https://user-images.githubusercontent.com/25517624/232264442-17e7253f-5256-4d9c-8aa4-232680877a33.jpg>

![IMG_2924](https://user-images.githubusercontent.com/25517624/232264623-d8d13b65-9062-4783-b424-cc0bc1a160c5.jpg)


</details>
