### PR TITLE
Trim whitespace from webpage titles in StatusCardControl

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusCardControl.swift
@@ -138,13 +138,14 @@ public final class StatusCardControl: UIControl {
     }
 
     public func configure(card: Card) {
+        let title = card.title.trimmingCharacters(in: .whitespacesAndNewlines)
         if let host = card.url?.host {
-            accessibilityLabel = "\(card.title) \(host)"
+            accessibilityLabel = "\(title) \(host)"
         } else {
-            accessibilityLabel = card.title
+            accessibilityLabel = title
         }
 
-        titleLabel.text = card.title
+        titleLabel.text = title
         linkLabel.text = card.url?.host
         imageView.contentMode = .center
 


### PR DESCRIPTION
Some links have extra whitespace in their titles:

(https://mstdn.social/@feditips/110209876836973494)

<img width=390 src=https://user-images.githubusercontent.com/25517624/232342714-0ee845a0-1b54-4009-a2c3-da1c2612cf7a.png>

This fixes that:

<img width=390 src= https://user-images.githubusercontent.com/25517624/232343177-cabea417-9738-4639-9c38-9fa9365ee3c3.jpeg>
