### PR TITLE
Fix “hide sensitive content” button being hidden

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -311,14 +311,15 @@ extension StatusView.ViewModel {
                 // statusView.spoilerBannerView.label.reset()
             }
             
-            if statusView.style == .editHistory, let spoilerContent = spoilerContent, !spoilerContent.string.isEmpty {
+            if statusView.style == .editHistory {
+                statusView.setContentSensitiveeToggleButtonDisplay(isDisplay: false)
+            }
+            if let spoilerContent = spoilerContent, !spoilerContent.string.isEmpty {
                 statusView.historyContentWarningLabel.configure(content: spoilerContent)
                 statusView.historyContentWarningAdaptiveMarginContainerView.isHidden = statusView.style != .editHistory
-                statusView.setContentSensitiveeToggleButtonDisplay(isDisplay: false)
             } else {
                 statusView.historyContentWarningLabel.reset()
                 statusView.historyContentWarningAdaptiveMarginContainerView.isHidden = true
-                statusView.setContentSensitiveeToggleButtonDisplay(isDisplay: false)
             }
             
             let paragraphStyle = statusView.contentMetaText.paragraphStyle


### PR DESCRIPTION
Previously, tapping on the 👁️ button would hide it, leaving no way to hide nsfw/content warning content after showing it.