### PR TITLE
Fix crash when a server has an emoji category named after its domain

### DIFF
--- a/MastodonSDK/Sources/MastodonCore/Model/Compose/CustomEmojiPickerSection.swift
+++ b/MastodonSDK/Sources/MastodonCore/Model/Compose/CustomEmojiPickerSection.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 public enum CustomEmojiPickerSection: Equatable, Hashable {
+    case uncategorized
     case emoji(name: String)
 }

--- a/MastodonSDK/Sources/MastodonUI/DataSource/CustomEmojiPickerSection+Diffable.swift
+++ b/MastodonSDK/Sources/MastodonUI/DataSource/CustomEmojiPickerSection+Diffable.swift
@@ -11,6 +11,7 @@ import MastodonCore
 extension CustomEmojiPickerSection {
     static func collectionViewDiffableDataSource(
         collectionView: UICollectionView,
+        authContext: AuthContext,
         context: AppContext
     ) -> UICollectionViewDiffableDataSource<CustomEmojiPickerSection, CustomEmojiPickerItem> {
         let dataSource = UICollectionViewDiffableDataSource<CustomEmojiPickerSection, CustomEmojiPickerItem>(collectionView: collectionView) { [weak context] collectionView, indexPath, item -> UICollectionViewCell? in
@@ -44,6 +45,8 @@ extension CustomEmojiPickerSection {
             case String(describing: CustomEmojiPickerHeaderCollectionReusableView.self):
                 let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: String(describing: CustomEmojiPickerHeaderCollectionReusableView.self), for: indexPath) as! CustomEmojiPickerHeaderCollectionReusableView
                 switch section {
+                case .uncategorized:
+                    header.titleLabel.text = authContext.mastodonAuthenticationBox.domain.uppercased()
                 case .emoji(let name):
                     header.titleLabel.text = name
                 }

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel+DataSource.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel+DataSource.swift
@@ -144,11 +144,13 @@ extension ComposeContentViewModel {
             .map({ (emojiMap) -> NSDiffableDataSourceSnapshot<CustomEmojiPickerSection, CustomEmojiPickerItem> in
 
                 var snapshot = NSDiffableDataSourceSnapshot<CustomEmojiPickerSection, CustomEmojiPickerItem>()
-                let customEmojiSection = CustomEmojiPickerSection.uncategorized
-                snapshot.appendSections([customEmojiSection])
-                snapshot.appendItems(emojiMap.noCategory.map({ emoji in
-                    CustomEmojiPickerItem.emoji(attribute: CustomEmojiPickerItem.CustomEmojiAttribute(emoji: emoji))
-                }), toSection: customEmojiSection)
+                if !emojiMap.noCategory.isEmpty {
+                    let customEmojiSection = CustomEmojiPickerSection.uncategorized
+                    snapshot.appendSections([customEmojiSection])
+                    snapshot.appendItems(emojiMap.noCategory.map({ emoji in
+                        CustomEmojiPickerItem.emoji(attribute: CustomEmojiPickerItem.CustomEmojiAttribute(emoji: emoji))
+                    }), toSection: customEmojiSection)
+                }
                 emojiMap.categorised.keys.sorted().forEach { category in
                     let section = CustomEmojiPickerSection.emoji(name: category)
                     snapshot.appendSections([section])

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel+DataSource.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel+DataSource.swift
@@ -102,11 +102,11 @@ extension ComposeContentViewModel {
     ) {
         let diffableDataSource = CustomEmojiPickerSection.collectionViewDiffableDataSource(
             collectionView: collectionView,
+            authContext: authContext,
             context: context
         )
         self.customEmojiPickerDiffableDataSource = diffableDataSource
 
-        let domain = authContext.mastodonAuthenticationBox.domain.uppercased()
         customEmojiViewModel?.emojis
             // Don't block the main queue
             .receive(on: DispatchQueue.global(qos: .userInteractive))
@@ -144,7 +144,7 @@ extension ComposeContentViewModel {
             .map({ (emojiMap) -> NSDiffableDataSourceSnapshot<CustomEmojiPickerSection, CustomEmojiPickerItem> in
 
                 var snapshot = NSDiffableDataSourceSnapshot<CustomEmojiPickerSection, CustomEmojiPickerItem>()
-                let customEmojiSection = CustomEmojiPickerSection.emoji(name: domain)
+                let customEmojiSection = CustomEmojiPickerSection.uncategorized
                 snapshot.appendSections([customEmojiSection])
                 snapshot.appendItems(emojiMap.noCategory.map({ emoji in
                     CustomEmojiPickerItem.emoji(attribute: CustomEmojiPickerItem.CustomEmojiAttribute(emoji: emoji))


### PR DESCRIPTION
Fixes #1042 two ways:

- The uncategorized (named after the server) section can no longer conflict with a named category section in the emoji picker and cause a crash
- The uncategorized section is now only shown if there are uncategorized emoji on the server.

To test, create a c.im account or update `EmojiService+CustomEmojiViewModel+LoadState.swift:43` and `CustomEmojiPickerSection+Diffable.swift:49` to hardcode `"c.im"` as the server domain.