### PR TITLE
Remove prohibited calling the super method

### DIFF
--- a/Mastodon/Scene/MediaPreview/AltTextViewController.swift
+++ b/Mastodon/Scene/MediaPreview/AltTextViewController.swift
@@ -48,7 +48,6 @@ class AltTextViewController: UIViewController {
     }
     
     override func loadView() {
-        super.loadView()
         view.translatesAutoresizingMaskIntoConstraints = false
     }
 


### PR DESCRIPTION
Hi,

This PR removes prohibited calling `super.loadView()`.

The document says:

> Your custom implementation of this method should not call `super`.

https://developer.apple.com/documentation/uikit/uiviewcontroller/1621454-loadview