### PR TITLE
Fix the alt text view initialization

### DIFF
--- a/Mastodon/Scene/MediaPreview/AltTextViewController.swift
+++ b/Mastodon/Scene/MediaPreview/AltTextViewController.swift
@@ -47,15 +47,11 @@ class AltTextViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func loadView() {
-        super.loadView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
         textView.translatesAutoresizingMaskIntoConstraints = false
+        view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = .systemBackground
         view.addSubview(textView)
 


### PR DESCRIPTION
Hi,

This PR fixes the alt text view initialization.

The document says:
> If you want to perform any additional initialization of your views, do so in the `viewDidLoad()` method.

https://developer.apple.com/documentation/uikit/uiviewcontroller/1621454-loadview

Related to https://github.com/mastodon/mastodon-ios/pull/1046.