### PR TITLE
Fix loading of follower/following count on profile pages

### DIFF
--- a/Mastodon/Scene/Profile/Header/ProfileHeaderViewController.swift
+++ b/Mastodon/Scene/Profile/Header/ProfileHeaderViewController.swift
@@ -183,32 +183,6 @@ extension ProfileHeaderViewController {
         
         // set display after view appear
         profileHeaderView.setupImageOverlayViews()
-        
-        guard let userID = viewModel.user?.id else { return }
-        Task {
-            do {
-                let response = try await viewModel.context.apiService.followers(
-                    userID: userID,
-                    maxID: nil,
-                    authenticationBox: viewModel.authContext.mastodonAuthenticationBox
-                )
-                
-                profileHeaderView.viewModel.followersCount = response.value.count
-            } catch {
-                logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): fetch follower fail: \(error.localizedDescription)")
-            }
-            do {
-                let response = try await viewModel.context.apiService.following(
-                    userID: userID,
-                    maxID: nil,
-                    authenticationBox: viewModel.authContext.mastodonAuthenticationBox
-                )
-                
-                profileHeaderView.viewModel.followingCount = response.value.count
-            } catch {
-                logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): fetch following fail: \(error.localizedDescription)")
-            }
-        }   // end Task
     }
     
     override func viewDidLayoutSubviews() {

--- a/Mastodon/Scene/Profile/ProfileViewController.swift
+++ b/Mastodon/Scene/Profile/ProfileViewController.swift
@@ -384,6 +384,21 @@ extension ProfileViewController {
                 self.navigationItem.title = name
             }
             .store(in: &disposeBag)
+        Publishers.CombineLatest(
+            profileHeaderViewController.viewModel.$user,
+            profileHeaderViewController.profileHeaderView.viewModel.viewDidAppear
+        )
+        .sink { [weak self] (user, _) in
+            guard let self = self, let user = user else { return }
+            Task {
+                _ = try await self.context.apiService.accountInfo(
+                    domain: user.domain,
+                    userID: user.id,
+                    authorization: self.authContext.mastodonAuthenticationBox.userAuthorization
+                )
+            }
+        }
+        .store(in: &disposeBag)
     }
 
     private func bindMoreBarButtonItem() {


### PR DESCRIPTION
This PR reverts #825 and replaces it with an implementation that fetches the entire account object from the API. This allows us to ensure all information is up to date (including follow/follower counts, as well as name/bio/etc.