### PR TITLE
IOS-119 Video attachment adjustments

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/InlineMediaOverlayContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/InlineMediaOverlayContainer.swift
@@ -8,10 +8,16 @@ import SwiftUI
 
 struct InlineMediaOverlayContainer: View {
     var altDescription: String?
-    var isGIF = false
+    var mediaType: MediaType = .image
     var showDuration = false
     var mediaDuration: TimeInterval?
-    
+
+    enum MediaType {
+        case image
+        case gif
+        case video
+    }
+
     @State private var showingAlt = false
     @State private var space = AnyHashable(UUID())
 
@@ -35,7 +41,7 @@ struct InlineMediaOverlayContainer: View {
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 }
-                if isGIF {
+                if mediaType == .gif {
                     MediaBadge("GIF")
                 }
                 if showDuration {

--- a/MastodonSDK/Sources/MastodonUI/View/Content/InlineMediaOverlayContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/InlineMediaOverlayContainer.swift
@@ -1,12 +1,12 @@
 //
-//  MediaBadgesContainer.swift
+//  InlineMediaOverlayContainer.swift
 //
 //  Created by Jed Fox on 2022-12-20.
 //
 
 import SwiftUI
 
-struct MediaBadgesContainer: View {
+struct InlineMediaOverlayContainer: View {
     var altDescription: String?
     var isGIF = false
     var showDuration = false
@@ -60,7 +60,7 @@ struct MediaBadgesContainer: View {
 
 struct MediaAltTextOverlay_Previews: PreviewProvider {
     static var previews: some View {
-        MediaBadgesContainer(altDescription: "Hello, world!")
+        InlineMediaOverlayContainer(altDescription: "Hello, world!")
             .frame(height: 300)
             .background(Color.gray)
             .previewLayout(.sizeThatFits)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/InlineMediaOverlayContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/InlineMediaOverlayContainer.swift
@@ -64,6 +64,12 @@ struct InlineMediaOverlayContainer: View {
                      .font(.system(size: 54))
                      .foregroundColor(.white)
                      .shadow(color: .black.opacity(0.5), radius: 32, x: 0, y: 0)
+                     .background(alignment: .center) {
+                         Circle()
+                             .fill(.ultraThinMaterial)
+                             .frame(width: 40, height: 40)
+                             .colorScheme(.light)
+                     }
             }
         }
         .onChange(of: altDescription) { _ in

--- a/MastodonSDK/Sources/MastodonUI/View/Content/InlineMediaOverlayContainer.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/InlineMediaOverlayContainer.swift
@@ -58,6 +58,14 @@ struct InlineMediaOverlayContainer: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
+        .overlay {
+            if mediaType == .video {
+                  Image(systemName: "play.circle.fill")
+                     .font(.system(size: 54))
+                     .foregroundColor(.white)
+                     .shadow(color: .black.opacity(0.5), radius: 32, x: 0, y: 0)
+            }
+        }
         .onChange(of: altDescription) { _ in
             showingAlt = false
         }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -51,21 +51,6 @@ public final class MediaView: UIView {
     }()
     private var playerLooper: AVPlayerLooper?
 
-    private(set) lazy var playbackImageView: UIView = {
-        let wrapper = UIView()
-
-        let imageView = UIImageView()
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.image = UIImage(systemName: "play.circle.fill")
-        imageView.tintColor = Asset.Colors.Label.primary.color
-        wrapper.addSubview(imageView)
-        imageView.pinToParent(padding: .init(top: 8, left: 8, bottom: 8, right: 8))
-        wrapper.backgroundColor = Asset.Theme.Mastodon.systemBackground.color.withAlphaComponent(0.8)
-        wrapper.applyCornerRadius(radius: 8)
-
-        return wrapper
-    }()
-    
     let overlayViewController: UIHostingController<InlineMediaOverlayContainer> = {
         let vc = UIHostingController(rootView: InlineMediaOverlayContainer())
         vc.view.backgroundColor = .clear
@@ -186,15 +171,6 @@ extension MediaView {
     
     private func layoutVideo() {
         layoutImage()
-        
-        playbackImageView.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(playbackImageView)
-        NSLayoutConstraint.activate([
-            playbackImageView.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-            playbackImageView.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-            playbackImageView.widthAnchor.constraint(equalToConstant: 88).priority(.required - 1),
-            playbackImageView.heightAnchor.constraint(equalToConstant: 88).priority(.required - 1),
-        ])
     }
     
     private func bindVideo(configuration: Configuration, info: Configuration.VideoInfo) {
@@ -277,8 +253,6 @@ extension MediaView {
         playerViewController.player?.pause()
         playerViewController.player = nil
         playerLooper = nil
-        
-        playbackImageView.removeFromSuperview()
         
         // blurhash
         blurhashImageView.removeFromSuperview()

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -66,8 +66,8 @@ public final class MediaView: UIView {
         return wrapper
     }()
     
-    let badgeViewController: UIHostingController<MediaBadgesContainer> = {
-        let vc = UIHostingController(rootView: MediaBadgesContainer())
+    let overlayViewController: UIHostingController<InlineMediaOverlayContainer> = {
+        let vc = UIHostingController(rootView: InlineMediaOverlayContainer())
         vc.view.backgroundColor = .clear
         return vc
     }()
@@ -167,8 +167,8 @@ extension MediaView {
     }
     
     private func bindGIF(configuration: Configuration, info: Configuration.VideoInfo) {
-        badgeViewController.rootView.mediaDuration = info.durationMS.map { Double($0) / 1000 }
-        badgeViewController.rootView.showDuration = false
+        overlayViewController.rootView.mediaDuration = info.durationMS.map { Double($0) / 1000 }
+        overlayViewController.rootView.showDuration = false
 
         guard let player = setupGIFPlayer(info: info) else { return }
         setupPlayerLooper(player: player)
@@ -178,7 +178,7 @@ extension MediaView {
         // auto play for GIF
         player.play()
 
-        badgeViewController.rootView.isGIF = true
+        overlayViewController.rootView.isGIF = true
 
         bindAlt(configuration: configuration, altDescription: info.altDescription)
     }
@@ -197,8 +197,8 @@ extension MediaView {
     }
     
     private func bindVideo(configuration: Configuration, info: Configuration.VideoInfo) {
-        badgeViewController.rootView.mediaDuration = info.durationMS.map { Double($0) / 1000 }
-        badgeViewController.rootView.showDuration = true
+        overlayViewController.rootView.mediaDuration = info.durationMS.map { Double($0) / 1000 }
+        overlayViewController.rootView.showDuration = true
 
         let imageInfo = Configuration.ImageInfo(
             aspectRadio: info.aspectRadio,
@@ -219,7 +219,7 @@ extension MediaView {
             accessibilityLabel = altDescription
         }
 
-        badgeViewController.rootView.altDescription = altDescription
+        overlayViewController.rootView.altDescription = altDescription
     }
 
     private func layoutBlurhash() {
@@ -251,9 +251,9 @@ extension MediaView {
     }
     
     private func layoutAlt() {
-        badgeViewController.view.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(badgeViewController.view)
-        badgeViewController.view.pinToParent()
+        overlayViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(overlayViewController.view)
+        overlayViewController.view.pinToParent()
     }
     
     public func prepareForReuse() {
@@ -288,10 +288,10 @@ extension MediaView {
         container.removeFromSuperview()
         container.removeConstraints(container.constraints)
         
-        badgeViewController.rootView.altDescription = nil
-        badgeViewController.rootView.isGIF = false
-        badgeViewController.rootView.showDuration = false
-        badgeViewController.rootView.mediaDuration = nil
+        overlayViewController.rootView.altDescription = nil
+        overlayViewController.rootView.isGIF = false
+        overlayViewController.rootView.showDuration = false
+        overlayViewController.rootView.mediaDuration = nil
 
         // reset configuration
         configuration = nil

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -112,14 +112,17 @@ extension MediaView {
         switch configuration.info {
         case .image(let info):
             layoutImage()
+            overlayViewController.rootView.mediaType = .image
             bindImage(configuration: configuration, info: info)
             accessibilityHint = L10n.Common.Controls.Status.Media.expandImageHint
         case .gif(let info):
             layoutGIF()
+            overlayViewController.rootView.mediaType = .gif
             bindGIF(configuration: configuration, info: info)
             accessibilityHint = L10n.Common.Controls.Status.Media.expandGifHint
         case .video(let info):
             layoutVideo()
+            overlayViewController.rootView.mediaType = .video
             bindVideo(configuration: configuration, info: info)
             accessibilityHint = L10n.Common.Controls.Status.Media.expandVideoHint
         }
@@ -177,8 +180,6 @@ extension MediaView {
         
         // auto play for GIF
         player.play()
-
-        overlayViewController.rootView.isGIF = true
 
         bindAlt(configuration: configuration, altDescription: info.altDescription)
     }
@@ -289,7 +290,6 @@ extension MediaView {
         container.removeConstraints(container.constraints)
         
         overlayViewController.rootView.altDescription = nil
-        overlayViewController.rootView.isGIF = false
         overlayViewController.rootView.showDuration = false
         overlayViewController.rootView.mediaDuration = nil
 


### PR DESCRIPTION
- [x] This is not an inline player. Tapping the attachment opens the fullscreen media viewer.
  - Already the case
- [x] Play button is SF Symbol play.circle.fill. It is always white with a drop shadow.
  - Updated sizing, removed the backdrop!
- [x] Use a media badge (IOS-125) to display the video duration timestamp (MM:SS)
  - Implemented in #1019


<img width=200 src=https://github.com/mastodon/mastodon-ios/assets/25517624/f860c75a-203c-4698-b766-f2c6464e29e0><img width=200 src=https://github.com/mastodon/mastodon-ios/assets/25517624/a2de75ee-9baa-4cdd-956e-d44ae567fa84><img width=200 src=https://github.com/mastodon/mastodon-ios/assets/25517624/c6c7c36b-6231-4ef7-b4f1-5eb65e225610>

Proposal: add a blur behind the triangle to improve contrast on complex videos (ultra thin material, always in the light color scheme regardless of app color scheme, on [this post](https://mastodon.social/@hootalex/110487091560971840) hacked to display the play button). What do you think @samhenrigold?

<img width=300 src=https://github.com/mastodon/mastodon-ios/assets/25517624/4ee4cdbc-5ec6-43fc-bcc4-f522e0c8f26c>
(included in this PR but willing to revert!)