### PR TITLE
IOS-159: Fix tap location check for dismissing media preview

### DIFF
--- a/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
+++ b/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
@@ -265,7 +265,7 @@ extension MediaPreviewViewController: MediaPreviewImageViewControllerDelegate {
     
     func mediaPreviewImageViewController(_ viewController: MediaPreviewImageViewController, tapGestureRecognizerDidTrigger tapGestureRecognizer: UITapGestureRecognizer) {
         let location = tapGestureRecognizer.location(in: viewController.previewImageView.imageView)
-        let isContainsTap = viewController.previewImageView.imageView.frame.contains(location)
+        let isContainsTap = viewController.previewImageView.imageView.bounds.contains(location)
         
         if isContainsTap {
             self.viewModel.showingChrome.toggle()


### PR DESCRIPTION
`view.bounds` is in the coordinate space of `view`, while `view.frame` is in the coordinate space of `view.superview`.