### PR TITLE
Set a solid background on the blurhash view in case it doesn’t load

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -30,6 +30,8 @@ public final class MediaView: UIView {
         imageView.contentMode = .scaleAspectFill
         imageView.isUserInteractionEnabled = false
         imageView.layer.masksToBounds = true    // clip overflow
+        imageView.backgroundColor = .gray
+        imageView.isOpaque = true
         return imageView
     }()
     


### PR DESCRIPTION
Fixes #1067. It seems that the underlying issue there was that the NSFW media somehow loaded before the blurhash image. (Maybe because whatever process produces the blurhashes gets backed up when scrolling quickly?) I fixed this by setting the background color of the blurhash image to a solid gray. This prevents anything from leaking through.