### PR TITLE
Hide the entire top toolbar for videos & audio

### DIFF
--- a/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
+++ b/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
@@ -116,7 +116,7 @@ extension MediaPreviewViewController {
                     self.topToolbar.isHidden = {
                         guard index < previewContext.attachments.count else { return false }
                         let attachment = previewContext.attachments[index]
-                        return attachment.kind == .video    // not hide buttno for audio
+                        return attachment.kind == .video || attachment.kind == .audio
                     }()
                 default:
                     break

--- a/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
+++ b/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
@@ -113,12 +113,11 @@ extension MediaPreviewViewController {
                 guard let self = self else { return }
                 switch self.viewModel.item {
                 case .attachment(let previewContext):
-                    let needsHideCloseButton: Bool = {
+                    self.topToolbar.isHidden = {
                         guard index < previewContext.attachments.count else { return false }
                         let attachment = previewContext.attachments[index]
                         return attachment.kind == .video    // not hide buttno for audio
                     }()
-                    self.topToolbar.isHidden = needsHideCloseButton
                 default:
                     break
                 }

--- a/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
+++ b/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
@@ -118,7 +118,7 @@ extension MediaPreviewViewController {
                         let attachment = previewContext.attachments[index]
                         return attachment.kind == .video    // not hide buttno for audio
                     }()
-                    self.closeButton.isHidden = needsHideCloseButton
+                    self.topToolbar.isHidden = needsHideCloseButton
                 default:
                     break
                 }


### PR DESCRIPTION
Hopefully fixes #485, fixes #955

Currently, the “alt” button covers the entire top of the video player interface. This is bad because the close button is underlapped by the “alt” button. It would be awesome if there was a way to add a “media description” button or similar to the “…” menu in the video player but unfortunately those sorts of APIs are restricted to tvOS. Since the alt text can generally be read in the inline preview (especially since videos are less commonly present with other media attachments so there should be a bunch of space), and folks who use screen readers will already have access to the full text through their screen reader / other accessibility tool, I don’t think losing access to the popover UI will be a huge loss. I think that if y’all want to explore adding any sort of UI over top of the video player, it would be best to identify and switch to a high-quality, accessible third party video player that offers better customization options (if such a project exists).