### PR TITLE
Improve heuristic for skipping the post discard confirmation modal

### DIFF
--- a/Localization/StringsConvertor/input/Base.lproj/app.json
+++ b/Localization/StringsConvertor/input/Base.lproj/app.json
@@ -15,10 +15,6 @@
                 "title": "Vote Failure",
                 "poll_ended": "The poll has ended"
             },
-            "discard_post_content": {
-                "title": "Discard Draft",
-                "message": "Confirm to discard composed post content."
-            },
             "publish_post_failure": {
                 "title": "Publish Failure",
                 "message": "Failed to publish the post.\nPlease check your internet connection.",

--- a/Localization/app.json
+++ b/Localization/app.json
@@ -15,10 +15,6 @@
                 "title": "Vote Failure",
                 "poll_ended": "The poll has ended"
             },
-            "discard_post_content": {
-                "title": "Discard Draft",
-                "message": "Confirm to discard composed post content."
-            },
             "publish_post_failure": {
                 "title": "Publish Failure",
                 "message": "Failed to publish the post.\nPlease check your internet connection.",

--- a/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
+++ b/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
@@ -40,12 +40,6 @@ public enum L10n {
         /// Delete Post
         public static let title = L10n.tr("Localizable", "Common.Alerts.DeletePost.Title", fallback: "Delete Post")
       }
-      public enum DiscardPostContent {
-        /// Confirm to discard composed post content.
-        public static let message = L10n.tr("Localizable", "Common.Alerts.DiscardPostContent.Message", fallback: "Confirm to discard composed post content.")
-        /// Discard Draft
-        public static let title = L10n.tr("Localizable", "Common.Alerts.DiscardPostContent.Title", fallback: "Discard Draft")
-      }
       public enum EditProfileFailure {
         /// Cannot edit profile. Please try again.
         public static let message = L10n.tr("Localizable", "Common.Alerts.EditProfileFailure.Message", fallback: "Cannot edit profile. Please try again.")

--- a/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
+++ b/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
@@ -6,8 +6,6 @@
 "Common.Alerts.Common.PleaseTryAgainLater" = "Please try again later.";
 "Common.Alerts.DeletePost.Message" = "Are you sure you want to delete this post?";
 "Common.Alerts.DeletePost.Title" = "Delete Post";
-"Common.Alerts.DiscardPostContent.Message" = "Confirm to discard composed post content.";
-"Common.Alerts.DiscardPostContent.Title" = "Discard Draft";
 "Common.Alerts.EditProfileFailure.Message" = "Cannot edit profile. Please try again.";
 "Common.Alerts.EditProfileFailure.Title" = "Edit Profile Error";
 "Common.Alerts.PublishPostFailure.AttachmentsMessage.MoreThanOneVideo" = "Cannot attach more than one video.";

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
@@ -479,7 +479,9 @@ extension ComposeContentViewModel {
                     return true
                 }
                 // if the trimmed content equal to initial content
-                return content.trimmingCharacters(in: .whitespacesAndNewlines) == self.initialContent
+                let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
+                let initialContent = self.initialContent.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmedContent == initialContent
             }
             .assign(to: &$shouldDismiss)
         


### PR DESCRIPTION
Fix #1076

Also expands the logic to show the confirmation modal if the user has entered a content warning, toggled the poll on, or added one or more attachments.

Additionally, removes some discard-related strings that are no longer used.