### PR TITLE
Make list of default servers configurable (IOS-171)

### DIFF
--- a/Localization/app.json
+++ b/Localization/app.json
@@ -270,7 +270,7 @@
         "welcome": {
             "log_in": "Log In",
             "learn_more": "Learn more",
-            "join_default_server": "Join mastodon.social",
+            "join_default_server": "Join %@",
             "pick_server": "Pick another server",
             "separator": {
                 "or": "or"

--- a/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
@@ -336,7 +336,7 @@ extension WelcomeViewController {
                 case .failure(let error ):
                     guard let randomServer = self.viewModel.pickRandomDefaultServer() else { return }
 
-                    viewModel.randomDefaultServer = randomServer
+                    self.viewModel.randomDefaultServer = randomServer
 
                     sender.isEnabled = true
                     sender.configuration?.showsActivityIndicator = false

--- a/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
@@ -47,10 +47,6 @@ final class WelcomeViewController: UIViewController, NeedsDependency {
 
     private(set) lazy var joinDefaultServerButton: UIButton = {
         var buttonConfiguration = UIButton.Configuration.filled()
-        buttonConfiguration.attributedTitle = AttributedString(
-            L10n.Scene.Welcome.joinDefaultServer,
-            attributes: .init([.font: UIFontMetrics(forTextStyle: .headline).scaledFont(for: .systemFont(ofSize: 17, weight: .semibold))])
-        )
         buttonConfiguration.baseForegroundColor = .white
         buttonConfiguration.background.backgroundColor = Asset.Colors.Brand.blurple.color
         buttonConfiguration.background.cornerRadius = 14
@@ -217,6 +213,23 @@ extension WelcomeViewController {
             .store(in: &disposeBag)
 
         setupIllustrationLayout()
+
+        joinDefaultServerButton.configuration?.showsActivityIndicator = true
+        joinDefaultServerButton.isEnabled = false
+        joinDefaultServerButton.configuration?.title = nil
+
+        viewModel.downloadDefaultServer { [weak self] in
+            guard let selectedDefaultServer = self?.viewModel.randomDefaultServer else { return }
+
+            DispatchQueue.main.async {
+                self?.joinDefaultServerButton.configuration?.showsActivityIndicator = false
+                self?.joinDefaultServerButton.isEnabled = true
+                self?.joinDefaultServerButton.configuration?.attributedTitle = AttributedString(
+                    L10n.Scene.Welcome.joinDefaultServer(selectedDefaultServer.domain),
+                    attributes: .init([.font: UIFontMetrics(forTextStyle: .headline).scaledFont(for: .systemFont(ofSize: 17, weight: .semibold))])
+                )
+            }
+        }
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -262,11 +275,11 @@ extension WelcomeViewController {
     //MARK: - Actions
     @objc
     private func joinDefaultServer(_ sender: UIButton) {
+
+        guard let server = viewModel.randomDefaultServer else { return }
         sender.configuration?.title = nil
         sender.isEnabled = false
         sender.configuration?.showsActivityIndicator = true
-
-        let server = Mastodon.Entity.Server.mastodonDotSocial
 
         authenticationViewModel.isAuthenticating.send(true)
 
@@ -320,19 +333,26 @@ extension WelcomeViewController {
                 self.authenticationViewModel.isAuthenticating.send(false)
 
                 switch completion {
-                    case .failure(let error):
-                        //TODO: show an alert or something
-                        break
-                    case .finished:
-                        break
+                case .failure(let error ):
+                    guard let randomServer = self.viewModel.pickRandomDefaultServer() else { return }
+
+                    viewModel.randomDefaultServer = randomServer
+
+                    sender.isEnabled = true
+                    sender.configuration?.showsActivityIndicator = false
+                    sender.configuration?.attributedTitle = AttributedString(
+                        L10n.Scene.Welcome.joinDefaultServer(randomServer.domain),
+                        attributes: .init([.font: UIFontMetrics(forTextStyle: .headline).scaledFont(for: .systemFont(ofSize: 17, weight: .semibold))])
+                    )
+                case .finished:
+                    sender.isEnabled = true
+                    sender.configuration?.showsActivityIndicator = false
+                    sender.configuration?.attributedTitle = AttributedString(
+                        L10n.Scene.Welcome.joinDefaultServer(server.domain),
+                        attributes: .init([.font: UIFontMetrics(forTextStyle: .headline).scaledFont(for: .systemFont(ofSize: 17, weight: .semibold))])
+                    )
                 }
 
-                sender.isEnabled = true
-                sender.configuration?.showsActivityIndicator = false
-                sender.configuration?.attributedTitle = AttributedString(
-                    L10n.Scene.Welcome.joinDefaultServer,
-                    attributes: .init([.font: UIFontMetrics(forTextStyle: .headline).scaledFont(for: .systemFont(ofSize: 17, weight: .semibold))])
-                )
             } receiveValue: { [weak self] response in
                 guard let self = self else { return }
                 if let rules = response.instance.value.rules, !rules.isEmpty {

--- a/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Onboarding.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Onboarding.swift
@@ -33,4 +33,8 @@ extension APIService {
     public func languages() -> AnyPublisher<Mastodon.Response.Content<[Mastodon.Entity.Language]>, Error> {
         return Mastodon.API.Onboarding.languages(session: session)
     }
+
+    public func defaultServers() -> AnyPublisher<Mastodon.Response.Content<[Mastodon.Entity.DefaultServer]>, Error> {
+        return Mastodon.API.Onboarding.defaultServers(session: session)
+    }
 }

--- a/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
+++ b/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
@@ -1510,8 +1510,10 @@ public enum L10n {
       }
     }
     public enum Welcome {
-      /// Join mastodon.social
-      public static let joinDefaultServer = L10n.tr("Localizable", "Scene.Welcome.JoinDefaultServer", fallback: "Join mastodon.social")
+      /// Join %@
+      public static func joinDefaultServer(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "Scene.Welcome.JoinDefaultServer", String(describing: p1), fallback: "Join %@")
+      }
       /// Learn more
       public static let learnMore = L10n.tr("Localizable", "Scene.Welcome.LearnMore", fallback: "Learn more")
       /// Log In

--- a/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
+++ b/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
@@ -530,7 +530,7 @@ uploaded to Mastodon.";
 "Scene.Welcome.Education.Mastodon.Title" = "Welcome to Mastodon";
 "Scene.Welcome.Education.Servers.Description" = "Every Mastodon account is hosted on a server — each with its own values, rules, & admins. No matter which one you pick, you can follow and interact with people on any server.";
 "Scene.Welcome.Education.Servers.Title" = "What are servers?";
-"Scene.Welcome.JoinDefaultServer" = "Join mastodon.social";
+"Scene.Welcome.JoinDefaultServer" = "Join %@";
 "Scene.Welcome.LearnMore" = "Learn more";
 "Scene.Welcome.LogIn" = "Log In";
 "Scene.Welcome.PickServer" = "Pick another server";

--- a/MastodonSDK/Sources/MastodonLocalization/Resources/en.lproj/Localizable.strings
+++ b/MastodonSDK/Sources/MastodonLocalization/Resources/en.lproj/Localizable.strings
@@ -530,7 +530,7 @@ uploaded to Mastodon.";
 "Scene.Welcome.Education.Mastodon.Title" = "Welcome to Mastodon";
 "Scene.Welcome.Education.Servers.Description" = "Every Mastodon account is hosted on a server — each with its own values, rules, & admins. No matter which one you pick, you can follow and interact with people on any server.";
 "Scene.Welcome.Education.Servers.Title" = "What are servers?";
-"Scene.Welcome.JoinDefaultServer" = "Join mastodon.social";
+"Scene.Welcome.JoinDefaultServer" = "Join %@";
 "Scene.Welcome.LearnMore" = "Learn more";
 "Scene.Welcome.LogIn" = "Log In";
 "Scene.Welcome.PickServer" = "Pick another server";

--- a/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+Onboarding.swift
+++ b/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+Onboarding.swift
@@ -13,6 +13,7 @@ extension Mastodon.API.Onboarding {
     static let serversEndpointURL = Mastodon.API.joinMastodonEndpointURL.appendingPathComponent("servers")
     static let categoriesEndpointURL = Mastodon.API.joinMastodonEndpointURL.appendingPathComponent("categories")
     static let languagesEndpointURL = Mastodon.API.joinMastodonEndpointURL.appendingPathComponent("languages")
+    static let defaultServersEndpointURL = Mastodon.API.joinMastodonEndpointURL.appendingPathComponent("default-servers")
  
     /// Fetch server list
     ///
@@ -96,6 +97,30 @@ extension Mastodon.API.Onboarding {
             }
             .eraseToAnyPublisher()
     }
+
+    /// Fetch default servers
+    ///
+    /// Using this endpoint to fetch default servers
+    ///
+    /// # Last Update
+    ///   2023/07/02
+    /// # Reference
+    ///   undocumented
+    /// - Parameters:
+    ///   - session: `URLSession`
+    /// - Returns: `AnyPublisher` contains `Language` nested in the response
+    public static func defaultServers(
+        session: URLSession
+    ) -> AnyPublisher<Mastodon.Response.Content<[Mastodon.Entity.DefaultServer]>, Error>  {
+        let request = Mastodon.API.get(url: defaultServersEndpointURL)
+        return session.dataTaskPublisher(for: request)
+            .tryMap { data, response in
+                let value = try Mastodon.API.decode(type: [Mastodon.Entity.DefaultServer].self, from: data, response: response)
+                return Mastodon.Response.Content(value: value, response: response)
+            }
+            .eraseToAnyPublisher()
+    }
+
 }
 
 extension Mastodon.API.Onboarding {

--- a/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API.swift
+++ b/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API.swift
@@ -134,7 +134,7 @@ extension Mastodon.API {
     static func get(
         url: URL,
         query: GetQuery? = nil,
-        authorization: OAuth.Authorization?
+        authorization: OAuth.Authorization? = nil
     ) -> URLRequest {
         return buildRequest(url: url, method: .GET, query: query, authorization: authorization)
     }
@@ -142,7 +142,7 @@ extension Mastodon.API {
     static func post(
         url: URL,
         query: PostQuery?,
-        authorization: OAuth.Authorization?
+        authorization: OAuth.Authorization? = nil
     ) -> URLRequest {
         return buildRequest(url: url, method: .POST, query: query, authorization: authorization)
     }
@@ -150,7 +150,7 @@ extension Mastodon.API {
     static func patch(
         url: URL,
         query: PatchQuery?,
-        authorization: OAuth.Authorization?
+        authorization: OAuth.Authorization? = nil
     ) -> URLRequest {
         return buildRequest(url: url, method: .PATCH, query: query, authorization: authorization)
     }
@@ -158,7 +158,7 @@ extension Mastodon.API {
     static func put(
         url: URL,
         query: PutQuery? = nil,
-        authorization: OAuth.Authorization?
+        authorization: OAuth.Authorization? = nil
     ) -> URLRequest {
         return buildRequest(url: url, method: .PUT, query: query, authorization: authorization)
     }
@@ -166,7 +166,7 @@ extension Mastodon.API {
     static func delete(
         url: URL,
         query: DeleteQuery?,
-        authorization: OAuth.Authorization?
+        authorization: OAuth.Authorization? = nil
     ) -> URLRequest {
         return buildRequest(url: url, method: .DELETE, query: query, authorization: authorization)
     }

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+DefaultServer.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+DefaultServer.swift
@@ -4,7 +4,12 @@ import Foundation
 
 extension Mastodon.Entity {
     public struct DefaultServer: Codable {
-        let domain: String
-        let weight: Int
+        public let domain: String
+        public let weight: Int
+
+        public init(domain: String, weight: Int) {
+            self.domain = domain
+            self.weight = weight
+        }
     }
 }

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+DefaultServer.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+DefaultServer.swift
@@ -1,0 +1,10 @@
+// Copyright © 2023 Mastodon gGmbH. All rights reserved.
+
+import Foundation
+
+extension Mastodon.Entity {
+    public struct DefaultServer: Codable {
+        let domain: String
+        let weight: Int
+    }
+}


### PR DESCRIPTION
- Download a list of suggested servers from [api.joinmastodon.org](https://api.joinmastodon.org/default-servers)
- Randomly pick on (based on a weighted list)
- Make the "Join $defaultServer"-button join this instance