### PR TITLE
Restore zoom behavior when double-tapping on text in an image

### DIFF
--- a/Mastodon/Scene/MediaPreview/Image/MediaPreviewImageView.swift
+++ b/Mastodon/Scene/MediaPreview/Image/MediaPreviewImageView.swift
@@ -70,6 +70,8 @@ extension MediaPreviewImageView {
         addSubview(imageView)
 
         doubleTapGestureRecognizer.addTarget(self, action: #selector(MediaPreviewImageView.doubleTapGestureRecognizerHandler(_:)))
+        doubleTapGestureRecognizer.delegate = self
+
         imageView.addGestureRecognizer(doubleTapGestureRecognizer)
         if #available(iOS 16.0, *) {
             imageView.addInteraction(liveTextInteraction)
@@ -111,6 +113,21 @@ extension MediaPreviewImageView {
         }
     }
     
+}
+
+extension MediaPreviewImageView: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer == doubleTapGestureRecognizer else { return false }
+        // block double-tap to select text gesture
+        // but only if the Live Text button is toggled off
+        if let gr = otherGestureRecognizer as? UITapGestureRecognizer,
+           gr.numberOfTapsRequired == 2,
+           #available(iOS 16, *),
+           !liveTextInteraction.selectableItemsHighlighted {
+            return true
+        }
+        return false
+    }
 }
 
 extension MediaPreviewImageView {

--- a/Mastodon/Scene/MediaPreview/Image/MediaPreviewImageViewController.swift
+++ b/Mastodon/Scene/MediaPreview/Image/MediaPreviewImageViewController.swift
@@ -15,7 +15,6 @@ import VisionKit
 
 protocol MediaPreviewImageViewControllerDelegate: AnyObject {
     func mediaPreviewImageViewController(_ viewController: MediaPreviewImageViewController, tapGestureRecognizerDidTrigger tapGestureRecognizer: UITapGestureRecognizer)
-    func mediaPreviewImageViewController(_ viewController: MediaPreviewImageViewController, longPressGestureRecognizerDidTrigger longPressGestureRecognizer: UILongPressGestureRecognizer)
     func mediaPreviewImageViewController(_ viewController: MediaPreviewImageViewController, contextMenuActionPerform action: MediaPreviewImageViewController.ContextMenuAction)
 }
 
@@ -31,7 +30,6 @@ final class MediaPreviewImageViewController: UIViewController {
     let previewImageView = MediaPreviewImageView()
 
     let tapGestureRecognizer = UITapGestureRecognizer.singleTapGestureRecognizer
-    let longPressGestureRecognizer = UILongPressGestureRecognizer()
 
     deinit {
         os_log("%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
@@ -58,13 +56,9 @@ extension MediaPreviewImageViewController {
 
         tapGestureRecognizer.addTarget(self, action: #selector(MediaPreviewImageViewController.tapGestureRecognizerHandler(_:)))
         tapGestureRecognizer.delegate = self
-        longPressGestureRecognizer.addTarget(self, action: #selector(MediaPreviewImageViewController.longPressGestureRecognizerHandler(_:)))
-        longPressGestureRecognizer.delegate = self
         tapGestureRecognizer.require(toFail: previewImageView.doubleTapGestureRecognizer)
-        tapGestureRecognizer.require(toFail: longPressGestureRecognizer)
         previewImageView.addGestureRecognizer(tapGestureRecognizer)
-        previewImageView.addGestureRecognizer(longPressGestureRecognizer)
-        
+
         let previewImageViewContextMenuInteraction = UIContextMenuInteraction(delegate: self)
         previewImageView.addInteraction(previewImageViewContextMenuInteraction)
 
@@ -93,11 +87,6 @@ extension MediaPreviewImageViewController {
     @objc private func tapGestureRecognizerHandler(_ sender: UITapGestureRecognizer) {
         os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
         delegate?.mediaPreviewImageViewController(self, tapGestureRecognizerDidTrigger: sender)
-    }
-    
-    @objc private func longPressGestureRecognizerHandler(_ sender: UILongPressGestureRecognizer) {
-        os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
-        delegate?.mediaPreviewImageViewController(self, longPressGestureRecognizerDidTrigger: sender)
     }
     
 }

--- a/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
+++ b/Mastodon/Scene/MediaPreview/MediaPreviewViewController.swift
@@ -273,10 +273,6 @@ extension MediaPreviewViewController: MediaPreviewImageViewControllerDelegate {
         }
     }
     
-    func mediaPreviewImageViewController(_ viewController: MediaPreviewImageViewController, longPressGestureRecognizerDidTrigger longPressGestureRecognizer: UILongPressGestureRecognizer) {
-        // do nothing
-    }
-    
     func mediaPreviewImageViewController(
         _ viewController: MediaPreviewImageViewController,
         contextMenuActionPerform action: MediaPreviewImageViewController.ContextMenuAction


### PR DESCRIPTION
I added a delegate to the double-tap gesture recognizer that causes it to cancel any other double-tap gesture recognizers, except when the Live Text button is toggled on. This makes it easy to zoom in/out by double-tapping anywhere, while still allowing the double-tap-to-select gesture when the user has explicitly opted into highlighting the text in the image.

This may stop working at some point if the `ImageAnalysisInteraction` stops using a `UITapGestureRecognizer` internally, but I don’t think this is a big problem since it will just go back to the old behavior and not, like, crash or something. 

I also took the opportunity to rip out a long press gesture recognizer that was added to the `MediaPreviewImageView` but didn’t do anything.

Fixes #1084.