### PR TITLE
Theme: Add translucency to navigation and tab bars on home timeline

### DIFF
--- a/MastodonSDK/Sources/MastodonCore/Service/Theme/ThemeService.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/Theme/ThemeService.swift
@@ -47,8 +47,9 @@ extension ThemeService {
     public func apply(theme: Theme) {
         // set navigation bar appearance
         let appearance = UINavigationBarAppearance()
-        appearance.configureWithDefaultBackground()
-        appearance.backgroundColor = theme.navigationBarBackgroundColor
+        let translucentColor = theme.navigationBarBackgroundColor.withAlphaComponent(0.99)
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = translucentColor
         UINavigationBar.appearance().standardAppearance = appearance
         UINavigationBar.appearance().compactAppearance = appearance
         UINavigationBar.appearance().scrollEdgeAppearance = appearance
@@ -71,7 +72,8 @@ extension ThemeService {
         tabBarAppearance.inlineLayoutAppearance = tabBarItemAppearance
         tabBarAppearance.compactInlineLayoutAppearance = tabBarItemAppearance
 
-        tabBarAppearance.backgroundColor = theme.tabBarBackgroundColor
+        tabBarAppearance.configureWithOpaqueBackground()
+        tabBarAppearance.backgroundColor = translucentColor
         UITabBar.appearance().standardAppearance = tabBarAppearance
         UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
         UITabBar.appearance().barTintColor = theme.tabBarBackgroundColor


### PR DESCRIPTION
Added translucency to the navigation and tab bars on the home timeline. I have kept the effect minimal and it can be adjusted (increased or decreased) based on feedback.

The effect is the same for both navigation and tab bars.

Before: https://ibb.co/qs6ksdq

After: https://ibb.co/tH2f7q4