### PR TITLE
Add credentials to trends + Error Handling for 401

### DIFF
--- a/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewController.swift
+++ b/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewController.swift
@@ -34,11 +34,6 @@ final class DiscoveryCommunityViewController: UIViewController, NeedsDependency,
     }()
     
     let refreshControl = RefreshControl()
-    
-    deinit {
-        os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
-    }
-    
 }
 
 extension DiscoveryCommunityViewController {

--- a/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewModel+State.swift
+++ b/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewModel+State.swift
@@ -5,15 +5,12 @@
 //  Created by MainasuK on 2022-4-29.
 //
 
-import os.log
 import Foundation
 import GameplayKit
 import MastodonSDK
 
 extension DiscoveryCommunityViewModel {
     class State: GKState {
-        
-        let logger = Logger(subsystem: "DiscoveryCommunityViewModel.State", category: "StateMachine")
 
         let id = UUID()
         
@@ -28,16 +25,11 @@ extension DiscoveryCommunityViewModel {
             
             let from = previousState.flatMap { String(describing: $0) } ?? "nil"
             let to = String(describing: self)
-            logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): \(from) -> \(to)")
         }
         
         @MainActor
         func enter(state: State.Type) {
             stateMachine?.enter(state)
-        }
-        
-        deinit {
-            logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): [\(self.id.uuidString)] \(String(describing: self))")
         }
     }
 }
@@ -87,9 +79,7 @@ extension DiscoveryCommunityViewModel.State {
             super.didEnter(from: previousState)
             guard let _ = viewModel, let stateMachine = stateMachine else { return }
             
-            os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s: retry loading 3s later…", ((#file as NSString).lastPathComponent), #line, #function)
             DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s: retry loading", ((#file as NSString).lastPathComponent), #line, #function)
                 stateMachine.enter(Loading.self)
             }
         }
@@ -174,7 +164,6 @@ extension DiscoveryCommunityViewModel.State {
                     viewModel.didLoadLatest.send()
                     
                 } catch {
-                    logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): fetch user timeline fail: \(error.localizedDescription)")
                     await enter(state: Fail.self)
                 }
             }   // end Task

--- a/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewModel+State.swift
+++ b/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewModel+State.swift
@@ -22,9 +22,6 @@ extension DiscoveryCommunityViewModel {
         
         override func didEnter(from previousState: GKState?) {
             super.didEnter(from: previousState)
-            
-            let from = previousState.flatMap { String(describing: $0) } ?? "nil"
-            let to = String(describing: self)
         }
         
         @MainActor

--- a/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewModel+State.swift
+++ b/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewModel+State.swift
@@ -8,6 +8,7 @@
 import Foundation
 import GameplayKit
 import MastodonSDK
+import enum NIOHTTP1.HTTPResponseStatus
 
 extension DiscoveryCommunityViewModel {
     class State: GKState {
@@ -161,7 +162,12 @@ extension DiscoveryCommunityViewModel.State {
                     viewModel.didLoadLatest.send()
                     
                 } catch {
-                    await enter(state: Fail.self)
+                    if let error = error as? Mastodon.API.Error,
+                       [HTTPResponseStatus.unauthorized, .notFound].contains(error.httpResponseStatus) {
+                        await enter(state: NoMore.self)
+                    } else {
+                        await enter(state: Fail.self)
+                    }
                 }
             }   // end Task
         }   // end func

--- a/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewModel.swift
+++ b/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewModel.swift
@@ -16,8 +16,6 @@ import MastodonCore
 
 final class DiscoveryCommunityViewModel {
     
-    let logger = Logger(subsystem: "DiscoveryCommunityViewModel", category: "ViewModel")
-    
     var disposeBag = Set<AnyCancellable>()
     
     // input
@@ -54,9 +52,4 @@ final class DiscoveryCommunityViewModel {
         )
         // end init
     }
-    
-    deinit {
-        os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
-    }
-    
 }

--- a/Mastodon/Scene/Discovery/ForYou/DiscoveryForYouViewController.swift
+++ b/Mastodon/Scene/Discovery/ForYou/DiscoveryForYouViewController.swift
@@ -5,16 +5,13 @@
 //  Created by MainasuK on 2022-4-14.
 //
 
-import os.log
 import UIKit
 import Combine
 import MastodonUI
 import MastodonCore
 
 final class DiscoveryForYouViewController: UIViewController, NeedsDependency, MediaPreviewableViewController {
-    
-    let logger = Logger(subsystem: "DiscoveryForYouViewController", category: "ViewController")
-    
+
     weak var context: AppContext! { willSet { precondition(!isViewLoaded) } }
     weak var coordinator: SceneCoordinator! { willSet { precondition(!isViewLoaded) } }
     
@@ -33,11 +30,6 @@ final class DiscoveryForYouViewController: UIViewController, NeedsDependency, Me
     }()
     
     let refreshControl = RefreshControl()
-    
-    deinit {
-        os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
-    }
-    
 }
 
 extension DiscoveryForYouViewController {
@@ -111,7 +103,6 @@ extension DiscoveryForYouViewController: AuthContextProvider {
 extension DiscoveryForYouViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): \(indexPath)")
         guard case let .user(record) = viewModel.diffableDataSource?.itemIdentifier(for: indexPath) else { return }
         guard let user = record.object(in: context.managedObjectContext) else { return }
         let profileViewModel = CachedProfileViewModel(

--- a/Mastodon/Scene/Discovery/ForYou/DiscoveryForYouViewModel.swift
+++ b/Mastodon/Scene/Discovery/ForYou/DiscoveryForYouViewModel.swift
@@ -5,7 +5,6 @@
 //  Created by MainasuK on 2022-4-14.
 //
 
-import os.log
 import UIKit
 import Combine
 import GameplayKit
@@ -41,11 +40,6 @@ final class DiscoveryForYouViewModel {
         )
         // end init
     }
-    
-    deinit {
-        os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
-    }
-    
 }
 
 extension DiscoveryForYouViewModel {

--- a/Mastodon/Scene/Discovery/Hashtags/DiscoveryHashtagsViewModel.swift
+++ b/Mastodon/Scene/Discovery/Hashtags/DiscoveryHashtagsViewModel.swift
@@ -16,8 +16,6 @@ import MastodonSDK
 
 final class DiscoveryHashtagsViewModel {
     
-    let logger = Logger(subsystem: "DiscoveryHashtagsViewModel", category: "ViewModel")
-    
     var disposeBag = Set<AnyCancellable>()
     
     // input
@@ -36,8 +34,12 @@ final class DiscoveryHashtagsViewModel {
         
         viewDidAppeared
             .throttle(for: 3, scheduler: DispatchQueue.main, latest: true)
-            .asyncMap { authenticationBox in
-                try await context.apiService.trendHashtags(domain: authContext.mastodonAuthenticationBox.domain, query: nil)
+            .asyncMap { _ in
+                let authenticationBox = authContext.mastodonAuthenticationBox
+                return try await context.apiService.trendHashtags(domain: authenticationBox.domain,
+                                                                  query: nil,
+                                                                  authenticationBox: authenticationBox
+                )
             }
             .retry(3)
             .map { response in Result<Mastodon.Response.Content<[Mastodon.Entity.Tag]>, Error> { response } }
@@ -46,28 +48,27 @@ final class DiscoveryHashtagsViewModel {
             .sink { [weak self] result in
                 guard let self = self else { return }
                 switch result {
-                case .success(let response):
-                    self.hashtags = response.value.filter { !$0.name.isEmpty }
-                case .failure:
-                    break
+                    case .success(let response):
+                        self.hashtags = response.value.filter { !$0.name.isEmpty }
+                    case .failure:
+                        break
                 }
             }
             .store(in: &disposeBag)
     }
-    
-    deinit {
-        os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
-    }
-    
 }
 
 extension DiscoveryHashtagsViewModel {
     
     @MainActor
     func fetch() async throws {
-        let response = try await context.apiService.trendHashtags(domain: authContext.mastodonAuthenticationBox.domain, query: nil)
+
+        let authenticationBox = authContext.mastodonAuthenticationBox
+        let response = try await context.apiService.trendHashtags(domain: authenticationBox.domain,
+                                                                  query: nil,
+                                                                  authenticationBox: authenticationBox
+        )
         hashtags = response.value.filter { !$0.name.isEmpty }
-        logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): fetch tags: \(response.value.count)")
     }
     
 }

--- a/Mastodon/Scene/Discovery/News/DiscoveryNewsViewModel+State.swift
+++ b/Mastodon/Scene/Discovery/News/DiscoveryNewsViewModel+State.swift
@@ -170,9 +170,13 @@ extension DiscoveryNewsViewModel.State {
                     viewModel.links = links
                     viewModel.didLoadLatest.send()
                 } catch {
-                    if let error = error as? Mastodon.API.Error, error.httpResponseStatus.code == 404 {
-                        viewModel.isServerSupportEndpoint = false
-                        await enter(state: NoMore.self)
+                    if let error = error as? Mastodon.API.Error {
+                        if error.httpResponseStatus == .notFound {
+                            viewModel.isServerSupportEndpoint = false
+                            await enter(state: NoMore.self)
+                        } else if error.httpResponseStatus == .unauthorized {
+                            await enter(state: NoMore.self)
+                        }
                     } else {
                         await enter(state: Fail.self)
                     }

--- a/Mastodon/Scene/Discovery/News/DiscoveryNewsViewModel.swift
+++ b/Mastodon/Scene/Discovery/News/DiscoveryNewsViewModel.swift
@@ -51,11 +51,6 @@ final class DiscoveryNewsViewModel {
             await checkServerEndpoint()
         }   // end Task
     }
-    
-    deinit {
-        os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
-    }
-    
 }
 
 
@@ -64,7 +59,8 @@ extension DiscoveryNewsViewModel {
         do {
             _ = try await context.apiService.trendLinks(
                 domain: authContext.mastodonAuthenticationBox.domain,
-                query: .init(offset: nil, limit: nil)
+                query: .init(offset: nil, limit: nil),
+                authenticationBox: authContext.mastodonAuthenticationBox
             )
         } catch let error as Mastodon.API.Error where error.httpResponseStatus.code == 404 {
             isServerSupportEndpoint = false

--- a/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewController.swift
+++ b/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewController.swift
@@ -35,11 +35,6 @@ final class DiscoveryPostsViewController: UIViewController, NeedsDependency, Med
     let refreshControl = RefreshControl()
     
     let discoveryIntroBannerView = DiscoveryIntroBannerView()
-
-    deinit {
-        os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
-    }
-    
 }
 
 extension DiscoveryPostsViewController {

--- a/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewModel+State.swift
+++ b/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewModel+State.swift
@@ -145,7 +145,8 @@ extension DiscoveryPostsViewModel.State {
                         query: Mastodon.API.Trends.StatusQuery(
                             offset: offset,
                             limit: nil
-                        )
+                        ),
+                        authenticationBox: viewModel.authContext.mastodonAuthenticationBox
                     )
                     let newOffset: Int? = {
                         guard let offset = response.link?.offset else { return nil }

--- a/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewModel+State.swift
+++ b/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewModel+State.swift
@@ -177,10 +177,13 @@ extension DiscoveryPostsViewModel.State {
                     viewModel.didLoadLatest.send()
                     
                 } catch {
-                    logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): fetch posts fail: \(error.localizedDescription)")
-                    if let error = error as? Mastodon.API.Error, error.httpResponseStatus.code == 404 {
-                        viewModel.isServerSupportEndpoint = false
-                        await enter(state: NoMore.self)
+                    if let error = error as? Mastodon.API.Error {
+                        if error.httpResponseStatus == .notFound {
+                            viewModel.isServerSupportEndpoint = false
+                            await enter(state: NoMore.self)
+                        } else if error.httpResponseStatus == .unauthorized {
+                            await enter(state: NoMore.self)
+                        }
                     } else {
                         await enter(state: Fail.self)
                     }

--- a/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewModel.swift
+++ b/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewModel.swift
@@ -5,7 +5,6 @@
 //  Created by MainasuK on 2022-4-12.
 //
 
-import os.log
 import UIKit
 import Combine
 import GameplayKit
@@ -56,11 +55,6 @@ final class DiscoveryPostsViewModel {
             await checkServerEndpoint()
         }   // end Task
     }
-    
-    deinit {
-        os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
-    }
-    
 }
 
 extension DiscoveryPostsViewModel {
@@ -68,7 +62,8 @@ extension DiscoveryPostsViewModel {
         do {
             _ = try await context.apiService.trendStatuses(
                 domain: authContext.mastodonAuthenticationBox.domain,
-                query: .init(offset: nil, limit: nil)
+                query: .init(offset: nil, limit: nil),
+                authenticationBox: authContext.mastodonAuthenticationBox
             )
         } catch let error as Mastodon.API.Error where error.httpResponseStatus.code == 404 {
             isServerSupportEndpoint = false

--- a/Mastodon/Scene/Onboarding/Login/MastodonLoginViewController.swift
+++ b/Mastodon/Scene/Onboarding/Login/MastodonLoginViewController.swift
@@ -236,7 +236,6 @@ class MastodonLoginViewController: UIViewController, NeedsDependency {
         let keyboardFrame = keyboardFrameValue.cgRectValue
         
         let keyboardOrigin = view.convert(keyboardFrame.origin, from: nil)
-        let intersectionY = CGRectGetMaxY(view.frame) - keyboardOrigin.y;
         
         UIView.animate(withDuration: duration.doubleValue, delay: 0, options: .curveEaseInOut) {
             self.view.layoutIfNeeded()

--- a/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
@@ -333,7 +333,7 @@ extension WelcomeViewController {
                 self.authenticationViewModel.isAuthenticating.send(false)
 
                 switch completion {
-                case .failure(let error ):
+                case .failure(_):
                     guard let randomServer = self.viewModel.pickRandomDefaultServer() else { return }
 
                     self.viewModel.randomDefaultServer = randomServer

--- a/Mastodon/Scene/Thread/ThreadViewModel+LoadThreadState.swift
+++ b/Mastodon/Scene/Thread/ThreadViewModel+LoadThreadState.swift
@@ -85,7 +85,7 @@ extension ThreadViewModel.LoadThreadState {
                     // assert(!Thread.isMainThread)
                     // await Task.sleep(1_000_000_000)     // 1s delay to prevent UI render issue
 
-                    let statusHistory = try await viewModel.context.apiService.getHistory(forStatusID: threadContext.statusID,
+                    _ = try await viewModel.context.apiService.getHistory(forStatusID: threadContext.statusID,
                                                                                           authenticationBox: viewModel.authContext.mastodonAuthenticationBox)
                     
                     viewModel.mastodonStatusThreadViewModel.appendAncestor(

--- a/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Trend.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Trend.swift
@@ -7,17 +7,20 @@
 
 import Foundation
 import MastodonSDK
+import CoreDataStack
 
 extension APIService {
     
     public func trendHashtags(
         domain: String,
-        query: Mastodon.API.Trends.HashtagQuery?
+        query: Mastodon.API.Trends.HashtagQuery?,
+        authenticationBox: MastodonAuthenticationBox
     ) async throws -> Mastodon.Response.Content<[Mastodon.Entity.Tag]> {
         let response = try await Mastodon.API.Trends.hashtags(
             session: session,
             domain: domain,
-            query: query
+            query: query,
+            authorization: authenticationBox.userAuthorization
         ).singleOutput()
         
         return response
@@ -25,12 +28,14 @@ extension APIService {
     
     public func trendStatuses(
         domain: String,
-        query: Mastodon.API.Trends.StatusQuery
+        query: Mastodon.API.Trends.StatusQuery,
+        authenticationBox: MastodonAuthenticationBox
     ) async throws -> Mastodon.Response.Content<[Mastodon.Entity.Status]> {
         let response = try await Mastodon.API.Trends.statuses(
             session: session,
             domain: domain,
-            query: query
+            query: query,
+            authorization: authenticationBox.userAuthorization
         ).singleOutput()
         
         let managedObjectContext = backgroundManagedObjectContext
@@ -55,12 +60,14 @@ extension APIService {
     
     public func trendLinks(
         domain: String,
-        query: Mastodon.API.Trends.LinkQuery
+        query: Mastodon.API.Trends.LinkQuery,
+        authenticationBox: MastodonAuthenticationBox
     ) async throws -> Mastodon.Response.Content<[Mastodon.Entity.Link]> {
         let response = try await Mastodon.API.Trends.links(
             session: session,
             domain: domain,
-            query: query
+            query: query,
+            authorization: authenticationBox.userAuthorization
         ).singleOutput()
         
         return response

--- a/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+Trends.swift
+++ b/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+Trends.swift
@@ -31,12 +31,13 @@ extension Mastodon.API.Trends {
     public static func hashtags(
         session: URLSession,
         domain: String,
-        query: Mastodon.API.Trends.HashtagQuery?
+        query: Mastodon.API.Trends.HashtagQuery?,
+        authorization: Mastodon.API.OAuth.Authorization
     ) -> AnyPublisher<Mastodon.Response.Content<[Mastodon.Entity.Tag]>, Error> {
         let request = Mastodon.API.get(
             url: trendsURL(domain: domain),
             query: query,
-            authorization: nil
+            authorization: authorization
         )
         return session.dataTaskPublisher(for: request)
             .tryMap { data, response in
@@ -88,12 +89,13 @@ extension Mastodon.API.Trends {
     public static func statuses(
         session: URLSession,
         domain: String,
-        query: Mastodon.API.Trends.StatusQuery?
+        query: Mastodon.API.Trends.StatusQuery?,
+        authorization: Mastodon.API.OAuth.Authorization
     ) -> AnyPublisher<Mastodon.Response.Content<[Mastodon.Entity.Status]>, Error> {
         let request = Mastodon.API.get(
             url: trendStatusesURL(domain: domain),
             query: query,
-            authorization: nil
+            authorization: authorization
         )
         return session.dataTaskPublisher(for: request)
             .tryMap { data, response in
@@ -152,12 +154,13 @@ extension Mastodon.API.Trends {
     public static func links(
         session: URLSession,
         domain: String,
-        query: Mastodon.API.Trends.LinkQuery?
+        query: Mastodon.API.Trends.LinkQuery?,
+        authorization: Mastodon.API.OAuth.Authorization
     ) -> AnyPublisher<Mastodon.Response.Content<[Mastodon.Entity.Link]>, Error> {
         let request = Mastodon.API.get(
             url: trendLinksURL(domain: domain),
             query: query,
-            authorization: nil
+            authorization: authorization
         )
         return session.dataTaskPublisher(for: request)
             .tryMap { data, response in

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
@@ -480,8 +480,6 @@ extension ComposeContentViewModel {
         )
         .receive(on: DispatchQueue.main)
         .map { contentWarning, content, hasPoll, attachments in
-            let canDiscardContentWarning = contentWarning.isEmpty
-
             let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
             let initialContent = self.initialContent.trimmingCharacters(in: .whitespacesAndNewlines)
             let canDiscardContent = trimmedContent.isEmpty || trimmedContent == initialContent

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Publisher/MastodonStatusEditPublisher.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Publisher/MastodonStatusEditPublisher.swift
@@ -5,6 +5,7 @@ import CoreData
 import CoreDataStack
 import MastodonCore
 import MastodonSDK
+import Combine
 
 public final class MastodonEditStatusPublisher: NSObject, ProgressReporting {
 
@@ -77,8 +78,6 @@ extension MastodonEditStatusPublisher: StatusPublisher {
         api: APIService,
         authContext: AuthContext
     ) async throws -> StatusPublishResult {
-        let idempotencyKey = UUID().uuidString
-
         let publishStatusTaskStartDelayWeight: Int64 = 20
         let publishStatusTaskStartDelayCount: Int64 = publishStatusTaskStartDelayWeight
 


### PR DESCRIPTION
See #1104 

To test simulate this:

1. Make `init` in L. 17 in `Mastodon+API+Error.swift` `public`
1. `throw Mastodon.API.Error(httpResponseStatus: .unauthorized, mastodonError: nil)` in `DiscoveryPostsViewModel+State.swift`, L.142, for example