### PR TITLE
Disable "Follow all"-button if there are no suggestions

### DIFF
--- a/Mastodon/Scene/SuggestionAccount/SuggestionAccountViewController.swift
+++ b/Mastodon/Scene/SuggestionAccount/SuggestionAccountViewController.swift
@@ -104,6 +104,8 @@ extension SuggestionAccountViewController: UITableViewDelegate {
             return nil
         }
 
+        footerView.followAllButton.isEnabled = viewModel.userFetchedResultsController.records.isNotEmpty
+
         footerView.delegate = self
         return footerView
     }

--- a/Mastodon/Scene/SuggestionAccount/SuggestionAccountViewModel.swift
+++ b/Mastodon/Scene/SuggestionAccount/SuggestionAccountViewModel.swift
@@ -66,7 +66,7 @@ final class SuggestionAccountViewModel: NSObject {
                 
             }
             
-            guard !userIDs.isEmpty else { return }
+            guard userIDs.isNotEmpty else { return }
             userFetchedResultsController.userIDs = userIDs
         }
         

--- a/Mastodon/Scene/SuggestionAccount/TableView-Components/SuggestionAccountTableViewFooter.swift
+++ b/Mastodon/Scene/SuggestionAccount/TableView-Components/SuggestionAccountTableViewFooter.swift
@@ -14,20 +14,20 @@ class SuggestionAccountTableViewFooter: UITableViewHeaderFooterView {
 
     weak var delegate: SuggestionAccountTableViewFooterDelegate?
 
-    let followAllButton: FollowButton
+    let followAllButton: UIButton
 
     override init(reuseIdentifier: String?) {
 
-        //TODO: Check if we can use UIButton.configuration here instead?
-        followAllButton = FollowButton()
-        followAllButton.translatesAutoresizingMaskIntoConstraints = false
-        followAllButton.setTitle(L10n.Scene.SuggestionAccount.followAll, for: .normal)
-        followAllButton.setBackgroundColor(Asset.Colors.Button.userFollow.color, for: .normal)
-        followAllButton.setTitleColor(.white, for: .normal)
-        followAllButton.contentEdgeInsets = .init(horizontal: 20, vertical: 12)
-        followAllButton.cornerRadius = 10
-        followAllButton.titleLabel?.font = UIFontMetrics(forTextStyle: .subheadline).scaledFont(for: .boldSystemFont(ofSize: 15))
+        var buttonConfiguration = UIButton.Configuration.filled()
+        buttonConfiguration.baseForegroundColor = .white
+        buttonConfiguration.baseBackgroundColor = Asset.Colors.Button.userFollow.color
+        buttonConfiguration.background.cornerRadius = 10
+        buttonConfiguration.attributedTitle = AttributedString(L10n.Scene.SuggestionAccount.followAll, attributes: AttributeContainer([.font: UIFontMetrics(forTextStyle: .subheadline).scaledFont(for: .boldSystemFont(ofSize: 15))]))
+        buttonConfiguration.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 20, bottom: 12, trailing: 20)
 
+        followAllButton = UIButton(configuration: buttonConfiguration)
+        followAllButton.isEnabled = false
+        followAllButton.translatesAutoresizingMaskIntoConstraints = false
         followAllButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         followAllButton.setContentHuggingPriority(.required, for: .horizontal)
 


### PR DESCRIPTION
If you don't follow any people, you can see some suggested accounts with a convenient "Follow all" at the bottom. This button was enabled all the time and while loading although this doesn't make a lot of sense. It looks like this now:

<img src="https://github.com/mastodon/mastodon-ios/assets/2580019/c928357b-cdcc-40dd-8abf-f84759eaea4b" width="200px">

I noticed this while testing, so I decided to quickly fix it. And while doing so I decided to replace the `FollowButton` with a `UIButton` with a `UIButton.Configuration`, this fixed one warning. We could use this as a first step to migrate the `FollowButton` to make it work with `Configuration`.
