### PR TITLE
Don't persist translations

### DIFF
--- a/Mastodon/Protocol/Provider/DataSourceProvider+NotificationTableViewCellDelegate.swift
+++ b/Mastodon/Protocol/Provider/DataSourceProvider+NotificationTableViewCellDelegate.swift
@@ -44,7 +44,7 @@ extension NotificationTableViewCellDelegate where Self: DataSourceProvider & Aut
                 action: action,
                 menuContext: .init(
                     author: author,
-                    status: nil,
+                    statusViewModel: nil,
                     button: button,
                     barButtonItem: nil
                 )

--- a/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
+++ b/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
@@ -498,13 +498,23 @@ extension StatusTableViewCellDelegate where Self: DataSourceProvider & AuthConte
                     }
                 }
             }
-                        
+
+            let statusViewModel: StatusView.ViewModel?
+
+            if let cell = cell as? StatusTableViewCell {
+                statusViewModel = await cell.statusView.viewModel
+            } else if let cell = cell as? StatusThreadRootTableViewCell {
+                statusViewModel = await cell.statusView.viewModel
+            } else {
+                statusViewModel = nil
+            }
+
             try await DataSourceFacade.responseToMenuAction(
                 dependency: self,
                 action: action,
                 menuContext: .init(
                     author: author,
-                    status: status,
+                    statusViewModel: statusViewModel,
                     button: button,
                     barButtonItem: nil
                 )

--- a/Mastodon/Scene/Profile/ProfileViewController.swift
+++ b/Mastodon/Scene/Profile/ProfileViewController.swift
@@ -894,7 +894,7 @@ extension ProfileViewController: MastodonMenuDelegate {
                 action: action,
                 menuContext: DataSourceFacade.MenuContext(
                     author: userRecord,
-                    status: nil,
+                    statusViewModel: nil,
                     button: nil,
                     barButtonItem: self.moreMenuBarButtonItem
                 )

--- a/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCell.swift
+++ b/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCell.swift
@@ -90,8 +90,7 @@ extension StatusTableViewCell {
             }
             .store(in: &_disposeBag)
 
-        statusView.viewModel
-            .$translation
+        statusView.viewModel.$translation
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] _ in
                 self?.invalidateIntrinsicContentSize()

--- a/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCell.swift
+++ b/Mastodon/Scene/Share/View/TableviewCell/StatusTableViewCell.swift
@@ -91,7 +91,7 @@ extension StatusTableViewCell {
             .store(in: &_disposeBag)
 
         statusView.viewModel
-            .$translatedFromLanguage
+            .$translation
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] _ in
                 self?.invalidateIntrinsicContentSize()

--- a/Mastodon/Scene/Share/View/TableviewCell/StatusThreadRootTableViewCell.swift
+++ b/Mastodon/Scene/Share/View/TableviewCell/StatusThreadRootTableViewCell.swift
@@ -76,8 +76,7 @@ extension StatusThreadRootTableViewCell {
         statusView.contentMetaText.textView.isAccessibilityElement = true
         statusView.contentMetaText.textView.isSelectable = true
         
-        statusView.viewModel
-            .$translation
+        statusView.viewModel.$translation
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] _ in
                 self?.invalidateIntrinsicContentSize()

--- a/Mastodon/Scene/Share/View/TableviewCell/StatusThreadRootTableViewCell.swift
+++ b/Mastodon/Scene/Share/View/TableviewCell/StatusThreadRootTableViewCell.swift
@@ -77,7 +77,7 @@ extension StatusThreadRootTableViewCell {
         statusView.contentMetaText.textView.isSelectable = true
         
         statusView.viewModel
-            .$translatedFromLanguage
+            .$translation
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] _ in
                 self?.invalidateIntrinsicContentSize()

--- a/MastodonSDK/Sources/CoreDataStack/Entity/Mastodon/Status.swift
+++ b/MastodonSDK/Sources/CoreDataStack/Entity/Mastodon/Status.swift
@@ -10,17 +10,7 @@ import Foundation
 
 public final class Status: NSManagedObject {
     public typealias ID = String
-    
-    public class TranslatedContent: NSObject {
-        public let content: String
-        public let provider: String?
-        
-        public init(content: String, provider: String?) {
-            self.content = content
-            self.provider = provider
-        }
-    }
-    
+
     // sourcery: autoGenerateProperty
     @NSManaged public private(set) var identifier: ID
     // sourcery: autoGenerateProperty
@@ -118,9 +108,6 @@ public final class Status: NSManagedObject {
     @NSManaged public private(set) var deletedAt: Date?
     // sourcery: autoUpdatableObject
     @NSManaged public private(set) var revealedAt: Date?
-    
-    // sourcery: autoUpdatableObject
-    @NSManaged public private(set) var translatedContent: TranslatedContent?
 }
 
 extension Status {
@@ -533,11 +520,6 @@ extension Status: AutoUpdatableObject {
     public func update(revealedAt: Date?) {
     	if self.revealedAt != revealedAt {
     		self.revealedAt = revealedAt
-    	}
-    }
-    public func update(translatedContent: TranslatedContent?) {
-    	if self.translatedContent != translatedContent {
-    		self.translatedContent = translatedContent
     	}
     }
     public func update(attachments: [MastodonAttachment]) {

--- a/MastodonSDK/Sources/MastodonCore/Extension/CoreDataStack/Instance.swift
+++ b/MastodonSDK/Sources/MastodonCore/Extension/CoreDataStack/Instance.swift
@@ -49,7 +49,7 @@ extension Instance {
         version?.majorServerVersion(greaterThanOrEquals: 4) ?? false // following Tags is support beginning with Mastodon v4.0.0
     }
     
-    var isTranslationEnabled: Bool {
+    public var isTranslationEnabled: Bool {
         if let configuration = configurationV2 {
             return configuration.translation?.enabled == true
         }

--- a/MastodonSDK/Sources/MastodonCore/MastodonAuthentication.swift
+++ b/MastodonSDK/Sources/MastodonCore/MastodonAuthentication.swift
@@ -84,12 +84,14 @@ public struct MastodonAuthentication: Codable, Hashable {
     }
     
     public func instance(in context: NSManagedObjectContext) -> Instance? {
-        guard
-            let instanceObjectIdURI = instanceObjectIdURI,
-        let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: instanceObjectIdURI)
-        else { return nil }
-        
-        return try? context.existingObject(with: objectID) as? Instance
+        guard let instanceObjectIdURI,
+              let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: instanceObjectIdURI)
+        else {
+            return nil
+        }
+
+        let instance = try? context.existingObject(with: objectID) as? Instance
+        return instance
     }
     
     public func user(in context: NSManagedObjectContext) -> MastodonUser? {

--- a/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Status+Translate.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Status+Translate.swift
@@ -19,12 +19,14 @@ extension APIService {
     ) async throws -> Mastodon.Response.Content<Mastodon.Entity.Translation> {
         let domain = authenticationBox.domain
         let authorization = authenticationBox.userAuthorization
+        let targetLanguage = Bundle.main.preferredLocalizations.first
 
         let response = try await Mastodon.API.Statuses.translate(
             session: session,
             domain: domain,
             statusID: statusID,
-            authorization: authorization
+            authorization: authorization,
+            targetLanguage: targetLanguage
         ).singleOutput()
         
         return response

--- a/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+Statuses+Translate.swift
+++ b/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+Statuses+Translate.swift
@@ -16,7 +16,11 @@ extension Mastodon.API.Statuses {
             .appendingPathComponent(statusID)
             .appendingPathComponent("translate")
     }
-    
+
+    public struct TranslateQuery: Codable, PostQuery {
+        public let lang: String
+    }
+
     /// Translate Status
     ///
     /// Translate a given Status.
@@ -31,11 +35,21 @@ extension Mastodon.API.Statuses {
         session: URLSession,
         domain: String,
         statusID: Mastodon.Entity.Status.ID,
-        authorization: Mastodon.API.OAuth.Authorization?
-    ) -> AnyPublisher<Mastodon.Response.Content<Mastodon.Entity.Translation>, Error>  {
+        authorization: Mastodon.API.OAuth.Authorization?,
+        targetLanguage: String?
+    ) -> AnyPublisher<Mastodon.Response.Content<Mastodon.Entity.Translation>, Error> {
+
+        let query: TranslateQuery?
+
+        if let targetLanguage {
+            query = TranslateQuery(lang: targetLanguage)
+        } else {
+            query = nil
+        }
+
         let request = Mastodon.API.post(
             url: translateEndpointURL(domain: domain, statusID: statusID),
-            query: nil,
+            query: query,
             authorization: authorization
         )
         return session.dataTaskPublisher(for: request)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/NotificationView+ViewModel.swift
@@ -221,38 +221,27 @@ extension NotificationView.ViewModel {
             )
         )
         .sink { [weak self] authorName, isMuting, isBlocking, isMyselfIsTranslatedIsFollowed in
-            guard let name = authorName?.string else {
+            guard let name = authorName?.string, let self, let context = self.context, let authContext = self.authContext else {
                 notificationView.menuButton.menu = nil
                 return
             }
-            
-            let (isMyself, isTranslated, isFollowed) = isMyselfIsTranslatedIsFollowed
-            
-            lazy var instanceConfigurationV2: Mastodon.Entity.V2.Instance.Configuration? = {
-                guard
-                    let self = self,
-                    let context = self.context,
-                    let authContext = self.authContext
-                else { return nil }
-                
-                var configuration: Mastodon.Entity.V2.Instance.Configuration? = nil
-                context.managedObjectContext.performAndWait {
-                    let authentication = authContext.mastodonAuthenticationBox.authentication
-                    configuration = authentication.instance(in: context.managedObjectContext)?.configurationV2
-                }
-                return configuration
-            }()
-            
-            let menuContext = NotificationView.AuthorMenuContext(
+
+              let (isMyself, isTranslated, isFollowed) = isMyselfIsTranslatedIsFollowed
+
+              let authentication = authContext.mastodonAuthenticationBox.authentication
+              let instance = authentication.instance(in: context.managedObjectContext)
+              let isTranslationEnabled = instance?.isTranslationEnabled ?? false
+
+              let menuContext = NotificationView.AuthorMenuContext(
                 name: name,
                 isMuting: isMuting,
                 isBlocking: isBlocking,
                 isMyself: isMyself,
                 isBookmarking: false,    // no bookmark action display for notification item
                 isFollowed: isFollowed,
-                isTranslationEnabled: instanceConfigurationV2?.translation?.enabled == true,
+                isTranslationEnabled: isTranslationEnabled,
                 isTranslated: isTranslated,
-                statusLanguage: ""
+                statusLanguage: nil
             )
             let (menu, actions) = notificationView.setupAuthorMenu(menuContext: menuContext)
             notificationView.menuButton.menu = menu

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusAuthorView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusAuthorView.swift
@@ -179,7 +179,10 @@ extension StatusAuthorView {
             postActions.append(.editStatus)
         }
 
-        if let statusLanguage = menuContext.statusLanguage, menuContext.isTranslationEnabled {
+        if menuContext.isTranslationEnabled,
+           let statusLanguage = menuContext.statusLanguage,
+           let deviceLanguage = Bundle.main.preferredLocalizations.first,
+           deviceLanguage != statusLanguage {
             if menuContext.isTranslated == false {
                 postActions.append(.translateStatus(.init(language: statusLanguage)))
             } else {

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
@@ -85,13 +85,10 @@ extension StatusView {
         configureToolbar(status: status)
         configureFilter(status: status)
         viewModel.originalStatus = status
-        [
-            status.publisher(for: \.translatedContent),
-            status.reblog?.publisher(for: \.translatedContent)
-        ].compactMap { $0 }
-            .last?
+
+        viewModel.$translation
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
+            .sink { [weak self] translation in
                 self?.configureTranslated(status: status)
             }
             .store(in: &disposeBag)
@@ -293,36 +290,26 @@ extension StatusView {
     public func revertTranslation() {
         guard let originalStatus = viewModel.originalStatus else { return }
         
-        viewModel.translatedFromLanguage = nil
-        viewModel.translatedUsingProvider = nil
-        originalStatus.reblog?.update(translatedContent: nil)
-        originalStatus.update(translatedContent: nil)
+        viewModel.translation = nil
         configure(status: originalStatus)
     }
     
     func configureTranslated(status: Status) {
-        let translatedContent: Status.TranslatedContent? = {
-            if let translatedContent = status.reblog?.translatedContent {
-                return translatedContent
-            }
-            return status.translatedContent
-
-        }()
-        
-        guard
-            let translatedContent = translatedContent
-        else {
+        guard let translation = viewModel.translation,
+              let translatedContent = translation.content,
+              let sourceLanguage = translation.sourceLanguage,
+              let provider = translation.provider else {
             viewModel.isCurrentlyTranslating = false
             return
         }
 
         // content
         do {
-            let content = MastodonContent(content: translatedContent.content, emojis: status.emojis.asDictionary)
+            let content = MastodonContent(content: translatedContent, emojis: status.emojis.asDictionary)
             let metaContent = try MastodonMetaContent.convert(document: content)
             viewModel.content = metaContent
-            viewModel.translatedFromLanguage = status.reblog?.language ?? status.language
-            viewModel.translatedUsingProvider = status.reblog?.translatedContent?.provider ?? status.translatedContent?.provider
+            viewModel.translatedFromLanguage = sourceLanguage
+            viewModel.translatedUsingProvider = provider
             viewModel.isCurrentlyTranslating = false
         } catch {
             assertionFailure(error.localizedDescription)
@@ -351,7 +338,7 @@ extension StatusView {
     }
 
     private func configureContent(status: Status) {
-        guard status.translatedContent == nil else {
+        guard viewModel.translation == nil else {
             return configureTranslated(status: status)
         }
         

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
@@ -296,9 +296,7 @@ extension StatusView {
     
     func configureTranslated(status: Status) {
         guard let translation = viewModel.translation,
-              let translatedContent = translation.content,
-              let sourceLanguage = translation.sourceLanguage,
-              let provider = translation.provider else {
+              let translatedContent = translation.content else {
             viewModel.isCurrentlyTranslating = false
             return
         }
@@ -308,8 +306,6 @@ extension StatusView {
             let content = MastodonContent(content: translatedContent, emojis: status.emojis.asDictionary)
             let metaContent = try MastodonMetaContent.convert(document: content)
             viewModel.content = metaContent
-            viewModel.translatedFromLanguage = sourceLanguage
-            viewModel.translatedUsingProvider = provider
             viewModel.isCurrentlyTranslating = false
         } catch {
             assertionFailure(error.localizedDescription)
@@ -329,7 +325,6 @@ extension StatusView {
             let content = MastodonContent(content: statusEdit.content, emojis: statusEdit.emojis.asDictionary)
             let metaContent = try MastodonMetaContent.convert(document: content)
             viewModel.content = metaContent
-            viewModel.translatedFromLanguage = nil
             viewModel.isCurrentlyTranslating = false
         } catch {
             assertionFailure(error.localizedDescription)
@@ -364,7 +359,6 @@ extension StatusView {
             let content = MastodonContent(content: status.content, emojis: status.emojis.asDictionary)
             let metaContent = try MastodonMetaContent.convert(document: content)
             viewModel.content = metaContent
-            viewModel.translatedFromLanguage = nil
             viewModel.isCurrentlyTranslating = false
         } catch {
             assertionFailure(error.localizedDescription)

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -48,6 +48,7 @@ extension StatusView {
         @Published public var isCurrentlyTranslating = false
         @Published public var translatedFromLanguage: String?
         @Published public var translatedUsingProvider: String?
+        @Published public var translation: Mastodon.Entity.Translation? = nil
 
         @Published public var timestamp: Date?
         public var timestampFormatter: ((_ date: Date, _ isEdited: Bool) -> String)?
@@ -151,7 +152,8 @@ extension StatusView {
             translatedFromLanguage = nil
             translatedUsingProvider = nil
             isCurrentlyTranslating = false
-            
+            translation = nil
+
             activeFilters = []
             filterContext = nil
         }
@@ -657,7 +659,7 @@ extension StatusView.ViewModel {
             $isFollowed
         )
         let publishersThree = Publishers.CombineLatest(
-            $translatedFromLanguage,
+            $translation,
             $language
         )
         

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -46,8 +46,6 @@ extension StatusView {
         
         // Translation
         @Published public var isCurrentlyTranslating = false
-        @Published public var translatedFromLanguage: String?
-        @Published public var translatedUsingProvider: String?
         @Published public var translation: Mastodon.Entity.Translation? = nil
 
         @Published public var timestamp: Date?
@@ -149,8 +147,6 @@ extension StatusView {
             isContentSensitive = false
             isMediaSensitive = false
             isSensitiveToggled = false
-            translatedFromLanguage = nil
-            translatedUsingProvider = nil
             isCurrentlyTranslating = false
             translation = nil
 
@@ -879,15 +875,20 @@ extension StatusView.ViewModel {
             .assign(to: \.toolbarActions, on: statusView)
             .store(in: &disposeBag)
 
-        let translatedFromLabel = Publishers.CombineLatest($translatedFromLanguage, $translatedUsingProvider)
-            .map { (language, provider) -> String? in
-                if let language {
-                    return L10n.Common.Controls.Status.Translation.translatedFrom(
-                        Locale.current.localizedString(forIdentifier: language) ?? L10n.Common.Controls.Status.Translation.unknownLanguage,
-                        provider ?? L10n.Common.Controls.Status.Translation.unknownProvider
-                    )
+        let translatedFromLabel = $translation
+            .map { translation -> String? in
+                guard let translation else { return nil }
+
+                let provider = translation.provider ?? L10n.Common.Controls.Status.Translation.unknownProvider
+                let sourceLanguage: String
+
+                if let language = translation.sourceLanguage {
+                    sourceLanguage = Locale.current.localizedString(forIdentifier: language) ?? L10n.Common.Controls.Status.Translation.unknownLanguage
+                } else {
+                    sourceLanguage = L10n.Common.Controls.Status.Translation.unknownLanguage
                 }
-                return nil
+
+                return L10n.Common.Controls.Status.Translation.translatedFrom(sourceLanguage, provider)
             }
 
         translatedFromLabel

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -668,7 +668,7 @@ extension StatusView {
     }
 
     private var hideTranslationAction: UIAccessibilityCustomAction? {
-        guard viewModel.translatedFromLanguage != nil else { return nil }
+        guard viewModel.translation?.sourceLanguage != nil else { return nil }
         return UIAccessibilityCustomAction(name: L10n.Common.Controls.Status.Translation.showOriginal) { [weak self] _ in
             self?.revertTranslation()
             return true


### PR DESCRIPTION
aka. Don't use CoreData for translations.

We don't need to persist translations. They're temporary nevertheless.

-------

This is basically my starting point for the CoreData-removal. Instead of ripping out something big, I decided to replace one property. I didn't feel confident to remove this property on a branch that doesn't build, that's why I chose `develop`. Being able to build and run to see if I may have broken the functionality helped me a lot.