### PR TITLE
Add option to focus the search bar when double tapping the search tab

### DIFF
--- a/Mastodon/Scene/Root/ContentSplitViewController.swift
+++ b/Mastodon/Scene/Root/ContentSplitViewController.swift
@@ -12,6 +12,7 @@ import MastodonCore
 
 protocol ContentSplitViewControllerDelegate: AnyObject {
     func contentSplitViewController(_ contentSplitViewController: ContentSplitViewController, sidebarViewController: SidebarViewController, didSelectTab tab: MainTabBarController.Tab)
+    func contentSplitViewController(_ contentSplitViewController: ContentSplitViewController, sidebarViewController: SidebarViewController, didDoubleTapTab tab: MainTabBarController.Tab)
 }
 
 final class ContentSplitViewController: UIViewController, NeedsDependency {
@@ -121,16 +122,7 @@ extension ContentSplitViewController: SidebarViewControllerDelegate {
     }
     
     func sidebarViewController(_ sidebarViewController: SidebarViewController, didDoubleTapItem item: SidebarViewModel.Item, sourceView: UIView) {
-        guard case let .tab(tab) = item, tab == .me else { return }
-        guard let authContext = authContext else { return }
-        assert(Thread.isMainThread)
-
-        guard let nextAccount = context.nextAccount(in: authContext) else { return }
-
-        Task { @MainActor in
-            let isActive = try await context.authenticationService.activeMastodonUser(domain: nextAccount.domain, userID: nextAccount.userID)
-            guard isActive else { return }
-            self.coordinator.setup()
-        }
+        guard case let .tab(tab) = item else { return }
+        delegate?.contentSplitViewController(self, sidebarViewController: sidebarViewController, didDoubleTapTab: tab)
     }
 }

--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -292,12 +292,11 @@ extension MainTabBarController {
         tabBarLongPressGestureRecognizer.delegate = self
         tabBar.addGestureRecognizer(tabBarLongPressGestureRecognizer)
 
-        // todo: reconsider the "double tap to change account" feature -> https://github.com/mastodon/mastodon-ios/issues/628
-//        let tabBarDoubleTapGestureRecognizer = UITapGestureRecognizer()
-//        tabBarDoubleTapGestureRecognizer.numberOfTapsRequired = 2
-//        tabBarDoubleTapGestureRecognizer.addTarget(self, action: #selector(MainTabBarController.tabBarDoubleTapGestureRecognizerHandler(_:)))
-//        tabBarDoubleTapGestureRecognizer.delaysTouchesEnded = false
-//        tabBar.addGestureRecognizer(tabBarDoubleTapGestureRecognizer)
+        let tabBarDoubleTapGestureRecognizer = UITapGestureRecognizer()
+        tabBarDoubleTapGestureRecognizer.numberOfTapsRequired = 2
+        tabBarDoubleTapGestureRecognizer.addTarget(self, action: #selector(MainTabBarController.tabBarDoubleTapGestureRecognizerHandler(_:)))
+        tabBarDoubleTapGestureRecognizer.delaysTouchesEnded = false
+        tabBar.addGestureRecognizer(tabBarDoubleTapGestureRecognizer)
 
         self.isReadyForWizardAvatarButton = authContext != nil
         
@@ -359,17 +358,22 @@ extension MainTabBarController {
         guard let tab = touchedTab(by: sender) else { return }
 
         switch tab {
-        case .me:
-            guard let authContext = authContext else { return }
+        // todo: reconsider the "double tap to change account" feature -> https://github.com/mastodon/mastodon-ios/issues/628
+//        case .me:
+//            guard let authContext = authContext else { return }
+//            assert(Thread.isMainThread)
+//
+//            guard let nextAccount = context.nextAccount(in: authContext) else { return }
+//            
+//            Task { @MainActor in
+//                let isActive = try await context.authenticationService.activeMastodonUser(domain: nextAccount.domain, userID: nextAccount.userID)
+//                guard isActive else { return }
+//                self.coordinator.setup()
+//            }
+        case .search:
             assert(Thread.isMainThread)
-
-            guard let nextAccount = context.nextAccount(in: authContext) else { return }
-            
-            Task { @MainActor in
-                let isActive = try await context.authenticationService.activeMastodonUser(domain: nextAccount.domain, userID: nextAccount.userID)
-                guard isActive else { return }
-                self.coordinator.setup()
-            }
+            // double tapping search tab opens the search bar without additional taps
+            searchViewController?.searchBarTapPublisher.send("")
         default:
             break
         }

--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -358,22 +358,10 @@ extension MainTabBarController {
         guard let tab = touchedTab(by: sender) else { return }
 
         switch tab {
-        // todo: reconsider the "double tap to change account" feature -> https://github.com/mastodon/mastodon-ios/issues/628
-//        case .me:
-//            guard let authContext = authContext else { return }
-//            assert(Thread.isMainThread)
-//
-//            guard let nextAccount = context.nextAccount(in: authContext) else { return }
-//            
-//            Task { @MainActor in
-//                let isActive = try await context.authenticationService.activeMastodonUser(domain: nextAccount.domain, userID: nextAccount.userID)
-//                guard isActive else { return }
-//                self.coordinator.setup()
-//            }
         case .search:
             assert(Thread.isMainThread)
             // double tapping search tab opens the search bar without additional taps
-            searchViewController?.searchBarTapPublisher.send("")
+            searchViewController?.searchBar.becomeFirstResponder()
         default:
             break
         }

--- a/Mastodon/Scene/Root/RootSplitViewController.swift
+++ b/Mastodon/Scene/Root/RootSplitViewController.swift
@@ -157,6 +157,24 @@ extension RootSplitViewController: ContentSplitViewControllerDelegate {
             
         }
     }
+    
+    func contentSplitViewController(_ contentSplitViewController: ContentSplitViewController, sidebarViewController: SidebarViewController, didDoubleTapTab tab: MainTabBarController.Tab) {
+        guard let _ = MainTabBarController.Tab.allCases.firstIndex(of: tab) else {
+            assertionFailure()
+            return
+        }
+        
+        switch tab {
+        case .search:
+            // allow double tap to focus search bar only when is not primary display (iPad potrait)
+            guard !isPrimaryDisplay else {
+                return
+            }
+            contentSplitViewController.mainTabBarController.searchViewController?.searchBar.becomeFirstResponder()
+        default:
+            break
+        }
+    }
 }
 
 // MARK: - UISplitViewControllerDelegate

--- a/Mastodon/Scene/Root/Sidebar/SidebarViewController.swift
+++ b/Mastodon/Scene/Root/Sidebar/SidebarViewController.swift
@@ -128,13 +128,12 @@ extension SidebarViewController {
         sidebarLongPressGestureRecognizer.addTarget(self, action: #selector(SidebarViewController.sidebarLongPressGestureRecognizerHandler(_:)))
         collectionView.addGestureRecognizer(sidebarLongPressGestureRecognizer)
         
-        // todo: reconsider the "double tap to change account" feature -> https://github.com/mastodon/mastodon-ios/issues/628
-//        let sidebarDoubleTapGestureRecognizer = UITapGestureRecognizer()
-//        sidebarDoubleTapGestureRecognizer.numberOfTapsRequired = 2
-//        sidebarDoubleTapGestureRecognizer.addTarget(self, action: #selector(SidebarViewController.sidebarDoubleTapGestureRecognizerHandler(_:)))
-//        sidebarDoubleTapGestureRecognizer.delaysTouchesEnded = false
-//        sidebarDoubleTapGestureRecognizer.cancelsTouchesInView = true
-//        collectionView.addGestureRecognizer(sidebarDoubleTapGestureRecognizer)
+        let sidebarDoubleTapGestureRecognizer = UITapGestureRecognizer()
+        sidebarDoubleTapGestureRecognizer.numberOfTapsRequired = 2
+        sidebarDoubleTapGestureRecognizer.addTarget(self, action: #selector(SidebarViewController.sidebarDoubleTapGestureRecognizerHandler(_:)))
+        sidebarDoubleTapGestureRecognizer.delaysTouchesEnded = false
+        sidebarDoubleTapGestureRecognizer.cancelsTouchesInView = true
+        collectionView.addGestureRecognizer(sidebarDoubleTapGestureRecognizer)
 
     }
     

--- a/Mastodon/Scene/Search/SearchDetail/SearchDetailViewController.swift
+++ b/Mastodon/Scene/Search/SearchDetail/SearchDetailViewController.swift
@@ -233,6 +233,7 @@ extension SearchDetailViewController {
             navigationItem.setHidesBackButton(true, animated: false)
             navigationItem.titleView = nil
             navigationItem.searchController = searchController
+            navigationItem.preferredSearchBarPlacement = .stacked
             searchController.searchBar.sizeToFit()
         }
 


### PR DESCRIPTION
## Changes

- Enables double tap for tab bar(s)
- Hides double tap for me tab (as per previous comment)
- Adds search tab double tab option to focus the search bar

## Issue

closes #748 

## Screenshots

In this below GIF, double tapping the search tab opens the search bar. Single tap only opens the search screen.

![Simulator Screen Recording - iPhone 15 - 2023-11-17 at 14 48 20](https://github.com/mastodon/mastodon-ios/assets/12063704/3f3ade3b-7264-4d75-989b-26971430e0d9)


## Notes
I'm new to the combine world. Please let me know if there is anything else Im missing out or needs a different approach for this one. 

