### PR TITLE
Restore Credentials from Keychain

### DIFF
--- a/ShareActionExtension/Scene/ShareViewController.swift
+++ b/ShareActionExtension/Scene/ShareViewController.swift
@@ -160,9 +160,11 @@ extension ShareViewController {
 
 extension ShareViewController {
     private func setupAuthContext() throws -> AuthContext? {
-        let _authentication = AuthenticationServiceProvider.shared.authenticationSortedByActivation().first
-        let _authContext = _authentication.flatMap { AuthContext(authentication: $0) }
-        return _authContext
+        AuthenticationServiceProvider.shared.restore()
+
+        let authentication = AuthenticationServiceProvider.shared.authenticationSortedByActivation().first
+        let authContext = authentication.flatMap { AuthContext(authentication: $0) }
+        return authContext
     }
     
     private func setupHintLabel() {


### PR DESCRIPTION
Seems to me that we overlooked this when migrating the credentials to keychain. At least we didn't restore credentials when we need them. I'm not sure how we can prevent this from happening in the future other than being and testing more thorough?

Closes #1168.