### PR TITLE
Show alert on iPad (#1172)

### DIFF
--- a/Mastodon/Coordinator/SceneCoordinator.swift
+++ b/Mastodon/Coordinator/SceneCoordinator.swift
@@ -601,10 +601,19 @@ extension SceneCoordinator: MastodonLoginViewControllerDelegate {
 //MARK: - SettingsCoordinatorDelegate
 extension SceneCoordinator: SettingsCoordinatorDelegate {
     func logout(_ settingsCoordinator: SettingsCoordinator) {
+
+        let preferredStyle: UIAlertController.Style
+
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            preferredStyle = .actionSheet
+        } else {
+            preferredStyle = .alert
+        }
+
         let alertController = UIAlertController(
             title: L10n.Common.Alerts.SignOut.title,
             message: L10n.Common.Alerts.SignOut.message,
-            preferredStyle: .actionSheet
+            preferredStyle: preferredStyle
         )
 
         let cancelAction = UIAlertAction(title: L10n.Common.Controls.Actions.cancel, style: .cancel)


### PR DESCRIPTION
To prevent accidential logouts, we show a confirmation-dialog. This used to be an `UIAlertController` with a `preferredStyle` set to `.actionSheet`. Unfortunately, this crashes on iPad, as we don't provide a `sourceView` or `sourceRect`:

> 'Your application has presented a UIAlertController (<UIAlertController: 0x12184da00>) of style UIAlertControllerStyleActionSheet from UINavigationController (<UINavigationController: 0x13a008200>). The modalPresentationStyle of a UIAlertController with this style is UIModalPresentationPopover. **You must provide location information for this popover through the alert controller's popoverPresentationController. You must provide either a sourceView and sourceRect or a barButtonItem.**  If this information is not known when you present the alert controller, you may provide it in the UIPopoverPresentationControllerDelegate method -prepareForPopoverPresentation.'

This resulted in a crash. So, to fix this, we show the `.actionSheet` on iPhone now and the `.alert` otherwise.

Fixes #1172