### PR TITLE
Delete authentication credentials from Keychain upon logout

### DIFF
--- a/MastodonSDK/Sources/MastodonCore/AuthenticationServiceProvider.swift
+++ b/MastodonSDK/Sources/MastodonCore/AuthenticationServiceProvider.swift
@@ -30,7 +30,8 @@ public class AuthenticationServiceProvider: ObservableObject {
         }
     }
     
-    func delete(authentication: MastodonAuthentication) {
+    func delete(authentication: MastodonAuthentication) throws {
+        try Self.keychain.remove(authentication.persistenceIdentifier)
         authentications.removeAll(where: { $0 == authentication })
     }
     

--- a/MastodonSDK/Sources/MastodonCore/Service/AuthenticationService.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/AuthenticationService.swift
@@ -150,8 +150,12 @@ extension AuthenticationService {
             for feed in feeds {
                 managedObjectContext.delete(feed)
             }
-            
-            AuthenticationServiceProvider.shared.delete(authentication: authenticationBox.authentication)
+        }
+        
+        do {
+            try AuthenticationServiceProvider.shared.delete(authentication: authenticationBox.authentication)
+        } catch {
+            assertionFailure("Failed to delete Authentication: \(error)")
         }
         
         // cancel push notification subscription


### PR DESCRIPTION
Fixes #1181

# How to reproduce

* In the App
  * Account Settings
    * Logout
  * Kill App
  * Restart App
  * Account should not be logged in anymore 