### PR TITLE
Fix endless fail-loop in search

### DIFF
--- a/Mastodon/Scene/Search/SearchDetail/SearchResult/SearchResultViewModel+State.swift
+++ b/Mastodon/Scene/Search/SearchDetail/SearchResult/SearchResultViewModel+State.swift
@@ -125,10 +125,15 @@ extension SearchResultViewModel.State {
 
                     let accounts = searchResults.accounts
 
-                    let relationships = try await viewModel.context.apiService.relationship(
-                        forAccounts: accounts,
-                        authenticationBox: viewModel.authContext.mastodonAuthenticationBox
-                    ).value
+                    let relationships: [Mastodon.Entity.Relationship]
+                    if accounts.isNotEmpty {
+                        relationships = try await viewModel.context.apiService.relationship(
+                            forAccounts: accounts,
+                            authenticationBox: viewModel.authContext.mastodonAuthenticationBox
+                        ).value
+                    } else {
+                        relationships = []
+                    }
 
                     let statusIDs = searchResults.statuses.map { $0.id }
 


### PR DESCRIPTION
Connected to #1187

If no accounts could be found for your search query, `ListBatchViewModel` and the search for relationships lead to an infinite loop always resulting in a `Fail`-state, but retrying every second resulting in a `Fail`-state, but retrying every second resulting in a `Fail`-state, but retrying every second resulting in a `Fail`-state, but retrying every second resulting in a `Fail`-state, but retrying every second (you get the picture, right?)