### PR TITLE
Show more metadata for posts

### DIFF
--- a/Mastodon.xcodeproj/project.pbxproj
+++ b/Mastodon.xcodeproj/project.pbxproj
@@ -122,7 +122,7 @@
 		855149C8295F1C5F00943D96 /* UIInterfaceOrientationMask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 855149C7295F1C5F00943D96 /* UIInterfaceOrientationMask.swift */; };
 		855149CA29606D6400943D96 /* PortraitAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 855149C929606D6400943D96 /* PortraitAlertController.swift */; };
 		85904C02293BC0EB0011C817 /* ImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85904C01293BC0EB0011C817 /* ImageProvider.swift */; };
-		85904C04293BC1940011C817 /* URLActivityItemWithMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85904C03293BC1940011C817 /* URLActivityItemWithMetadata.swift */; };
+		85904C04293BC1940011C817 /* URLActivityItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85904C03293BC1940011C817 /* URLActivityItem.swift */; };
 		85BC11B32932414900E191CD /* AltTextViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85BC11B22932414900E191CD /* AltTextViewController.swift */; };
 		9E44C7202967AD17004B2A72 /* MastodonSDKDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 9E44C71F2967AD17004B2A72 /* MastodonSDKDynamic */; };
 		9E44C7222967AD17004B2A72 /* MastodonSDKDynamic in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 9E44C71F2967AD17004B2A72 /* MastodonSDKDynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -766,7 +766,7 @@
 		855149C7295F1C5F00943D96 /* UIInterfaceOrientationMask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIInterfaceOrientationMask.swift; sourceTree = "<group>"; };
 		855149C929606D6400943D96 /* PortraitAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortraitAlertController.swift; sourceTree = "<group>"; };
 		85904C01293BC0EB0011C817 /* ImageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageProvider.swift; sourceTree = "<group>"; };
-		85904C03293BC1940011C817 /* URLActivityItemWithMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLActivityItemWithMetadata.swift; sourceTree = "<group>"; };
+		85904C03293BC1940011C817 /* URLActivityItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLActivityItem.swift; sourceTree = "<group>"; };
 		85BC11B22932414900E191CD /* AltTextViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AltTextViewController.swift; sourceTree = "<group>"; };
 		8850E70A1D5FF51432E43653 /* Pods-Mastodon-MastodonUITests.asdk - release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mastodon-MastodonUITests.asdk - release.xcconfig"; path = "Target Support Files/Pods-Mastodon-MastodonUITests/Pods-Mastodon-MastodonUITests.asdk - release.xcconfig"; sourceTree = "<group>"; };
 		89FE8B85A00419CEF4678056 /* Pods_MastodonTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MastodonTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2921,7 +2921,7 @@
 			children = (
 				DBF3B7402733EB9400E21627 /* MastodonLocalCode.swift */,
 				85904C01293BC0EB0011C817 /* ImageProvider.swift */,
-				85904C03293BC1940011C817 /* URLActivityItemWithMetadata.swift */,
+				85904C03293BC1940011C817 /* URLActivityItem.swift */,
 				855149C929606D6400943D96 /* PortraitAlertController.swift */,
 			);
 			path = Helper;
@@ -3650,7 +3650,7 @@
 				62FD27D52893708A00B205C5 /* BookmarkViewModel+Diffable.swift in Sources */,
 				DB72602725E36A6F00235243 /* MastodonServerRulesViewModel.swift in Sources */,
 				2D364F7225E66D7500204FDC /* MastodonResendEmailViewController.swift in Sources */,
-				85904C04293BC1940011C817 /* URLActivityItemWithMetadata.swift in Sources */,
+				85904C04293BC1940011C817 /* URLActivityItem.swift in Sources */,
 				DB68A06325E905E000CFDF14 /* UIApplication.swift in Sources */,
 				DB02CDAB26256A9500D0A2AF /* ThreadReplyLoaderTableViewCell.swift in Sources */,
 				DBEFCD80282A2AA900C0ABEA /* ReportServerRulesViewModel.swift in Sources */,

--- a/Mastodon/Helper/URLActivityItem.swift
+++ b/Mastodon/Helper/URLActivityItem.swift
@@ -1,5 +1,5 @@
 //
-//  URLActivityItemWithMetadata.swift
+//  URLActivityItem.swift
 //  Mastodon
 //
 //  Created by Jed Fox on 2022-12-03.
@@ -8,17 +8,12 @@
 import UIKit
 import LinkPresentation
 
-class URLActivityItemWithMetadata: NSObject, UIActivityItemSource {
-    init(url: URL, configureMetadata: (LPLinkMetadata) -> Void) {
-        self.url = url
-        self.metadata = LPLinkMetadata()
-        metadata.url = url
-        metadata.originalURL = url
-        configureMetadata(metadata)
-    }
-
+class URLActivityItem: NSObject, UIActivityItemSource {
     let url: URL
-    let metadata: LPLinkMetadata
+
+    init(url: URL) {
+        self.url = url
+    }
 
     func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
         return url

--- a/Mastodon/Helper/URLActivityItemWithMetadata.swift
+++ b/Mastodon/Helper/URLActivityItemWithMetadata.swift
@@ -13,6 +13,7 @@ class URLActivityItemWithMetadata: NSObject, UIActivityItemSource {
         self.url = url
         self.metadata = LPLinkMetadata()
         metadata.url = url
+        metadata.originalURL = url
         configureMetadata(metadata)
     }
 
@@ -20,14 +21,10 @@ class URLActivityItemWithMetadata: NSObject, UIActivityItemSource {
     let metadata: LPLinkMetadata
 
     func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
-        url
+        return url
     }
 
     func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
-        url
-    }
-
-    func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
-        metadata
+        return url
     }
 }

--- a/Mastodon/Protocol/Provider/DataSourceFacade+Status.swift
+++ b/Mastodon/Protocol/Provider/DataSourceFacade+Status.swift
@@ -71,6 +71,10 @@ extension DataSourceFacade {
                         url: status.entity.account.avatarImageURLWithFallback(domain: status.entity.account.domain ?? ""),
                         filter: ScaledToSizeFilter(size: CGSize.authorAvatarButtonSize)
                     ).itemProvider
+
+                    if let firstAssetURL = status.attachments.first?.previewURL, let url = URL(string: firstAssetURL) {
+                        metadata.imageProvider = ImageProvider(url: url).itemProvider
+                    }
                 }
             ] as [Any]
         }()

--- a/Mastodon/Protocol/Provider/DataSourceFacade+Status.swift
+++ b/Mastodon/Protocol/Provider/DataSourceFacade+Status.swift
@@ -62,23 +62,12 @@ extension DataSourceFacade {
         status: MastodonStatus
     ) async throws -> UIActivityViewController {
         var activityItems: [Any] = {
-            guard let url = URL(string: status.entity.url ?? status.entity.uri)
-            else { return [] }
+            guard let url = URL(string: status.entity.url ?? status.entity.uri) else { return [] }
             return [
-                URLActivityItemWithMetadata(url: url) { metadata in
-                    metadata.title = "\(status.entity.account.displayName) (@\(status.entity.account.acctWithDomain))"
-                    metadata.iconProvider = ImageProvider(
-                        url: status.entity.account.avatarImageURLWithFallback(domain: status.entity.account.domain ?? ""),
-                        filter: ScaledToSizeFilter(size: CGSize.authorAvatarButtonSize)
-                    ).itemProvider
-
-                    if let firstAssetURL = status.attachments.first?.previewURL, let url = URL(string: firstAssetURL) {
-                        metadata.imageProvider = ImageProvider(url: url).itemProvider
-                    }
-                }
-            ] as [Any]
+                URLActivityItem(url: url)
+            ]
         }()
-        
+
         var applicationActivities: [UIActivity] = [
             SafariActivity(sceneCoordinator: dependency.coordinator),     // open URL
         ]

--- a/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
+++ b/Mastodon/Protocol/Provider/DataSourceProvider+StatusTableViewCellDelegate.swift
@@ -202,13 +202,7 @@ extension StatusTableViewCellDelegate where Self: DataSourceProvider & AuthConte
                 DispatchQueue.main.async {
                     let activityViewController = UIActivityViewController(
                         activityItems: [
-                            URLActivityItemWithMetadata(url: url) { metadata in
-                                metadata.title = card.title
-
-                                if let image = card.image, let url = URL(string: image) {
-                                    metadata.iconProvider = ImageProvider(url: url, filter: nil).itemProvider
-                                }
-                            }
+                            URLActivityItem(url: url)
                         ],
                         applicationActivities: []
                     )


### PR DESCRIPTION
Fixes #1199.

Sets sharing back to Default-URL-Sharing without custom meta data (aka no account icon) so that sharing a status looks like copy'n'pasting that very status in iMessage directly:

![1200](https://github.com/mastodon/mastodon-ios/assets/2580019/a38ee327-6dad-437c-97c0-4a1ba5dc87be)
