### PR TITLE
#1049 - fix max character limit and other server configs are not respected

### DIFF
--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Instance.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Instance.swift
@@ -114,7 +114,7 @@ extension Mastodon.Entity.Instance {
 }
 
 extension Mastodon.Entity.Instance {
-    public struct Configuration: Codable, StatusesMediaAttachmentsPollsContaining {
+    public struct Configuration: Codable, InstanceConfigLimitingPropertyContaining {
         public let statuses: Statuses?
         public let mediaAttachments: MediaAttachments?
         public let polls: Polls?

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Instance.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Instance.swift
@@ -114,7 +114,7 @@ extension Mastodon.Entity.Instance {
 }
 
 extension Mastodon.Entity.Instance {
-    public struct Configuration: Codable {
+    public struct Configuration: Codable, StatusesMediaAttachmentsPollsContaining {
         public let statuses: Statuses?
         public let mediaAttachments: MediaAttachments?
         public let polls: Polls?

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+InstanceV2.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+InstanceV2.swift
@@ -71,7 +71,7 @@ extension Mastodon.Entity.V2 {
 }
 
 extension Mastodon.Entity.V2.Instance {
-    public struct Configuration: Codable {
+    public struct Configuration: Codable, StatusesMediaAttachmentsPollsContaining {
         public let statuses: Mastodon.Entity.Instance.Configuration.Statuses?
         public let mediaAttachments: Mastodon.Entity.Instance.Configuration.MediaAttachments?
         public let polls: Mastodon.Entity.Instance.Configuration.Polls?

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+InstanceV2.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+InstanceV2.swift
@@ -71,7 +71,7 @@ extension Mastodon.Entity.V2 {
 }
 
 extension Mastodon.Entity.V2.Instance {
-    public struct Configuration: Codable, StatusesMediaAttachmentsPollsContaining {
+    public struct Configuration: Codable, InstanceConfigLimitingPropertyContaining {
         public let statuses: Mastodon.Entity.Instance.Configuration.Statuses?
         public let mediaAttachments: Mastodon.Entity.Instance.Configuration.MediaAttachments?
         public let polls: Mastodon.Entity.Instance.Configuration.Polls?

--- a/MastodonSDK/Sources/MastodonSDK/InstanceConfigLimitingPropertyContaining.swift
+++ b/MastodonSDK/Sources/MastodonSDK/InstanceConfigLimitingPropertyContaining.swift
@@ -1,6 +1,6 @@
 // Copyright © 2024 Mastodon gGmbH. All rights reserved.
 
-public protocol StatusesMediaAttachmentsPollsContaining {
+public protocol InstanceConfigLimitingPropertyContaining {
     var statuses: Mastodon.Entity.Instance.Configuration.Statuses? { get }
     var mediaAttachments: Mastodon.Entity.Instance.Configuration.MediaAttachments? { get }
     var polls: Mastodon.Entity.Instance.Configuration.Polls? { get }

--- a/MastodonSDK/Sources/MastodonSDK/StatusesMediaAttachmentsPollsContaining.swift
+++ b/MastodonSDK/Sources/MastodonSDK/StatusesMediaAttachmentsPollsContaining.swift
@@ -1,0 +1,7 @@
+// Copyright © 2024 Mastodon gGmbH. All rights reserved.
+
+public protocol StatusesMediaAttachmentsPollsContaining {
+    var statuses: Mastodon.Entity.Instance.Configuration.Statuses? { get }
+    var mediaAttachments: Mastodon.Entity.Instance.Configuration.MediaAttachments? { get }
+    var polls: Mastodon.Entity.Instance.Configuration.Polls? { get }
+}


### PR DESCRIPTION
# Rationale

This fixes server limits which are imposed, e.g. max characters (amongst others) to be respected by the app again.

Apparently, when introducing the v2 instance config, this part of the App has not been ported, thus not respecting the server config anymore as we're not keeping the v1 config if we can query a v2 instance config from the server.