### PR TITLE
fix: Load missing posts

### DIFF
--- a/MastodonSDK/Sources/MastodonSDK/MastodonFeed.swift
+++ b/MastodonSDK/Sources/MastodonSDK/MastodonFeed.swift
@@ -20,7 +20,7 @@ public final class MastodonFeed {
     
     public let kind: Feed.Kind
     
-    init(hasMore: Bool, isLoadingMore: Bool, status: MastodonStatus?, notification: Mastodon.Entity.Notification?, kind: Feed.Kind) {
+    public init(hasMore: Bool, isLoadingMore: Bool, status: MastodonStatus?, notification: Mastodon.Entity.Notification?, kind: Feed.Kind) {
         self.id = notification?.id ?? status?.id ?? UUID().uuidString
         self.hasMore = hasMore
         self.isLoadingMore = isLoadingMore


### PR DESCRIPTION
# Rationale

Fixes a bug where the "Load missing posts" button is not showing up anymore / no way to load a gap in the home timeline.