### PR TITLE
Implement async context menu for statuses

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+Configuration.swift
@@ -219,6 +219,8 @@ extension StatusView {
                 }
             }()
             
+            viewModel.authorId = author.id
+            
             // author username
             viewModel.authorUsername = author.acct
             
@@ -238,20 +240,6 @@ extension StatusView {
                 viewModel.isBlocking = false
                 viewModel.isFollowed = false
                 return
-            }
-            
-            if let relationship = try? await Mastodon.API.Account.relationships(
-                session: .shared,
-                domain: auth.domain,
-                query: .init(ids: [author.id]),
-                authorization: auth.userAuthorization
-            ).singleOutput().value {
-                guard let rel = relationship.first else { return }
-                DispatchQueue.main.async { [self] in
-                    viewModel.isMuting = rel.muting ?? false
-                    viewModel.isBlocking = rel.blocking
-                    viewModel.isFollowed = rel.followedBy
-                }
             }
         }
     }

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -717,9 +717,10 @@ extension StatusView.ViewModel {
                                     
                                     menuElement(menu.children)
                                 }
+                            } else {
+                                menuElement(MastodonMenu.setupMenu(actions: [[.shareStatus]], delegate: statusView).children)
                             }
                         }
-                        
                     })
                 ])
                                 

--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView+ViewModel.swift
@@ -46,6 +46,7 @@ extension StatusView {
         @Published public var authorAvatarImage: UIImage?
         @Published public var authorAvatarImageURL: URL?
         @Published public var authorName: MetaContent?
+        @Published public var authorId: String?
         @Published public var authorUsername: String?
         
         @Published public var locked = false
@@ -655,16 +656,12 @@ extension StatusView.ViewModel {
     
     private func bindMenu(statusView: StatusView) {
         let authorView = statusView.authorView
-        let publisherOne = Publishers.CombineLatest(
+        let publisherOne = Publishers.CombineLatest3(
             $authorName,
+            $authorId,
             $isMyself
         )
-        let publishersTwo = Publishers.CombineLatest4(
-            $isMuting,
-            $isBlocking,
-            $isBookmark,
-            $isFollowed
-        )
+
         let publishersThree = Publishers.CombineLatest(
             $translation,
             $language
@@ -672,15 +669,14 @@ extension StatusView.ViewModel {
 
         Publishers.CombineLatest3(
             publisherOne.eraseToAnyPublisher(),
-            publishersTwo.eraseToAnyPublisher(),
+            $isBookmark,
             publishersThree.eraseToAnyPublisher()
         ).eraseToAnyPublisher()
-            .sink { tupleOne, tupleTwo, tupleThree in
-                let (authorName, isMyself) = tupleOne
-                let (isMuting, isBlocking, isBookmark, isFollowed) = tupleTwo
+            .sink { tupleOne, isBookmark, tupleThree in
+                let (authorName, authorId, isMyself) = tupleOne
                 let (translatedFromLanguage, language) = tupleThree
 
-                guard let name = authorName?.string, let context = self.context, let authContext = self.authContext else {
+                guard let name = authorName?.string, let authorId = authorId, let context = self.context, let authContext = self.authContext else {
                     statusView.authorView.menuButton.menu = nil
                     return
                 }
@@ -689,21 +685,44 @@ extension StatusView.ViewModel {
                 let instance = authentication.instance(in: context.managedObjectContext)
                 let isTranslationEnabled = instance?.isTranslationEnabled ?? false
 
-                let menuContext = StatusAuthorView.AuthorMenuContext(
-                    name: name,
-                    isMuting: isMuting,
-                    isBlocking: isBlocking,
-                    isMyself: isMyself,
-                    isBookmarking: isBookmark,
-                    isFollowed: isFollowed,
-                    isTranslationEnabled: isTranslationEnabled,
-                    isTranslated: translatedFromLanguage != nil,
-                    statusLanguage: language
-                )
-                
-                let (menu, actions) = authorView.setupAuthorMenu(menuContext: menuContext)
-                authorView.menuButton.menu = menu
-                authorView.authorActions = actions
+                authorView.menuButton.menu = UIMenu(children: [
+                    UIDeferredMenuElement({ menuElement in
+                        
+                        let domain = authContext.mastodonAuthenticationBox.domain
+
+                        Task { @MainActor in
+                            if let relationship = try? await Mastodon.API.Account.relationships(
+                                session: .shared,
+                                domain: domain,
+                                query: .init(ids: [authorId]),
+                                authorization: authContext.mastodonAuthenticationBox.userAuthorization
+                            ).singleOutput().value {
+                                guard let rel = relationship.first else { return }
+                                DispatchQueue.main.async {
+
+                                    let menuContext = StatusAuthorView.AuthorMenuContext(
+                                        name: name,
+                                        isMuting: rel.muting ?? false,
+                                        isBlocking: rel.blocking,
+                                        isMyself: isMyself,
+                                        isBookmarking: isBookmark,
+                                        isFollowed: rel.followedBy,
+                                        isTranslationEnabled: isTranslationEnabled,
+                                        isTranslated: translatedFromLanguage != nil,
+                                        statusLanguage: language
+                                    )
+                                
+                                    let (menu, actions) = authorView.setupAuthorMenu(menuContext: menuContext)
+                                    authorView.authorActions = actions
+                                    
+                                    menuElement(menu.children)
+                                }
+                            }
+                        }
+                        
+                    })
+                ])
+                                
                 authorView.menuButton.showsMenuAsPrimaryAction = true
             }
             .store(in: &disposeBag)


### PR DESCRIPTION
# Rationale

To reduce fetching user relationship we could fetch the relationship per-status only wehen the user taps the context menu, as it's only required there.