### PR TITLE
Load User-lists initially (#1227)

### DIFF
--- a/Mastodon/Scene/Profile/UserList/FavoritedBy/FavoritedByViewController.swift
+++ b/Mastodon/Scene/Profile/UserList/FavoritedBy/FavoritedByViewController.swift
@@ -59,6 +59,8 @@ extension FavoritedByViewController {
                 self.viewModel.stateMachine.enter(UserListViewModel.State.Loading.self)
             }
             .store(in: &disposeBag)
+
+        viewModel.listBatchFetchViewModel.shouldFetch.send()
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/Mastodon/Scene/Profile/UserList/RebloggedBy/RebloggedByViewController.swift
+++ b/Mastodon/Scene/Profile/UserList/RebloggedBy/RebloggedByViewController.swift
@@ -65,6 +65,8 @@ extension RebloggedByViewController {
                 self.viewModel.stateMachine.enter(UserListViewModel.State.Loading.self)
             }
             .store(in: &disposeBag)
+
+        viewModel.listBatchFetchViewModel.shouldFetch.send()
     }
     
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
The `UserList`-screens (Reblogged by/Favorited by) relied on the `ListBatchViewModel` to load their data initially. The `ListBatchViewModel` triggered an update every second. When we changed the time interval for that `ListBatchViewModel` from one to 30 seconds, the screens waited for those 30 seconds to load data.

This PR adds an initial load for those screens, so that it doesn't need to wait for the `ListBatchViewModel` to trigger an update.