### PR TITLE
#1229, but for status-reporting

### DIFF
--- a/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
+++ b/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
@@ -117,7 +117,9 @@ extension ReportStatusViewController {
         }
         
         navigationActionView.backButton.addTarget(self, action: #selector(ReportStatusViewController.skipButtonDidPressed(_:)), for: .touchUpInside)
-        navigationActionView.nextButton.addTarget(self, action: #selector(ReportStatusViewController.nextButtonDidPressed(_:)), for: .touchUpInside)        
+        navigationActionView.nextButton.addTarget(self, action: #selector(ReportStatusViewController.nextButtonDidPressed(_:)), for: .touchUpInside)
+
+        viewModel.listBatchFetchViewModel.shouldFetch.send()
     }
     
 }


### PR DESCRIPTION
Trigger status-loading immediately (and not 30 seconds later), see #1227/#1229

(Randomly found during testing)