### PR TITLE
Fix Sourcery for `DiscoveryCommunityViewController`

### DIFF
--- a/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewController.swift
+++ b/Mastodon/Scene/Discovery/Community/DiscoveryCommunityViewController.swift
@@ -102,7 +102,7 @@ extension DiscoveryCommunityViewController: AuthContextProvider {
 
 // MARK: - UITableViewDelegate
 extension DiscoveryCommunityViewController: UITableViewDelegate, AutoGenerateTableViewDelegate {
-    // sourcery:inline:CommunityViewController.AutoGenerateTableViewDelegate
+    // sourcery:inline:DiscoveryCommunityViewController.AutoGenerateTableViewDelegate
 
     // Generated using Sourcery
     // DO NOT EDIT


### PR DESCRIPTION
The annotation was referencing the wrong type.