### PR TITLE
Fix crash / deadlock when selecting hashtag from search history

### DIFF
--- a/Mastodon/Protocol/Provider/DataSourceFacade+Hashtag.swift
+++ b/Mastodon/Protocol/Provider/DataSourceFacade+Hashtag.swift
@@ -13,14 +13,6 @@ import MastodonSDK
 extension DataSourceFacade {
     @MainActor
     static func coordinateToHashtagScene(
-        provider: DataSourceProvider & AuthContextProvider,
-        tag: Mastodon.Entity.Tag
-    ) async {
-        await coordinateToHashtagScene(provider: provider, tag: tag)
-    }
-    
-    @MainActor
-    static func coordinateToHashtagScene(
         provider: ViewControllerWithDependencies & AuthContextProvider,
         tag: Mastodon.Entity.Tag
     ) async {


### PR DESCRIPTION
# Rationale

Fixes a deadlock that's happening due to a recursion when tapping a hashtag search inside the search history. 