### PR TITLE
Replace deprecated `AVAsset.tracks(withMediaType:)`

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentViewModel+Compress.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentViewModel+Compress.swift
@@ -15,7 +15,7 @@ extension AttachmentViewModel {
     func compressVideo(url: URL) async throws -> URL? {
         let urlAsset = AVURLAsset(url: url)
         
-        guard let track = urlAsset.tracks(withMediaType: .video).first else {
+        guard let track = try await urlAsset.loadTracks(withMediaType: .video).first else {
             return nil
         }
         


### PR DESCRIPTION
This PR replaces deprecated `AVAsset.tracks(withMediaType:)` to resolve the following warning:

```
'tracks(withMediaType:)' was deprecated in iOS 16.0: Use loadTracks(withMediaType:) instead
```

https://developer.apple.com/documentation/avfoundation/avasset/1387140-tracks