### PR TITLE
Use static cursor color

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentView.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Attachment/AttachmentView.swift
@@ -58,6 +58,7 @@ public struct AttachmentView: View {
                                         .lineLimit(1)
                                         .textFieldStyle(.plain)
                                         .font(.footnote)
+                                        .tint(Color(UIColor.white.withAlphaComponent(0.8)))
                                         .foregroundColor(Color(UIColor.white.withAlphaComponent(0.8)))
                                         .padding(EdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 4))
                                         .placeholder(when: viewModel.caption.isEmpty) {


### PR DESCRIPTION
This very little PR fixes:

> The first letter of the alt text placeholder is slightly cut