### PR TITLE
Switch Everything and Mentions Tabs order (IOS-240)

### DIFF
--- a/Mastodon/Scene/Notification/NotificationViewController.swift
+++ b/Mastodon/Scene/Notification/NotificationViewController.swift
@@ -224,9 +224,9 @@ extension NotificationViewController {
         
         switch category {
         case .mentions:
-            scrollToPage(.first, animated: true, completion: nil)
-        case .everything:
             scrollToPage(.last, animated: true, completion: nil)
+        case .everything:
+            scrollToPage(.first, animated: true, completion: nil)
         }
     }
     

--- a/Mastodon/Scene/Notification/NotificationViewModel.swift
+++ b/Mastodon/Scene/Notification/NotificationViewModel.swift
@@ -31,14 +31,18 @@ final class NotificationViewModel {
     
     private var lastPageIndex: Int {
         get {
-            UserDefaults.shared.getLastSelectedNotificationsTab(
+            guard let selectedTabName = UserDefaults.shared.getLastSelectedNotificationsTabName(
                 accessToken: authContext.mastodonAuthenticationBox.userAuthorization.accessToken
-            )
+            ), let scope = APIService.MastodonNotificationScope(rawValue: selectedTabName) else {
+                return 0
+            }
+            
+            return APIService.MastodonNotificationScope.allCases.firstIndex(of: scope) ?? 0
         }
         set {
-            UserDefaults.shared.setLastSelectedNotificationsTab(
+            UserDefaults.shared.setLastSelectedNotificationsTabName(
                 accessToken: authContext.mastodonAuthenticationBox.userAuthorization.accessToken,
-                value: newValue
+                value: APIService.MastodonNotificationScope.allCases[newValue].rawValue
             )
         }
     }

--- a/MastodonSDK/Sources/MastodonCommon/Preference/Preference+Notification.swift
+++ b/MastodonSDK/Sources/MastodonCommon/Preference/Preference+Notification.swift
@@ -38,14 +38,14 @@ extension UserDefaults {
         let count = getNotificationCountWithAccessToken(accessToken: accessToken)
         setNotificationCountWithAccessToken(accessToken: accessToken, value: count + 1)
     }
-    
-    @objc public func getLastSelectedNotificationsTab(accessToken: String) -> Int {
+
+    @objc public func getLastSelectedNotificationsTabName(accessToken: String) -> String? {
         let prefix = UserDefaults.notificationsLastTabIndexKeyPrefix
         let key = UserDefaults.deriveKey(from: accessToken, prefix: prefix)
-        return integer(forKey: key)
+        return object(forKey: key) as? String
     }
     
-    @objc public func setLastSelectedNotificationsTab(accessToken: String, value: Int) {
+    @objc public func setLastSelectedNotificationsTabName(accessToken: String, value: String?) {
         let prefix = UserDefaults.notificationsLastTabIndexKeyPrefix
         let key = UserDefaults.deriveKey(from: accessToken, prefix: prefix)
         setValue(value, forKey: key)

--- a/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Notification.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Notification.swift
@@ -14,9 +14,9 @@ import OSLog
 
 extension APIService {
     
-    public enum MastodonNotificationScope: Hashable, CaseIterable {
-        case mentions
+    public enum MastodonNotificationScope: String, Hashable, CaseIterable {
         case everything
+        case mentions
         
         public var includeTypes: [MastodonNotificationType]? {
             switch self {


### PR DESCRIPTION
# Rationale

Switch "Everything" and "Mentions" order on notifications tab.
I have thought about migrating the old setting, but for the sake of reduced complexity I've dropped the idea.