### PR TITLE
Explore Tab: Use a segmented picker under the search bar (IOS-237)

### DIFF
--- a/Mastodon/Scene/Discovery/DiscoveryViewController.swift
+++ b/Mastodon/Scene/Discovery/DiscoveryViewController.swift
@@ -12,8 +12,6 @@ import MastodonAsset
 import MastodonCore
 import MastodonUI
 
-
-
 public class DiscoveryViewController: PageboyViewController, NeedsDependency {
 
     public static let containerViewMarginForRegularHorizontalSizeClass: CGFloat = 64

--- a/Mastodon/Scene/Discovery/DiscoveryViewController.swift
+++ b/Mastodon/Scene/Discovery/DiscoveryViewController.swift
@@ -7,14 +7,15 @@
 
 import UIKit
 import Combine
-import Tabman
 import Pageboy
 import MastodonAsset
 import MastodonCore
 import MastodonUI
 
-public class DiscoveryViewController: TabmanViewController, NeedsDependency {
-    
+
+
+public class DiscoveryViewController: PageboyViewController, NeedsDependency {
+
     public static let containerViewMarginForRegularHorizontalSizeClass: CGFloat = 64
     public static let containerViewMarginForCompactHorizontalSizeClass: CGFloat = 16
     
@@ -25,71 +26,12 @@ public class DiscoveryViewController: TabmanViewController, NeedsDependency {
         
     var viewModel: DiscoveryViewModel!
     
-    private(set) lazy var buttonBar: TMBar.ButtonBar = {
-        let buttonBar = TMBar.ButtonBar()
-        buttonBar.backgroundView.style = .custom(view: buttonBarBackgroundView)
-        buttonBar.layout.interButtonSpacing = 0
-        buttonBar.layout.contentInset = .zero
-        buttonBar.indicator.backgroundColor = Asset.Colors.Label.primary.color
-        buttonBar.indicator.weight = .custom(value: 2)
-        return buttonBar
-    }()
-    
-    let buttonBarBackgroundView: UIView = {
-        let view = UIView()
-        let barBottomLine = UIView.separatorLine
-        barBottomLine.backgroundColor = Asset.Colors.Label.secondary.color.withAlphaComponent(0.5)
-        barBottomLine.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(barBottomLine)
-        NSLayoutConstraint.activate([
-            barBottomLine.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            barBottomLine.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            barBottomLine.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            barBottomLine.heightAnchor.constraint(equalToConstant: 2).priority(.required - 1),
-        ])
-        return view
-    }()
-    
-    func customizeButtonBarAppearance() {
-        // The implmention use CATextlayer. Adapt for Dark Mode without dynamic colors
-        // Needs trigger update when `userInterfaceStyle` chagnes
-        let userInterfaceStyle = traitCollection.userInterfaceStyle
-        buttonBar.buttons.customize { button in
-            switch userInterfaceStyle {
-            case .dark:
-                // Asset.Colors.Label.primary.color
-                button.selectedTintColor = UIColor(red: 238.0/255.0, green: 238.0/255.0, blue: 238.0/255.0, alpha: 1.0)
-                // Asset.Colors.Label.secondary.color
-                button.tintColor = UIColor(red: 151.0/255.0, green: 157.0/255.0, blue: 173.0/255.0, alpha: 1.0)
-            default:
-                // Asset.Colors.Label.primary.color
-                button.selectedTintColor = UIColor(red: 40.0/255.0, green: 44.0/255.0, blue: 55.0/255.0, alpha: 1.0)
-                // Asset.Colors.Label.secondary.color
-                button.tintColor = UIColor(red: 60.0/255.0, green: 60.0/255.0, blue: 67.0/255.0, alpha: 0.6)
-            }
-            
-            button.backgroundColor = .clear
-            button.contentInset = UIEdgeInsets(top: 12, left: 26, bottom: 12, right: 26)
-        }
-    }
-    
-}
-
-extension DiscoveryViewController {
-    
     public override func viewDidLoad() {
         super.viewDidLoad()
 
         setupAppearance()
         
         dataSource = viewModel
-        addBar(
-            buttonBar,
-            dataSource: viewModel,
-            at: .top
-        )
-        customizeButtonBarAppearance()
-    
         viewModel.$viewControllers
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
@@ -98,22 +40,10 @@ extension DiscoveryViewController {
             }
             .store(in: &disposeBag)
     }
-    
-    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
 
-        customizeButtonBarAppearance()
-    }
-
-}
-
-extension DiscoveryViewController {
-    
     private func setupAppearance() {
         view.backgroundColor = .secondarySystemBackground
-        buttonBarBackgroundView.backgroundColor = .systemBackground
     }
-    
 }
 
 // MARK: - ScrollViewContainer
@@ -148,5 +78,4 @@ extension DiscoveryViewController: PageboyNavigateable {
     @objc func pageboyNavigateKeyCommandHandlerRelay(_ sender: UIKeyCommand) {
         pageboyNavigateKeyCommandHandler(sender)
     }
-    
 }

--- a/Mastodon/Scene/Discovery/DiscoveryViewModel.swift
+++ b/Mastodon/Scene/Discovery/DiscoveryViewModel.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 import Combine
-import Tabman
 import Pageboy
 import MastodonCore
 import MastodonLocalization
@@ -24,7 +23,7 @@ final class DiscoveryViewModel {
     let discoveryNewsViewController: DiscoveryNewsViewController
     let discoveryForYouViewController: DiscoveryForYouViewController
     
-    @Published var viewControllers: [ScrollViewContainer & PageViewController]
+    @Published var viewControllers: [ScrollViewContainer]
     
     @MainActor
     init(context: AppContext, coordinator: SceneCoordinator, authContext: AuthContext) {
@@ -109,54 +108,4 @@ extension DiscoveryViewModel: PageboyViewControllerDataSource {
         return .first
     }
     
-}
-
-// MARK: - TMBarDataSource
-extension DiscoveryViewModel: TMBarDataSource {
-    func barItem(for bar: TMBar, at index: Int) -> TMBarItemable {
-        guard !viewControllers.isEmpty, index < viewControllers.count else {
-            assertionFailure()
-            return TMBarItem(title: "")
-        }
-        return viewControllers[index].tabItem
-    }
-}
-
-protocol PageViewController: UIViewController {
-    var tabItemTitle: String { get }
-    var tabItem: TMBarItemable { get }
-}
-
-// MARK: - PageViewController
-extension DiscoveryPostsViewController: PageViewController {
-    var tabItemTitle: String { L10n.Scene.Discovery.Tabs.posts }
-    var tabItem: TMBarItemable {
-        return TMBarItem(title: tabItemTitle)
-    }
-}
-
-
-// MARK: - PageViewController
-extension DiscoveryHashtagsViewController: PageViewController {
-    var tabItemTitle: String { L10n.Scene.Discovery.Tabs.hashtags }
-    var tabItem: TMBarItemable {
-
-        return TMBarItem(title: tabItemTitle)
-    }
-}
-
-// MARK: - PageViewController
-extension DiscoveryNewsViewController: PageViewController {
-    var tabItemTitle: String { L10n.Scene.Discovery.Tabs.news }
-    var tabItem: TMBarItemable {
-        return TMBarItem(title: tabItemTitle)
-    }
-}
-
-// MARK: - PageViewController
-extension DiscoveryForYouViewController: PageViewController {
-    var tabItemTitle: String { L10n.Scene.Discovery.Tabs.forYou }
-    var tabItem: TMBarItemable {
-        return TMBarItem(title: tabItemTitle)
-    }
 }

--- a/Mastodon/Scene/Search/Search/SearchViewModel.swift
+++ b/Mastodon/Scene/Search/Search/SearchViewModel.swift
@@ -21,7 +21,6 @@ final class SearchViewModel: NSObject {
     // input
     let context: AppContext
     let authContext: AuthContext?
-    let viewDidAppeared = PassthroughSubject<Void, Never>()
     
     // output
     var diffableDataSource: UICollectionViewDiffableDataSource<SearchSection, SearchItem>?


### PR DESCRIPTION
- Replace the Tab-menus in Explore with a UISegmentedControl
- First idea was to use `UISearchBar` with its `scopeTitles` and this also worked in iPhone, but not on iPad (for whatever reason the navigation bar height just doesn't change)
- So I got back to use a normal `UISegmentedControl` (but not as part of the navigation bar) and it looks like this:

![Simulator Screenshot - iPhone 15 Pro - 2024-03-22 at 17 26 14](https://github.com/mastodon/mastodon-ios/assets/2580019/6c8a5768-4d82-4181-8fd9-b1650694a535)
![Simulator Screenshot - iPad (10th generation) - 2024-03-22 at 17 20 19](https://github.com/mastodon/mastodon-ios/assets/2580019/294b7c9e-b4a0-4df9-9e54-8b02c25e6969)

LMK if you want me to add a thin line below the segmented control