### PR TITLE
Scrolling crash content offset (IOS-254)

### DIFF
--- a/Mastodon/Extension/UITableView.swift
+++ b/Mastodon/Extension/UITableView.swift
@@ -27,22 +27,4 @@ extension UITableView {
             }
         })
     }
-    
-    func blinkRow(at indexPath: IndexPath) {
-        DispatchQueue.main.asyncAfter(wallDeadline: .now() + 1) { [weak self] in
-            guard let self = self else { return }
-            guard let cell = self.cellForRow(at: indexPath) else { return }
-            let backgroundColor = cell.backgroundColor
-            
-            UIView.animate(withDuration: 0.3) {
-                cell.backgroundColor = Asset.Colors.Brand.blurple.color.withAlphaComponent(0.5)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    UIView.animate(withDuration: 0.3) {
-                        cell.backgroundColor = backgroundColor
-                    }
-                }
-            }
-        }
-    }
-    
 }

--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewController.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewController.swift
@@ -338,8 +338,6 @@ extension HomeTimelineViewController {
                 if isOffline {
                     self.timelinePill.update(with: .offline)
                     self.showTimelinePill()
-                } else {
-                    self.hideTimelinePill()
                 }
             })
             .store(in: &disposeBag)

--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewController.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewController.swift
@@ -81,9 +81,6 @@ final class HomeTimelineViewController: UIViewController, NeedsDependency, Media
     
     let tableView: UITableView = {
         let tableView = ControlContainableTableView()
-        tableView.register(StatusTableViewCell.self, forCellReuseIdentifier: String(describing: StatusTableViewCell.self))
-        tableView.register(TimelineMiddleLoaderTableViewCell.self, forCellReuseIdentifier: String(describing: TimelineMiddleLoaderTableViewCell.self))
-        tableView.register(TimelineBottomLoaderTableViewCell.self, forCellReuseIdentifier: String(describing: TimelineBottomLoaderTableViewCell.self))
         tableView.rowHeight = UITableView.automaticDimension
         tableView.separatorStyle = .none
         tableView.backgroundColor = .clear

--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel+Diffable.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel+Diffable.swift
@@ -85,7 +85,9 @@ extension HomeTimelineViewModel {
                     }
                     
                     await self.updateDataSource(snapshot: newSnapshot, animatingDifferences: false)
-                    tableView.scrollToRow(at: difference.targetIndexPath, at: .top, animated: false)
+                    if tableView.numberOfSections >= difference.targetIndexPath.section && tableView.numberOfRows(inSection: difference.targetIndexPath.section) >= difference.targetIndexPath.row {
+                        tableView.scrollToRow(at: difference.targetIndexPath, at: .top, animated: false)
+                    }
                     var contentOffset = tableView.contentOffset
                     contentOffset.y = tableView.contentOffset.y - difference.sourceDistanceToTableViewTopEdge
                     tableView.setContentOffset(contentOffset, animated: false)

--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel.swift
@@ -99,7 +99,9 @@ final class HomeTimelineViewModel: NSObject {
         self.dataController.$records
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
-            .sink(receiveValue: { feeds in
+            .sink(receiveValue: { [weak self] feeds in
+                guard let self, self.timelineContext == .home else { return }
+
                 let items: [MastodonStatus] = feeds.compactMap { feed -> MastodonStatus? in
                     guard let status = feed.status else { return nil }
                     return status

--- a/Mastodon/Scene/Notification/NotificationTimeline/NotificationTimelineViewModel+Diffable.swift
+++ b/Mastodon/Scene/Notification/NotificationTimeline/NotificationTimelineViewModel+Diffable.swift
@@ -77,14 +77,6 @@ extension NotificationTimelineViewModel {
 }
 
 extension NotificationTimelineViewModel {
-    
-    @MainActor func updateDataSource(
-        snapshot: NSDiffableDataSourceSnapshot<NotificationSection, NotificationItem>,
-        animatingDifferences: Bool
-    ) async {
-        await diffableDataSource?.apply(snapshot, animatingDifferences: animatingDifferences)
-    }
-    
     @MainActor func updateSnapshotUsingReloadData(
         snapshot: NSDiffableDataSourceSnapshot<NotificationSection, NotificationItem>
     ) async {


### PR DESCRIPTION
- This PR is an attempt to fix our most prominent crash. As I haven't been able to reproduce it, I can't say for sure that it's fixed. We'll find out.
- It fixes another issue introduces with #1275: The pill disappeared immediately
- It also makes sure to only persist the `following`-timeline (but not the `public`-timeline).