### PR TITLE
Enable dismissal of keyboard in registration view on overscroll (IOS-222)

### DIFF
--- a/Mastodon/Scene/Onboarding/Register/MastodonRegisterView.swift
+++ b/Mastodon/Scene/Onboarding/Register/MastodonRegisterView.swift
@@ -117,6 +117,7 @@ struct MastodonRegisterView: View {
                     viewModel.endEditing.send()
                 }
         )
+        .scrollDismissesKeyboard(.interactively)
     }
     
     struct FormTextFieldModifier: ViewModifier {


### PR DESCRIPTION
Previous the keyboard did not dismiss on over scroll, this is fixed now.

![RocketSim_Recording_iPhone_15_6 1_2024-05-07_09 19 26](https://github.com/mastodon/mastodon-ios/assets/126418/642b8fb8-3362-4c45-9984-0221d1cf75dd)
