### PR TITLE
Only show mentions in mentions (IOS-270)

### DIFF
--- a/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Notification.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/API/APIService+Notification.swift
@@ -63,10 +63,7 @@ extension APIService {
                         .moderationWarning
                     ]
                 case .mentions:
-                    return [
-                        .mention,
-                        .status,
-                    ]
+                    return [.mention]
                 }
             }(),
             excludeTypes: {


### PR DESCRIPTION
You can be notified if other people post something. For some reason we showed that also in the "Mentions"-section of the Notification-screen. This PR fixes that.