### PR TITLE
Improve CW Overlay / size (IOS-278)

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusView.swift
@@ -517,9 +517,10 @@ extension StatusView.Style {
         // link preview card
         statusView.contentContainer.addArrangedSubview(statusView.statusCardControl)
 
-        statusView.spoilerOverlayView.translatesAutoresizingMaskIntoConstraints = false
-        statusView.containerStackView.addSubview(statusView.spoilerOverlayView)
-        statusView.contentContainer.pinTo(to: statusView.spoilerOverlayView)
+        statusView.containerStackView.addArrangedSubview(statusView.spoilerOverlayView)
+        NSLayoutConstraint.activate([
+            statusView.spoilerOverlayView.heightAnchor.constraint(equalToConstant: 128).priority(.defaultHigh)
+        ])
 
         // media container: V - [ mediaGridContainerView ]
         statusView.mediaContainerView.translatesAutoresizingMaskIntoConstraints = false
@@ -616,7 +617,7 @@ extension StatusView.Style {
         base(statusView: statusView)
         
         statusView.contentAdaptiveMarginContainerView.removeFromSuperview()
-        statusView.spoilerOverlayView.removeFromSuperview()
+        statusView.spoilerOverlayView.isHidden = true
         statusView.mediaContainerView.removeFromSuperview()
         statusView.pollAdaptiveMarginContainerView.removeFromSuperview()
         statusView.actionToolbarAdaptiveMarginContainerView.removeFromSuperview()
@@ -638,7 +639,7 @@ extension StatusView {
     
     func setSpoilerOverlayViewHidden(isHidden: Bool) {
         spoilerOverlayView.isHidden = isHidden
-        spoilerOverlayView.setComponentHidden(isHidden)
+        contentAdaptiveMarginContainerView.isHidden = !isHidden
     }
     
     func setMediaDisplay(isDisplay: Bool = true) {

--- a/MastodonSDK/Sources/MastodonUI/View/Control/SpoilerOverlayView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Control/SpoilerOverlayView.swift
@@ -69,8 +69,4 @@ extension SpoilerOverlayView {
         isAccessibilityElement = true
         accessibilityTraits.insert(.button)
     }
-    
-    public func setComponentHidden(_ isHidden: Bool) {
-        containerStackView.arrangedSubviews.forEach { $0.isHidden = isHidden }
-    }
 }


### PR DESCRIPTION
# Rationale

Improves the Content Warning's height to not use the full height of the actual status content.

| Before | After |
|---|---|
| ![RocketSim_Recording_iPhone_15_6 1_2024-05-22_13 02 27](https://github.com/mastodon/mastodon-ios/assets/126418/f37e5a7a-95b5-475c-b1cd-062ea84d3dd7) | ![RocketSim_Recording_iPhone_15_6 1_2024-05-22_12 59 24](https://github.com/mastodon/mastodon-ios/assets/126418/e25c8ef9-cf2a-4447-8b2a-4e1200b9ecf7) |

