### PR TITLE
Improve "Load more"-times when scrolling to the end (IOS-272)

### DIFF
--- a/Mastodon.xcodeproj/project.pbxproj
+++ b/Mastodon.xcodeproj/project.pbxproj
@@ -365,7 +365,7 @@
 		DB6D9F3526351B7A008423CD /* NotificationService+Decrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6D9F3426351B7A008423CD /* NotificationService+Decrypt.swift */; };
 		DB72601C25E36A2100235243 /* MastodonServerRulesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB72601B25E36A2100235243 /* MastodonServerRulesViewController.swift */; };
 		DB72602725E36A6F00235243 /* MastodonServerRulesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB72602625E36A6F00235243 /* MastodonServerRulesViewModel.swift */; };
-		DB7274F4273BB9B200577D95 /* ListBatchFetchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7274F3273BB9B200577D95 /* ListBatchFetchViewModel.swift */; };
+		DB7274F4273BB9B200577D95 /* UIScrollViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7274F3273BB9B200577D95 /* UIScrollViewDelegate.swift */; };
 		DB73B490261F030A002E9E9F /* SafariActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB73B48F261F030A002E9E9F /* SafariActivity.swift */; };
 		DB75BF1E263C1C1B00EDBF1F /* CustomScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB75BF1D263C1C1B00EDBF1F /* CustomScheduler.swift */; };
 		DB789A0B25F9F2950071ACA0 /* ComposeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB789A0A25F9F2950071ACA0 /* ComposeViewController.swift */; };
@@ -1045,7 +1045,7 @@
 		DB6D9F3426351B7A008423CD /* NotificationService+Decrypt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationService+Decrypt.swift"; sourceTree = "<group>"; };
 		DB72601B25E36A2100235243 /* MastodonServerRulesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MastodonServerRulesViewController.swift; sourceTree = "<group>"; };
 		DB72602625E36A6F00235243 /* MastodonServerRulesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MastodonServerRulesViewModel.swift; sourceTree = "<group>"; };
-		DB7274F3273BB9B200577D95 /* ListBatchFetchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListBatchFetchViewModel.swift; sourceTree = "<group>"; };
+		DB7274F3273BB9B200577D95 /* UIScrollViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollViewDelegate.swift; sourceTree = "<group>"; };
 		DB73B48F261F030A002E9E9F /* SafariActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariActivity.swift; sourceTree = "<group>"; };
 		DB75BF1D263C1C1B00EDBF1F /* CustomScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomScheduler.swift; sourceTree = "<group>"; };
 		DB789A0A25F9F2950071ACA0 /* ComposeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeViewController.swift; sourceTree = "<group>"; };
@@ -2524,27 +2524,28 @@
 			children = (
 				2A82294E29262EE000D2A1F7 /* AppContext+NextAccount.swift */,
 				5DF1056325F887CB00D6C0D4 /* AVPlayer.swift */,
+				2A1FE47D2938C11200784BF1 /* Collection+IsNotEmpty.swift */,
 				2D206B8525F5FB0900143C56 /* Double.swift */,
 				DBB3BA2926A81C020004F2D4 /* FLAnimatedImageView.swift */,
 				DB68586325E619B700F0A850 /* NSKeyValueObservation.swift */,
 				2D939AB425EDD8A90076FA61 /* String.swift */,
-				DB68A06225E905E000CFDF14 /* UIApplication.swift */,
 				DB45FAB525CA5485005A8AC7 /* UIAlertController.swift */,
+				DB68A06225E905E000CFDF14 /* UIApplication.swift */,
 				DB45FAD625CA6C76005A8AC7 /* UIBarButtonItem.swift */,
+				2D206B9125F60EA700143C56 /* UIControl.swift */,
+				0FAA101B25E10E760017CCDE /* UIFont.swift */,
+				2AE244472927831100BDBF7C /* UIImage+SFSymbols.swift */,
+				855149C7295F1C5F00943D96 /* UIInterfaceOrientationMask.swift */,
+				DB9E0D6E25EE008500CFDD76 /* UIInterpolatingMotionEffect.swift */,
+				2D84350425FF858100EECE90 /* UIScrollView.swift */,
+				DB7274F3273BB9B200577D95 /* UIScrollViewDelegate.swift */,
+				DBCC3B2F261440A50045B23D /* UITabBarController.swift */,
 				DB4481B825EE289600BEFB67 /* UITableView.swift */,
 				DBD376B1269302A4007FEC24 /* UITableViewCell.swift */,
-				0FAA101B25E10E760017CCDE /* UIFont.swift */,
-				2D206B9125F60EA700143C56 /* UIControl.swift */,
-				5DA732CB2629CEF500A92342 /* UIView+Remove.swift */,
-				2D24E1222626ED9D00A59D4F /* UIView+Gesture.swift */,
-				DB8AF55C25C138B7002E6C99 /* UIViewController.swift */,
 				2D3F9E0325DFA133004262D9 /* UITapGestureRecognizer.swift */,
-				2D84350425FF858100EECE90 /* UIScrollView.swift */,
-				DB9E0D6E25EE008500CFDD76 /* UIInterpolatingMotionEffect.swift */,
-				2AE244472927831100BDBF7C /* UIImage+SFSymbols.swift */,
-				DBCC3B2F261440A50045B23D /* UITabBarController.swift */,
-				2A1FE47D2938C11200784BF1 /* Collection+IsNotEmpty.swift */,
-				855149C7295F1C5F00943D96 /* UIInterfaceOrientationMask.swift */,
+				2D24E1222626ED9D00A59D4F /* UIView+Gesture.swift */,
+				5DA732CB2629CEF500A92342 /* UIView+Remove.swift */,
+				DB8AF55C25C138B7002E6C99 /* UIViewController.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -2676,7 +2677,6 @@
 		DB9D6C2025E502C60051B173 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
-				DB7274F3273BB9B200577D95 /* ListBatchFetchViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -3663,7 +3663,7 @@
 				DBB45B5927B39FE4002DC5A7 /* MediaPreviewVideoViewModel.swift in Sources */,
 				DB0FCB76279571C5006C02E2 /* ThreadViewController+DataSourceProvider.swift in Sources */,
 				DB1E346825F518E20079D7DF /* CategoryPickerSection.swift in Sources */,
-				DB7274F4273BB9B200577D95 /* ListBatchFetchViewModel.swift in Sources */,
+				DB7274F4273BB9B200577D95 /* UIScrollViewDelegate.swift in Sources */,
 				DB0618052785A73D0030EE79 /* RegisterItem.swift in Sources */,
 				DB6B74EF272FB55000C70B6E /* FollowerListViewController.swift in Sources */,
 				DB4AA6B327BA34B6009EC082 /* CellFrameCacheContainer.swift in Sources */,

--- a/Mastodon/Extension/UIScrollViewDelegate.swift
+++ b/Mastodon/Extension/UIScrollViewDelegate.swift
@@ -1,13 +1,8 @@
-//
-//  ListBatchFetchViewModel.swift
-//  Mastodon
-//
-//  Created by Cirno MainasuK on 2021-11-10.
-//
+// Copyright © 2024 Mastodon gGmbH. All rights reserved.
 
 import UIKit
 
-final class ListBatchFetchViewModel {
+extension UIScrollViewDelegate {
     static func scrollViewDidScrollToEnd(_ scrollView: UIScrollView, action: () -> Void) {
         if scrollView.isDragging || scrollView.isTracking { return }
 

--- a/Mastodon/Scene/Discovery/News/DiscoveryNewsViewController.swift
+++ b/Mastodon/Scene/Discovery/News/DiscoveryNewsViewController.swift
@@ -199,7 +199,7 @@ extension DiscoveryNewsViewController: TableViewControllerNavigateable {
 
 extension DiscoveryNewsViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
+        Self.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(DiscoveryNewsViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Discovery/News/DiscoveryNewsViewController.swift
+++ b/Mastodon/Scene/Discovery/News/DiscoveryNewsViewController.swift
@@ -57,17 +57,6 @@ extension DiscoveryNewsViewController {
                 self.refreshControl.endRefreshing()
             }
             .store(in: &disposeBag)
-        
-        // setup batch fetch
-        viewModel.listBatchFetchViewModel.setup(scrollView: tableView)
-        viewModel.listBatchFetchViewModel.shouldFetch
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self = self else { return }
-                guard self.view.window != nil else { return }
-                self.viewModel.stateMachine.enter(DiscoveryNewsViewModel.State.Loading.self)
-            }
-            .store(in: &disposeBag)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -204,4 +193,14 @@ extension DiscoveryNewsViewController: TableViewControllerNavigateable {
         navigateKeyCommandHandler(sender)
     }
 
+}
+
+//MARK: - UIScrollViewDelegate
+
+extension DiscoveryNewsViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+            viewModel.stateMachine.enter(DiscoveryNewsViewModel.State.Loading.self)
+        }
+    }
 }

--- a/Mastodon/Scene/Discovery/News/DiscoveryNewsViewController.swift
+++ b/Mastodon/Scene/Discovery/News/DiscoveryNewsViewController.swift
@@ -199,7 +199,7 @@ extension DiscoveryNewsViewController: TableViewControllerNavigateable {
 
 extension DiscoveryNewsViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(DiscoveryNewsViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Discovery/News/DiscoveryNewsViewModel.swift
+++ b/Mastodon/Scene/Discovery/News/DiscoveryNewsViewModel.swift
@@ -20,7 +20,6 @@ final class DiscoveryNewsViewModel {
     // input
     let context: AppContext
     let authContext: AuthContext
-    let listBatchFetchViewModel = ListBatchFetchViewModel()
 
     // output
     @Published var links: [Mastodon.Entity.Link] = []

--- a/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewController.swift
+++ b/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewController.swift
@@ -165,7 +165,7 @@ extension DiscoveryPostsViewController: StatusTableViewControllerNavigateable {
 
 extension DiscoveryPostsViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
+        Self.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(DiscoveryPostsViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewController.swift
+++ b/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewController.swift
@@ -74,17 +74,6 @@ extension DiscoveryPostsViewController {
                 self.refreshControl.endRefreshing()
             }
             .store(in: &disposeBag)
-        
-        // setup batch fetch
-        viewModel.listBatchFetchViewModel.setup(scrollView: tableView)
-        viewModel.listBatchFetchViewModel.shouldFetch
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self = self else { return }
-                guard self.view.window != nil else { return }
-                self.viewModel.stateMachine.enter(DiscoveryPostsViewModel.State.Loading.self)
-            }
-            .store(in: &disposeBag)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -169,5 +158,15 @@ extension DiscoveryPostsViewController: StatusTableViewControllerNavigateable {
 
     @objc func statusKeyCommandHandlerRelay(_ sender: UIKeyCommand) {
         statusKeyCommandHandler(sender)
+    }
+}
+
+//MARK: - UIScrollViewDelegate
+
+extension DiscoveryPostsViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+            viewModel.stateMachine.enter(DiscoveryPostsViewModel.State.Loading.self)
+        }
     }
 }

--- a/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewController.swift
+++ b/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewController.swift
@@ -165,7 +165,7 @@ extension DiscoveryPostsViewController: StatusTableViewControllerNavigateable {
 
 extension DiscoveryPostsViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(DiscoveryPostsViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewModel.swift
+++ b/Mastodon/Scene/Discovery/Posts/DiscoveryPostsViewModel.swift
@@ -21,7 +21,6 @@ final class DiscoveryPostsViewModel {
     let context: AppContext
     let authContext: AuthContext
     let dataController: StatusDataController
-    let listBatchFetchViewModel = ListBatchFetchViewModel()
     
     // output
     var diffableDataSource: UITableViewDiffableDataSource<StatusSection, StatusItem>?

--- a/Mastodon/Scene/HashtagTimeline/HashtagTimelineViewController.swift
+++ b/Mastodon/Scene/HashtagTimeline/HashtagTimelineViewController.swift
@@ -252,7 +252,7 @@ extension HashtagTimelineViewController: StatusTableViewControllerNavigateable {
 
 extension HashtagTimelineViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
+        Self.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(HashtagTimelineViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/HashtagTimeline/HashtagTimelineViewController.swift
+++ b/Mastodon/Scene/HashtagTimeline/HashtagTimelineViewController.swift
@@ -95,17 +95,7 @@ extension HashtagTimelineViewController {
                 self.refreshControl.endRefreshing()
             }
             .store(in: &disposeBag)
-        
-        // setup batch fetch
-        viewModel.listBatchFetchViewModel.setup(scrollView: tableView)
-        viewModel.listBatchFetchViewModel.shouldFetch
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self = self else { return }
-                self.viewModel.stateMachine.enter(HashtagTimelineViewModel.State.Loading.self)
-            }
-            .store(in: &disposeBag)
-        
+
         viewModel.hashtagEntity
             .receive(on: DispatchQueue.main)
             .sink { [weak self] tag in
@@ -255,5 +245,15 @@ extension HashtagTimelineViewController: StatusTableViewControllerNavigateable {
     
     @objc func statusKeyCommandHandlerRelay(_ sender: UIKeyCommand) {
         statusKeyCommandHandler(sender)
+    }
+}
+
+// MARK: - UIScrollViewDelegate
+
+extension HashtagTimelineViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+            viewModel.stateMachine.enter(HashtagTimelineViewModel.State.Loading.self)
+        }
     }
 }

--- a/Mastodon/Scene/HashtagTimeline/HashtagTimelineViewController.swift
+++ b/Mastodon/Scene/HashtagTimeline/HashtagTimelineViewController.swift
@@ -252,7 +252,7 @@ extension HashtagTimelineViewController: StatusTableViewControllerNavigateable {
 
 extension HashtagTimelineViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(HashtagTimelineViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/HashtagTimeline/HashtagTimelineViewModel.swift
+++ b/Mastodon/Scene/HashtagTimeline/HashtagTimelineViewModel.swift
@@ -28,7 +28,6 @@ final class HashtagTimelineViewModel {
     let isFetchingLatestTimeline = CurrentValueSubject<Bool, Never>(false)
     let timelinePredicate = CurrentValueSubject<NSPredicate?, Never>(nil)
     let hashtagEntity = CurrentValueSubject<Mastodon.Entity.Tag?, Never>(nil)
-    let listBatchFetchViewModel = ListBatchFetchViewModel()
 
     // output
     var diffableDataSource: UITableViewDiffableDataSource<StatusSection, StatusItem>?

--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewController.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewController.swift
@@ -192,18 +192,7 @@ extension HomeTimelineViewController {
             statusTableViewCellDelegate: self,
             timelineMiddleLoaderTableViewCellDelegate: self
         )
-        
-        // setup batch fetch
-        viewModel?.listBatchFetchViewModel.setup(scrollView: tableView)
-        viewModel?.listBatchFetchViewModel.shouldFetch
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self = self else { return }
-                guard self.view.window != nil else { return }
-                self.viewModel?.loadOldestStateMachine.enter(HomeTimelineViewModel.LoadOldestState.Loading.self)
-            }
-            .store(in: &disposeBag)
-        
+
         // bind refresh control
         viewModel?.didLoadLatest
             .receive(on: DispatchQueue.main)

--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewController.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewController.swift
@@ -576,11 +576,22 @@ extension HomeTimelineViewController {
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        Self.scrollViewDidScrollToEnd(scrollView) {
+            guard let viewModel,
+                  let currentState = viewModel.loadLatestStateMachine.currentState as? HomeTimelineViewModel.LoadLatestState,
+                  (currentState.self is HomeTimelineViewModel.LoadLatestState.ContextSwitch) == false else { return }
+
+            viewModel.timelineDidReachEnd()
+        }
+
+        
         guard (scrollView.safeAreaInsets.top + scrollView.contentOffset.y) == 0 else {
             return
         }
 
         hideTimelinePill()
+
+
     }
 
     private func savePositionBeforeScrollToTop() {
@@ -662,16 +673,6 @@ extension HomeTimelineViewController: UITableViewDelegate, AutoGenerateTableView
     }
 
     // sourcery:end
-    
-    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        guard let viewModel,
-                let currentState = viewModel.loadLatestStateMachine.currentState as? HomeTimelineViewModel.LoadLatestState,
-              (currentState.self is HomeTimelineViewModel.LoadLatestState.ContextSwitch) == false else { return }
-
-        if indexPath.row == tableView.numberOfRows(inSection: indexPath.section) - 1 {
-            viewModel.timelineDidReachEnd()
-        }
-    }
 }
 
 // MARK: - TimelineMiddleLoaderTableViewCellDelegate

--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel.swift
@@ -25,7 +25,6 @@ final class HomeTimelineViewModel: NSObject {
     let context: AppContext
     let authContext: AuthContext
     let dataController: FeedDataController
-    let listBatchFetchViewModel = ListBatchFetchViewModel()
 
     var presentedSuggestions = false
 

--- a/Mastodon/Scene/Notification/NotificationTimeline/NotificationTimelineViewController.swift
+++ b/Mastodon/Scene/Notification/NotificationTimeline/NotificationTimelineViewController.swift
@@ -301,7 +301,7 @@ extension NotificationTimelineViewController: TableViewControllerNavigateable {
 
 extension NotificationTimelineViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
+        Self.scrollViewDidScrollToEnd(scrollView) {
             viewModel.loadOldestStateMachine.enter(NotificationTimelineViewModel.LoadOldestState.Loading.self)
         }
     }

--- a/Mastodon/Scene/Notification/NotificationTimeline/NotificationTimelineViewController.swift
+++ b/Mastodon/Scene/Notification/NotificationTimeline/NotificationTimelineViewController.swift
@@ -55,16 +55,6 @@ extension NotificationTimelineViewController {
             notificationTableViewCellDelegate: self
         )
         
-        // setup batch fetch
-        viewModel.listBatchFetchViewModel.setup(scrollView: tableView)
-        viewModel.listBatchFetchViewModel.shouldFetch
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self = self else { return }
-                self.viewModel.loadOldestStateMachine.enter(NotificationTimelineViewModel.LoadOldestState.Loading.self)
-            }
-            .store(in: &disposeBag)
-        
         // setup refresh control
         tableView.refreshControl = refreshControl
         viewModel.didLoadLatest
@@ -305,4 +295,14 @@ extension NotificationTimelineViewController: TableViewControllerNavigateable {
         navigateKeyCommandHandler(sender)
     }
 
+}
+
+//MARK: - UIScrollViewDelegate
+
+extension NotificationTimelineViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+            viewModel.loadOldestStateMachine.enter(NotificationTimelineViewModel.LoadOldestState.Loading.self)
+        }
+    }
 }

--- a/Mastodon/Scene/Notification/NotificationTimeline/NotificationTimelineViewController.swift
+++ b/Mastodon/Scene/Notification/NotificationTimeline/NotificationTimelineViewController.swift
@@ -54,7 +54,7 @@ extension NotificationTimelineViewController {
             tableView: tableView,
             notificationTableViewCellDelegate: self
         )
-        
+
         // setup refresh control
         tableView.refreshControl = refreshControl
         viewModel.didLoadLatest
@@ -301,7 +301,7 @@ extension NotificationTimelineViewController: TableViewControllerNavigateable {
 
 extension NotificationTimelineViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
             viewModel.loadOldestStateMachine.enter(NotificationTimelineViewModel.LoadOldestState.Loading.self)
         }
     }

--- a/Mastodon/Scene/Notification/NotificationTimeline/NotificationTimelineViewModel.swift
+++ b/Mastodon/Scene/Notification/NotificationTimeline/NotificationTimelineViewModel.swift
@@ -21,7 +21,6 @@ final class NotificationTimelineViewModel {
     let authContext: AuthContext
     let scope: Scope
     let dataController: FeedDataController
-    let listBatchFetchViewModel = ListBatchFetchViewModel()
     @Published var isLoadingLatest = false
     @Published var lastAutomaticFetchTimestamp: Date?
     

--- a/Mastodon/Scene/Profile/Bookmark/BookmarkViewController.swift
+++ b/Mastodon/Scene/Profile/Bookmark/BookmarkViewController.swift
@@ -58,16 +58,6 @@ extension BookmarkViewController {
             tableView: tableView,
             statusTableViewCellDelegate: self
         )
-
-        // setup batch fetch
-        viewModel.listBatchFetchViewModel.setup(scrollView: tableView)
-        viewModel.listBatchFetchViewModel.shouldFetch
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self = self else { return }
-                self.viewModel.stateMachine.enter(BookmarkViewModel.State.Loading.self)
-            }
-            .store(in: &disposeBag)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -75,13 +65,6 @@ extension BookmarkViewController {
         
         tableView.deselectRow(with: transitionCoordinator, animated: animated)
     }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        
-//        aspectViewDidDisappear(animated)
-    }
-    
 }
 
 // MARK: - UITableViewDelegate
@@ -136,5 +119,16 @@ extension BookmarkViewController: StatusTableViewControllerNavigateable {
     
     @objc func statusKeyCommandHandlerRelay(_ sender: UIKeyCommand) {
         statusKeyCommandHandler(sender)
+    }
+}
+
+//MARK: - UIScrollViewDelegate
+
+extension BookmarkViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+            print("See me loading \(Date())")
+            viewModel.stateMachine.enter(BookmarkViewModel.State.Loading.self)
+        }
     }
 }

--- a/Mastodon/Scene/Profile/Bookmark/BookmarkViewController.swift
+++ b/Mastodon/Scene/Profile/Bookmark/BookmarkViewController.swift
@@ -126,7 +126,7 @@ extension BookmarkViewController: StatusTableViewControllerNavigateable {
 
 extension BookmarkViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
+        Self.scrollViewDidScrollToEnd(scrollView) {
             print("See me loading \(Date())")
             viewModel.stateMachine.enter(BookmarkViewModel.State.Loading.self)
         }

--- a/Mastodon/Scene/Profile/Bookmark/BookmarkViewController.swift
+++ b/Mastodon/Scene/Profile/Bookmark/BookmarkViewController.swift
@@ -127,7 +127,6 @@ extension BookmarkViewController: StatusTableViewControllerNavigateable {
 extension BookmarkViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         Self.scrollViewDidScrollToEnd(scrollView) {
-            print("See me loading \(Date())")
             viewModel.stateMachine.enter(BookmarkViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Profile/Bookmark/BookmarkViewController.swift
+++ b/Mastodon/Scene/Profile/Bookmark/BookmarkViewController.swift
@@ -126,7 +126,7 @@ extension BookmarkViewController: StatusTableViewControllerNavigateable {
 
 extension BookmarkViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
             print("See me loading \(Date())")
             viewModel.stateMachine.enter(BookmarkViewModel.State.Loading.self)
         }

--- a/Mastodon/Scene/Profile/Bookmark/BookmarkViewModel.swift
+++ b/Mastodon/Scene/Profile/Bookmark/BookmarkViewModel.swift
@@ -21,7 +21,6 @@ final class BookmarkViewModel {
     let authContext: AuthContext
     
     let dataController: StatusDataController
-    let listBatchFetchViewModel = ListBatchFetchViewModel()
 
     // output
     var diffableDataSource: UITableViewDiffableDataSource<StatusSection, StatusItem>?

--- a/Mastodon/Scene/Profile/Favorite/FavoriteViewController.swift
+++ b/Mastodon/Scene/Profile/Favorite/FavoriteViewController.swift
@@ -61,16 +61,6 @@ extension FavoriteViewController {
             tableView: tableView,
             statusTableViewCellDelegate: self
         )
-
-        // setup batch fetch
-        viewModel.listBatchFetchViewModel.setup(scrollView: tableView)
-        viewModel.listBatchFetchViewModel.shouldFetch
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self = self else { return }
-                self.viewModel.stateMachine.enter(FavoriteViewModel.State.Loading.self)
-            }
-            .store(in: &disposeBag)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -139,5 +129,15 @@ extension FavoriteViewController: StatusTableViewControllerNavigateable {
     
     @objc func statusKeyCommandHandlerRelay(_ sender: UIKeyCommand) {
         statusKeyCommandHandler(sender)
+    }
+}
+
+//MARK: - UIScrollViewDelegate
+
+extension FavoriteViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+            viewModel.stateMachine.enter(FavoriteViewModel.State.Loading.self)
+        }
     }
 }

--- a/Mastodon/Scene/Profile/Favorite/FavoriteViewController.swift
+++ b/Mastodon/Scene/Profile/Favorite/FavoriteViewController.swift
@@ -136,7 +136,7 @@ extension FavoriteViewController: StatusTableViewControllerNavigateable {
 
 extension FavoriteViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
+        Self.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(FavoriteViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Profile/Favorite/FavoriteViewController.swift
+++ b/Mastodon/Scene/Profile/Favorite/FavoriteViewController.swift
@@ -136,7 +136,7 @@ extension FavoriteViewController: StatusTableViewControllerNavigateable {
 
 extension FavoriteViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(FavoriteViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Profile/Favorite/FavoriteViewModel.swift
+++ b/Mastodon/Scene/Profile/Favorite/FavoriteViewModel.swift
@@ -20,7 +20,6 @@ final class FavoriteViewModel {
     let context: AppContext
     let authContext: AuthContext
     let dataController: StatusDataController
-    let listBatchFetchViewModel = ListBatchFetchViewModel()
 
     // output
     var diffableDataSource: UITableViewDiffableDataSource<StatusSection, StatusItem>?

--- a/Mastodon/Scene/Profile/Follower/FollowerListViewController.swift
+++ b/Mastodon/Scene/Profile/Follower/FollowerListViewController.swift
@@ -71,15 +71,6 @@ extension FollowerListViewController {
             userTableViewCellDelegate: self
         )
         
-        // setup batch fetch
-        viewModel.shouldFetch
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self = self else { return }
-                self.viewModel.stateMachine.enter(FollowerListViewModel.State.Loading.self)
-            }
-            .store(in: &disposeBag)
-        
         // trigger user timeline loading
         Publishers.CombineLatest(
             viewModel.$domain.removeDuplicates(),
@@ -168,19 +159,8 @@ extension FollowerListViewController: DataSourceProvider {
 
 extension FollowerListViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-
-        if scrollView.isDragging || scrollView.isTracking { return }
-
-        let frame = scrollView.frame
-        let contentOffset = scrollView.contentOffset
-        let contentSize = scrollView.contentSize
-
-        let visibleBottomY = contentOffset.y + frame.height
-        let offset = 2 * frame.height
-        let fetchThrottleOffsetY = contentSize.height - offset
-
-        if visibleBottomY > fetchThrottleOffsetY {
-            viewModel.shouldFetch.send()
+        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+            viewModel.stateMachine.enter(FollowerListViewModel.State.Loading.self)
         }
     }
 }

--- a/Mastodon/Scene/Profile/Follower/FollowerListViewController.swift
+++ b/Mastodon/Scene/Profile/Follower/FollowerListViewController.swift
@@ -159,7 +159,7 @@ extension FollowerListViewController: DataSourceProvider {
 
 extension FollowerListViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
+        Self.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(FollowerListViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Profile/Follower/FollowerListViewController.swift
+++ b/Mastodon/Scene/Profile/Follower/FollowerListViewController.swift
@@ -159,7 +159,7 @@ extension FollowerListViewController: DataSourceProvider {
 
 extension FollowerListViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(FollowerListViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Profile/Following/FollowingListViewController.swift
+++ b/Mastodon/Scene/Profile/Following/FollowingListViewController.swift
@@ -164,18 +164,7 @@ extension FollowingListViewController: DataSourceProvider {
 
 extension FollowingListViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-
-        if scrollView.isDragging || scrollView.isTracking { return }
-
-        let frame = scrollView.frame
-        let contentOffset = scrollView.contentOffset
-        let contentSize = scrollView.contentSize
-
-        let visibleBottomY = contentOffset.y + frame.height
-        let offset = 2 * frame.height
-        let fetchThrottleOffsetY = contentSize.height - offset
-
-        if visibleBottomY > fetchThrottleOffsetY {
+        Self.scrollViewDidScrollToEnd(scrollView) {
             viewModel.shouldFetch.send()
         }
     }

--- a/Mastodon/Scene/Profile/Timeline/UserTimelineViewController.swift
+++ b/Mastodon/Scene/Profile/Timeline/UserTimelineViewController.swift
@@ -162,7 +162,7 @@ extension UserTimelineViewController: IndicatorInfoProvider {
 //MARK: - UIScrollViewDelegate
 extension UserTimelineViewController: UIScrollViewDelegate {
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
+        Self.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(UserTimelineViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Profile/Timeline/UserTimelineViewController.swift
+++ b/Mastodon/Scene/Profile/Timeline/UserTimelineViewController.swift
@@ -54,17 +54,6 @@ extension UserTimelineViewController {
             tableView: tableView,
             statusTableViewCellDelegate: self
         )
-        
-        // setup batch fetch
-        viewModel.listBatchFetchViewModel.setup(scrollView: tableView)
-        viewModel.listBatchFetchViewModel.shouldFetch
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self = self else { return }
-                guard self.view.window != nil else { return }
-                self.viewModel.stateMachine.enter(UserTimelineViewModel.State.Loading.self)
-            }
-            .store(in: &disposeBag)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -167,5 +156,14 @@ extension UserTimelineViewController: StatusTableViewControllerNavigateable {
 extension UserTimelineViewController: IndicatorInfoProvider {
     func indicatorInfo(for pagerTabStripController: PagerTabStripViewController) -> IndicatorInfo {
         return IndicatorInfo(title: viewModel.title)
+    }
+}
+
+//MARK: - UIScrollViewDelegate
+extension UserTimelineViewController: UIScrollViewDelegate {
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
+            viewModel.stateMachine.enter(UserTimelineViewModel.State.Loading.self)
+        }
     }
 }

--- a/Mastodon/Scene/Profile/Timeline/UserTimelineViewModel.swift
+++ b/Mastodon/Scene/Profile/Timeline/UserTimelineViewModel.swift
@@ -22,7 +22,6 @@ final class UserTimelineViewModel {
     let authContext: AuthContext
     let title: String
     let dataController: StatusDataController
-    let listBatchFetchViewModel = ListBatchFetchViewModel()
     @Published var userIdentifier: UserIdentifier?
     @Published var queryFilter: QueryFilter
 

--- a/Mastodon/Scene/Profile/UserList/FavoritedBy/FavoritedByViewController.swift
+++ b/Mastodon/Scene/Profile/UserList/FavoritedBy/FavoritedByViewController.swift
@@ -86,7 +86,7 @@ extension FavoritedByViewController: UserTableViewCellDelegate {}
 
 extension FavoritedByViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
+        Self.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(UserListViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Profile/UserList/FavoritedBy/FavoritedByViewController.swift
+++ b/Mastodon/Scene/Profile/UserList/FavoritedBy/FavoritedByViewController.swift
@@ -86,7 +86,7 @@ extension FavoritedByViewController: UserTableViewCellDelegate {}
 
 extension FavoritedByViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(UserListViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Profile/UserList/FavoritedBy/FavoritedByViewController.swift
+++ b/Mastodon/Scene/Profile/UserList/FavoritedBy/FavoritedByViewController.swift
@@ -49,18 +49,8 @@ extension FavoritedByViewController {
             tableView: tableView,
             userTableViewCellDelegate: self
         )
-        
-        // setup batch fetch
-        viewModel.listBatchFetchViewModel.setup(scrollView: tableView)
-        viewModel.listBatchFetchViewModel.shouldFetch
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self = self else { return }
-                self.viewModel.stateMachine.enter(UserListViewModel.State.Loading.self)
-            }
-            .store(in: &disposeBag)
 
-        viewModel.listBatchFetchViewModel.shouldFetch.send()
+        viewModel.stateMachine.enter(UserListViewModel.State.Loading.self)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -91,3 +81,13 @@ extension FavoritedByViewController: UITableViewDelegate, AutoGenerateTableViewD
 
 // MARK: - UserTableViewCellDelegate
 extension FavoritedByViewController: UserTableViewCellDelegate {}
+
+//MARK: - UIScrollViewDelegate
+
+extension FavoritedByViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+            viewModel.stateMachine.enter(UserListViewModel.State.Loading.self)
+        }
+    }
+}

--- a/Mastodon/Scene/Profile/UserList/RebloggedBy/RebloggedByViewController.swift
+++ b/Mastodon/Scene/Profile/UserList/RebloggedBy/RebloggedByViewController.swift
@@ -56,17 +56,8 @@ extension RebloggedByViewController {
             userTableViewCellDelegate: self
         )
         
-        // setup batch fetch
-        viewModel.listBatchFetchViewModel.setup(scrollView: tableView)
-        viewModel.listBatchFetchViewModel.shouldFetch
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self = self else { return }
-                self.viewModel.stateMachine.enter(UserListViewModel.State.Loading.self)
-            }
-            .store(in: &disposeBag)
 
-        viewModel.listBatchFetchViewModel.shouldFetch.send()
+        viewModel.stateMachine.enter(UserListViewModel.State.Loading.self)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -97,3 +88,13 @@ extension RebloggedByViewController: UITableViewDelegate, AutoGenerateTableViewD
 
 // MARK: - UserTableViewCellDelegate
 extension RebloggedByViewController: UserTableViewCellDelegate {}
+
+//MARK: - UIScrollViewDelegate
+
+extension RebloggedByViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
+            viewModel.stateMachine.enter(UserListViewModel.State.Loading.self)
+        }
+    }
+}

--- a/Mastodon/Scene/Profile/UserList/RebloggedBy/RebloggedByViewController.swift
+++ b/Mastodon/Scene/Profile/UserList/RebloggedBy/RebloggedByViewController.swift
@@ -93,7 +93,7 @@ extension RebloggedByViewController: UserTableViewCellDelegate {}
 
 extension RebloggedByViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
+        Self.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(UserListViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Profile/UserList/UserListViewModel.swift
+++ b/Mastodon/Scene/Profile/UserList/UserListViewModel.swift
@@ -21,7 +21,6 @@ final class UserListViewModel {
     let kind: Kind
     @Published var accounts: [Mastodon.Entity.Account]
     @Published var relationships: [Mastodon.Entity.Relationship]
-    let listBatchFetchViewModel = ListBatchFetchViewModel()
 
     // output
     var diffableDataSource: UITableViewDiffableDataSource<UserSection, UserItem>!

--- a/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
+++ b/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
@@ -191,7 +191,7 @@ extension ReportStatusViewController: UIAdaptivePresentationControllerDelegate {
 
 extension ReportStatusViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
+        Self.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(ReportStatusViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
+++ b/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
@@ -96,17 +96,6 @@ extension ReportStatusViewController {
             }
             .store(in: &observations)
         
-        // setup batch fetch
-        viewModel.listBatchFetchViewModel.setup(scrollView: tableView)
-        viewModel.listBatchFetchViewModel.shouldFetch
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self = self else { return }
-                guard self.view.window != nil else { return }
-                self.viewModel.stateMachine.enter(ReportStatusViewModel.State.Loading.self)
-            }
-            .store(in: &disposeBag)
-        
         viewModel.$isNextButtonEnabled
             .receive(on: DispatchQueue.main)
             .assign(to: \.isEnabled, on: navigationActionView.nextButton)
@@ -119,7 +108,7 @@ extension ReportStatusViewController {
         navigationActionView.backButton.addTarget(self, action: #selector(ReportStatusViewController.skipButtonDidPressed(_:)), for: .touchUpInside)
         navigationActionView.nextButton.addTarget(self, action: #selector(ReportStatusViewController.nextButtonDidPressed(_:)), for: .touchUpInside)
 
-        viewModel.listBatchFetchViewModel.shouldFetch.send()
+        viewModel.stateMachine.enter(ReportStatusViewModel.State.Loading.self)
     }
     
 }
@@ -195,5 +184,15 @@ extension ReportStatusViewController: UITableViewDelegate {
 extension ReportStatusViewController: UIAdaptivePresentationControllerDelegate {
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
         return false
+    }
+}
+
+//MARK: - UIScrollViewDelegate
+
+extension ReportStatusViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+            viewModel.stateMachine.enter(ReportStatusViewModel.State.Loading.self)
+        }
     }
 }

--- a/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
+++ b/Mastodon/Scene/Report/ReportStatus/ReportStatusViewController.swift
@@ -191,7 +191,7 @@ extension ReportStatusViewController: UIAdaptivePresentationControllerDelegate {
 
 extension ReportStatusViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(ReportStatusViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Report/ReportStatus/ReportStatusViewModel.swift
+++ b/Mastodon/Scene/Report/ReportStatus/ReportStatusViewModel.swift
@@ -27,7 +27,6 @@ class ReportStatusViewModel {
     let account: Mastodon.Entity.Account
     let status: MastodonStatus?
     let dataController: StatusDataController
-    let listBatchFetchViewModel = ListBatchFetchViewModel()
 
     @Published var isSkip = false
     @Published var selectStatuses = OrderedSet<MastodonStatus>()

--- a/Mastodon/Scene/Search/SearchDetail/SearchResult/SearchResultViewController.swift
+++ b/Mastodon/Scene/Search/SearchDetail/SearchResult/SearchResultViewController.swift
@@ -50,25 +50,8 @@ extension SearchResultViewController {
             userTableViewCellDelegate: self
         )
         
-        // setup batch fetch
-        viewModel.listBatchFetchViewModel.setup(scrollView: tableView)
-        viewModel.listBatchFetchViewModel.shouldFetch
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self = self else { return }
-                guard self.view.window != nil else { return }
-                self.viewModel.stateMachine.enter(SearchResultViewModel.State.Loading.self)
-            }
-            .store(in: &disposeBag)
-
         title = viewModel.searchText
-        viewModel.listBatchFetchViewModel.shouldFetch.send()
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        viewModel.stateMachine.enter(SearchResultViewModel.State.Initial.self)
+        viewModel.stateMachine.enter(SearchResultViewModel.State.Loading.self)
     }
 }
 
@@ -110,3 +93,13 @@ extension SearchResultViewController: StatusTableViewCellDelegate { }
 
 // MARK: - UserTableViewCellDelegate
 extension SearchResultViewController: UserTableViewCellDelegate {}
+
+//MARK: - UIScrollViewDelegate
+
+extension SearchResultViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+            viewModel.stateMachine.enter(SearchResultViewModel.State.Loading.self)
+        }
+    }
+}

--- a/Mastodon/Scene/Search/SearchDetail/SearchResult/SearchResultViewController.swift
+++ b/Mastodon/Scene/Search/SearchDetail/SearchResult/SearchResultViewController.swift
@@ -98,7 +98,7 @@ extension SearchResultViewController: UserTableViewCellDelegate {}
 
 extension SearchResultViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewdidScrollToEnd(scrollView) {
+        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(SearchResultViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Search/SearchDetail/SearchResult/SearchResultViewController.swift
+++ b/Mastodon/Scene/Search/SearchDetail/SearchResult/SearchResultViewController.swift
@@ -98,7 +98,7 @@ extension SearchResultViewController: UserTableViewCellDelegate {}
 
 extension SearchResultViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        ListBatchFetchViewModel.scrollViewDidScrollToEnd(scrollView) {
+        Self.scrollViewDidScrollToEnd(scrollView) {
             viewModel.stateMachine.enter(SearchResultViewModel.State.Loading.self)
         }
     }

--- a/Mastodon/Scene/Search/SearchDetail/SearchResult/SearchResultViewModel.swift
+++ b/Mastodon/Scene/Search/SearchDetail/SearchResult/SearchResultViewModel.swift
@@ -25,7 +25,6 @@ final class SearchResultViewModel {
     @Published var accounts: [Mastodon.Entity.Account] = []
     var relationships: [Mastodon.Entity.Relationship] = []
     let dataController: StatusDataController
-    let listBatchFetchViewModel = ListBatchFetchViewModel()
 
     var cellFrameCache = NSCache<NSNumber, NSValue>()
     var navigationBarFrame = CurrentValueSubject<CGRect, Never>(.zero)

--- a/Mastodon/Scene/Share/ViewModel/ListBatchFetchViewModel.swift
+++ b/Mastodon/Scene/Share/ViewModel/ListBatchFetchViewModel.swift
@@ -10,59 +10,31 @@ import Combine
 
 // ref: Texture.ASBatchFetchingDelegate
 final class ListBatchFetchViewModel {
-    
-    var disposeBag = Set<AnyCancellable>()
-    
-    // timer running on `common` mode
-    let timerPublisher = Timer.publish(every: 30.0, on: .main, in: .common)
-        .autoconnect()
-        .share()
-        .eraseToAnyPublisher()
-    
-    // input
-    private(set) weak var scrollView: UIScrollView?
-    let hasMore = CurrentValueSubject<Bool, Never>(true)
-    
-    // output
     let shouldFetch = PassthroughSubject<Void, Never>()
     
-    init() {
-        Publishers.CombineLatest(
-            hasMore,
-            timerPublisher
-        )
-        .sink { [weak self] hasMore, _ in
-            guard let self = self else { return }
-            guard hasMore else { return }
-            guard let scrollView = self.scrollView else { return }
-            
-            // skip trigger if user interacting
-            if scrollView.isDragging || scrollView.isTracking { return }
-            
-            // send fetch request
-            if scrollView.contentSize.height < scrollView.frame.height {
-                self.shouldFetch.send()
-            } else {
-                let frame = scrollView.frame
-                let contentOffset = scrollView.contentOffset
-                let contentSize = scrollView.contentSize
-                
-                let visibleBottomY = contentOffset.y + frame.height
-                let offset = 2 * frame.height
-                let fetchThrottleOffsetY = contentSize.height - offset
-                
-                if visibleBottomY > fetchThrottleOffsetY {
-                    self.shouldFetch.send()
-                }
-            }
+    init() {}
+
+    static func scrollViewdidScrollToEnd(_ scrollView: UIScrollView, action: () -> Void) {
+        if scrollView.isDragging || scrollView.isTracking { return }
+
+        let frame = scrollView.frame
+        let contentOffset = scrollView.contentOffset
+        let contentSize = scrollView.contentSize
+
+        let visibleBottomY = contentOffset.y + frame.height
+        let offset = 2 * frame.height
+        let fetchThrottleOffsetY = contentSize.height - offset
+
+        if visibleBottomY > fetchThrottleOffsetY {
+            action()
         }
-        .store(in: &disposeBag)
+
     }
-    
 }
 
 extension ListBatchFetchViewModel {
-    func setup(scrollView: UIScrollView) {
-        self.scrollView = scrollView
-    }
+    @available(*, deprecated, message: "Implement `UIScrollViewDelegate` and invoce `scrollViewdidScrollToEnd` for now.")
+    func setup(scrollView: UIScrollView) {}
 }
+
+

--- a/Mastodon/Scene/Share/ViewModel/ListBatchFetchViewModel.swift
+++ b/Mastodon/Scene/Share/ViewModel/ListBatchFetchViewModel.swift
@@ -6,12 +6,8 @@
 //
 
 import UIKit
-import Combine
 
-// ref: Texture.ASBatchFetchingDelegate
 final class ListBatchFetchViewModel {
-    init() {}
-
     static func scrollViewDidScrollToEnd(_ scrollView: UIScrollView, action: () -> Void) {
         if scrollView.isDragging || scrollView.isTracking { return }
 
@@ -27,9 +23,4 @@ final class ListBatchFetchViewModel {
             action()
         }
     }
-}
-
-extension ListBatchFetchViewModel {
-    @available(*, deprecated, message: "Implement `UIScrollViewDelegate` and invoce `scrollViewdidScrollToEnd` for now.")
-    func setup(scrollView: UIScrollView) {}
 }

--- a/Mastodon/Scene/Share/ViewModel/ListBatchFetchViewModel.swift
+++ b/Mastodon/Scene/Share/ViewModel/ListBatchFetchViewModel.swift
@@ -14,7 +14,7 @@ final class ListBatchFetchViewModel {
     
     init() {}
 
-    static func scrollViewdidScrollToEnd(_ scrollView: UIScrollView, action: () -> Void) {
+    static func scrollViewDidScrollToEnd(_ scrollView: UIScrollView, action: () -> Void) {
         if scrollView.isDragging || scrollView.isTracking { return }
 
         let frame = scrollView.frame

--- a/Mastodon/Scene/Share/ViewModel/ListBatchFetchViewModel.swift
+++ b/Mastodon/Scene/Share/ViewModel/ListBatchFetchViewModel.swift
@@ -10,8 +10,6 @@ import Combine
 
 // ref: Texture.ASBatchFetchingDelegate
 final class ListBatchFetchViewModel {
-    let shouldFetch = PassthroughSubject<Void, Never>()
-    
     init() {}
 
     static func scrollViewDidScrollToEnd(_ scrollView: UIScrollView, action: () -> Void) {

--- a/Mastodon/Scene/Share/ViewModel/ListBatchFetchViewModel.swift
+++ b/Mastodon/Scene/Share/ViewModel/ListBatchFetchViewModel.swift
@@ -19,7 +19,6 @@ final class ListBatchFetchViewModel {
         if contentSize.height < frame.height { return }
 
         if contentOffset.y > (contentSize.height - frame.height) {
-            print("ACTION!")
             action()
         }
     }

--- a/Mastodon/Scene/Share/ViewModel/ListBatchFetchViewModel.swift
+++ b/Mastodon/Scene/Share/ViewModel/ListBatchFetchViewModel.swift
@@ -21,14 +21,13 @@ final class ListBatchFetchViewModel {
         let contentOffset = scrollView.contentOffset
         let contentSize = scrollView.contentSize
 
-        let visibleBottomY = contentOffset.y + frame.height
-        let offset = 2 * frame.height
-        let fetchThrottleOffsetY = contentSize.height - offset
+        // if not enough content to fill the screen: don't do anything
+        if contentSize.height < frame.height { return }
 
-        if visibleBottomY > fetchThrottleOffsetY {
+        if contentOffset.y > (contentSize.height - frame.height) {
+            print("ACTION!")
             action()
         }
-
     }
 }
 
@@ -36,5 +35,3 @@ extension ListBatchFetchViewModel {
     @available(*, deprecated, message: "Implement `UIScrollViewDelegate` and invoce `scrollViewdidScrollToEnd` for now.")
     func setup(scrollView: UIScrollView) {}
 }
-
-


### PR DESCRIPTION
This is basically a refactoring of the `ListBatchFetchViewModel`, it does two things:

1. Remove the "Reload this every 30 seconds", which caused a delay on several screens
2. When users reach the bottom of the ScrollView, new content is requested
3. DIY: Use this mechanism everywhere

The previous mechanism worked like this: Check every second, if the user reached the end of the scrollView. If so: `shouldFetch`. As we increased "every second" to "30 seconds", this caused a significant delay on all screens which used this mechanism.

Others brought their own solution to fetch new content when users reached THE END, like the HomeTimeline or the FollowerList. From now one, there's a suggested way to deal with this "We must do something once the user reachs the end!!!!"-issue.

P.S.: I'm not so happy with the `Self.`-approach and if someone has a better name for `scrollViewDidScrollToEnd`, I'd be also thankful for a hint. Maybe it's me, but I would have loved to add a new method to the `UIScrollViewDelegate`-protocol (without Protocol-inheritance). Maybe someone knows a way to do this?
