### PR TITLE
Update avatar in Sidebar/TabBar on change (IOS-277)

### DIFF
--- a/Mastodon/Scene/Profile/ProfileViewModel.swift
+++ b/Mastodon/Scene/Profile/ProfileViewModel.swift
@@ -234,6 +234,7 @@ extension ProfileViewModel {
         )
 
         FileManager.default.store(account: response.value, forUserID: authenticationBox.authentication.userIdentifier())
+        NotificationCenter.default.post(name: .userFetched, object: nil)
 
         return response
     }

--- a/Mastodon/Scene/Root/Sidebar/SidebarViewController.swift
+++ b/Mastodon/Scene/Root/Sidebar/SidebarViewController.swift
@@ -135,6 +135,14 @@ extension SidebarViewController {
         sidebarDoubleTapGestureRecognizer.cancelsTouchesInView = true
         collectionView.addGestureRecognizer(sidebarDoubleTapGestureRecognizer)
 
+        NotificationCenter.default.publisher(for: .userFetched)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self, let snapshot = self.viewModel.diffableDataSource?.snapshot() else { return }
+
+                self.viewModel.diffableDataSource?.applySnapshotUsingReloadData(snapshot)
+            }
+            .store(in: &disposeBag)
     }
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {


### PR DESCRIPTION
When the user uploaded new account information, it got saved, but nobody informed `MainTabBarController` (on iPhone) (and others), that the account got updated. The `.userFetched`-notification was never sent. But to use the updated picture, this notification is required. This PR fixes that. It also adds the Update-ability to the Sidebar (which is used on iPad)

In other words: When the user changes their image, the TabBar (or the Sidebar, on iPad) shows the new image now.