### PR TITLE
Use an existing account for the me-Screen (IOS-255)

### DIFF
--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -85,6 +85,10 @@ class MainTabBarController: UITabBarController {
             notificationViewController.viewModel = NotificationViewModel(context: context, authContext: authContext)
             homeTimelineViewController.viewModel = HomeTimelineViewModel(context: context, authContext: authContext)
             searchViewController.viewModel = SearchViewModel(context: context, authContext: authContext)
+
+            if let account = authContext.mastodonAuthenticationBox.authentication.account() {
+                meProfileViewController.viewModel = ProfileViewModel(context: context, authContext: authContext, account: account, relationship: nil, me: account)
+            }
         }
 
         super.init(nibName: nil, bundle: nil)


### PR DESCRIPTION
Technically this is a workaround: Replacing the `ProfileViewModel!` with a real optional (or no optional at all) most probably requires a rewrite of the entire Profile-screen, including header etc. as the `ProfileViewModel!` is used basically everywhere.

So the workaround is to use the existing account (at least until it is updated and replaced) to not have the app crash when the user taps on their profile too quickly (without an account, which this PR fixes). For some reason, we persist the users very own profile, but never used it.