### PR TITLE
"About profile"-Fixes (#1290)

### DIFF
--- a/Mastodon/Scene/Profile/ProfileViewController.swift
+++ b/Mastodon/Scene/Profile/ProfileViewController.swift
@@ -809,6 +809,7 @@ extension ProfileViewController: ProfileHeaderViewControllerDelegate {
                     guard let self else { return }
 
                     self.profileHeaderViewController.viewModel.setProfileInfo(accountForEdit: response.value)
+                    self.viewModel.accountForEdit = response.value
                 }
                 .store(in: &disposeBag)
         } else if isEdited == false {

--- a/Mastodon/Scene/Profile/ProfileViewController.swift
+++ b/Mastodon/Scene/Profile/ProfileViewController.swift
@@ -607,6 +607,7 @@ extension ProfileViewController {
             {
                 viewModel.account = updatedAccount
                 viewModel.relationship = updatedRelationship
+                viewModel.profileAboutViewModel.fields = updatedAccount.mastodonFields
             }
 
             if let updatedMe = try? await context.apiService.authenticatedUserInfo(authenticationBox: authContext.mastodonAuthenticationBox).value {
@@ -761,6 +762,7 @@ extension ProfileViewController: ProfileHeaderViewControllerDelegate {
                     self.profileHeaderViewController.viewModel.isEditing = false
                     profileAboutViewModel.isEditing = false
                     self.viewModel.account = updatedAccount
+                    self.viewModel.profileAboutViewModel.fields = updatedAccount.mastodonFields
 
                 } catch {
                     let alertController = UIAlertController(


### PR DESCRIPTION
When fixing the broken avatar-upload, we (well, I) broke the fields in the "About"-section. This PR fixes two things:

1. It fixes #1290 (Now you can edit fields again)
2. Field weren't updated when using Pull to Refresh on the Profile-screen.