### PR TITLE
Add authorization to custom emojis

### DIFF
--- a/MastodonSDK/Sources/MastodonCore/AppContext.swift
+++ b/MastodonSDK/Sources/MastodonCore/AppContext.swift
@@ -73,7 +73,8 @@ public class AppContext: ObservableObject {
         authenticationService = _authenticationService
         
         emojiService = EmojiService(
-            apiService: apiService
+            apiService: apiService,
+            authenticationService: _authenticationService
         )
         
         publisherService = .init(apiService: _apiService)

--- a/MastodonSDK/Sources/MastodonCore/Service/API/APIService+CustomEmoji.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/API/APIService+CustomEmoji.swift
@@ -12,9 +12,17 @@ import CoreDataStack
 import MastodonSDK
 
 extension APIService {
- 
-    func customEmoji(domain: String) -> AnyPublisher<Mastodon.Response.Content<[Mastodon.Entity.Emoji]>, Error> {
-        return Mastodon.API.CustomEmojis.customEmojis(session: session, domain: domain)
+
+    func customEmoji(
+        domain: String,
+        authenticationBox: MastodonAuthenticationBox
+    ) -> AnyPublisher<Mastodon.Response.Content<[Mastodon.Entity.Emoji]>, Error> {
+
+        return Mastodon.API.CustomEmojis.customEmojis(
+            session: session,
+            domain: domain,
+            authorization: authenticationBox.userAuthorization
+        )
     }
-    
+
 }

--- a/MastodonSDK/Sources/MastodonCore/Service/Emoji/EmojiService+CustomEmojiViewModel+LoadState.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/Emoji/EmojiService+CustomEmojiViewModel+LoadState.swift
@@ -33,9 +33,13 @@ extension EmojiService.CustomEmojiViewModel.LoadState {
         
         override func didEnter(from previousState: GKState?) {
             super.didEnter(from: previousState)
-            guard let viewModel = viewModel, let apiService = viewModel.service?.apiService, let stateMachine = stateMachine else { return }
-            
-            apiService.customEmoji(domain: viewModel.domain)
+            guard let viewModel,
+                  let authenticationBox = viewModel.service.authenticationService.mastodonAuthenticationBoxes.first,
+                  let stateMachine else { return }
+
+            let apiService = viewModel.service.apiService
+
+            apiService.customEmoji(domain: viewModel.domain, authenticationBox: authenticationBox)
                 // .receive(on: DispatchQueue.main)
                 .sink { completion in
                     switch completion {

--- a/MastodonSDK/Sources/MastodonCore/Service/Emoji/EmojiService+CustomEmojiViewModel.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/Emoji/EmojiService+CustomEmojiViewModel.swift
@@ -18,7 +18,7 @@ extension EmojiService {
         
         // input
         public let domain: String
-        public weak var service: EmojiService?
+        public let service: EmojiService
         
         // output
         private(set) lazy var stateMachine: GKStateMachine = {

--- a/MastodonSDK/Sources/MastodonCore/Service/Emoji/EmojiService.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/Emoji/EmojiService.swift
@@ -10,15 +10,15 @@ import Combine
 import MastodonSDK
 
 public final class EmojiService {
-    
-    
-    weak var apiService: APIService?
-    
+    let apiService: APIService
+    let authenticationService: AuthenticationService
+
     let workingQueue = DispatchQueue(label: "org.joinmastodon.app.EmojiService.working-queue")
     private(set) var customEmojiViewModelDict: [String: CustomEmojiViewModel] = [:]
     
-    init(apiService: APIService) {
+    init(apiService: APIService, authenticationService: AuthenticationService) {
         self.apiService = apiService
+        self.authenticationService = authenticationService
     }
     
 }

--- a/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+CustomEmojis.swift
+++ b/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+CustomEmojis.swift
@@ -30,12 +30,12 @@ extension Mastodon.API.CustomEmojis {
     /// - Returns: `AnyPublisher` contains [`Emoji`] nested in the response
     public static func customEmojis(
         session: URLSession,
-        domain: String
+        domain: String,
+        authorization: Mastodon.API.OAuth.Authorization?
     ) -> AnyPublisher<Mastodon.Response.Content<[Mastodon.Entity.Emoji]>, Error> {
         let request = Mastodon.API.get(
             url: customEmojisEndpointURL(domain: domain),
-            query: nil,
-            authorization: nil
+            authorization: authorization
         )
         return session.dataTaskPublisher(for: request)
             .tryMap { data, response in


### PR DESCRIPTION
This is (mostly) relevant for isolated instances but also these people have a right to custom emojis, right? :D

I encountered this minor issue when working on the Preview-card on an isolated instance.