### PR TITLE
fix: Remove charset from application/json content type

### DIFF
--- a/MastodonSDK/Sources/MastodonSDK/Query/Query.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Query/Query.swift
@@ -28,7 +28,7 @@ extension RequestQuery {
 // A `Get` query only contains queryItems, it should not be `Encodable`
 extension RequestQuery where Self: Encodable {
     var contentType: String? {
-        return "application/json; charset=utf-8"
+        return "application/json"
     }
     var body: Data? {
         return try? Mastodon.API.encoder.encode(self)


### PR DESCRIPTION
Per https://datatracker.ietf.org/doc/html/rfc8259, application/json does not have a charset parameter