### PR TITLE
Fixes for empty list state and hashtags (IOS-287)

### DIFF
--- a/Localization/app.json
+++ b/Localization/app.json
@@ -491,6 +491,9 @@
                 "offline": "Offline",
                 "new_posts": "New Posts",
                 "post_sent": "Post Sent"
+            },
+            "empty_state": {
+                "list_empty_message_title": "This list is empty"
             }
         },
         "suggestion_account": {

--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewController.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewController.swift
@@ -202,12 +202,13 @@ final class HomeTimelineViewController: UIViewController, NeedsDependency, Media
                 ).singleOutput().value) ?? []
                 
                 var listEntries = lists.map { entry in
-                    return LabeledAction(title: entry.name, image: nil, handler: { [weak self] in
+                    let entryName = "#\(entry.name)"
+                    return LabeledAction(title: entryName, image: nil, handler: { [weak self] in
                         guard let self, let viewModel = self.viewModel else { return }
                         viewModel.timelineContext = .hashtag(entry.name)
                         viewModel.loadLatestStateMachine.enter(HomeTimelineViewModel.LoadLatestState.ContextSwitch.self)
                         timelineSelectorButton.setAttributedTitle(
-                            .init(string: entry.name, attributes: [
+                            .init(string: entryName, attributes: [
                                 .font: UIFontMetrics(forTextStyle: .headline).scaledFont(for: .systemFont(ofSize: 20, weight: .semibold))
                             ]),
                             for: .normal)

--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel+LoadLatestState.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel+LoadLatestState.swift
@@ -105,7 +105,8 @@ extension HomeTimelineViewModel.LoadLatestState {
 
         guard let viewModel else { return }
 
-
+        viewModel.timelineIsEmpty.send(nil)
+        
         Task { @MainActor in
             let latestFeedRecords = viewModel.dataController.records
 
@@ -170,8 +171,20 @@ extension HomeTimelineViewModel.LoadLatestState {
                     
                     viewModel.dataController.records = (toAdd + latestFeedRecords).removingDuplicates()
                 }
-                viewModel.timelineIsEmpty.value = latestStatusIDs.isEmpty && statuses.isEmpty
-                
+
+                viewModel.timelineIsEmpty.value = (latestStatusIDs.isEmpty && statuses.isEmpty) ? {
+                    switch viewModel.timelineContext {
+                    case .home:
+                        return .timeline
+                    case .public:
+                        return .timeline
+                    case .list:
+                        return .list
+                    case .hashtag:
+                        return .list
+                    }
+                }() : nil
+
                 if !isUserInitiated {
                     FeedbackGenerator.shared.generate(.impact(.light))
                 }

--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel+LoadLatestState.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel+LoadLatestState.swift
@@ -152,8 +152,9 @@ extension HomeTimelineViewModel.LoadLatestState {
 
                 if statuses.isEmpty {
                     // stop refresher if no new statuses
+                    viewModel.dataController.records = []
                     viewModel.didLoadLatest.send()
-                } else {                    
+                } else {
                     var toAdd = [MastodonFeed]()
                     
                     let last = statuses.last

--- a/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel.swift
+++ b/Mastodon/Scene/HomeTimeline/HomeTimelineViewModel.swift
@@ -43,11 +43,15 @@ final class HomeTimelineViewModel: NSObject {
             hasNewPosts.send(false)
         }
     }
+    
+    enum EmptyViewState {
+        case timeline, list
+    }
 
     weak var tableView: UITableView?
     weak var timelineMiddleLoaderTableViewCellDelegate: TimelineMiddleLoaderTableViewCellDelegate?
     
-    let timelineIsEmpty = CurrentValueSubject<Bool, Never>(false)
+    let timelineIsEmpty = CurrentValueSubject<EmptyViewState?, Never>(nil)
     let homeTimelineNeedRefresh = PassthroughSubject<Void, Never>()
     
     // output

--- a/MastodonIntent/Handler/HashtagIntentHandler.swift
+++ b/MastodonIntent/Handler/HashtagIntentHandler.swift
@@ -23,7 +23,7 @@ class HashtagIntentHandler: INExtension, HashtagIntentHandling {
                 .search(query: .init(q: searchTerm, type: .hashtags), authenticationBox: authenticationBox)
                 .value
                 .hashtags
-                .compactMap { $0.name as NSString }
+                .compactMap { "#\($0.name)" as NSString }
 
             results = searchResults
 
@@ -33,7 +33,7 @@ class HashtagIntentHandler: INExtension, HashtagIntentHandling {
                 query: Mastodon.API.Account.FollowedTagsQuery(limit: nil),
                 authenticationBox: authenticationBox)
                 .value
-                .compactMap { $0.name as NSString }
+                .compactMap { "#\($0.name)" as NSString }
 
             results = followedTags
 

--- a/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
+++ b/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
@@ -857,6 +857,10 @@ public enum L10n {
     public enum HomeTimeline {
       /// Home
       public static let title = L10n.tr("Localizable", "Scene.HomeTimeline.Title", fallback: "Home")
+      public enum EmptyState {
+        /// This list is empty
+        public static let listEmptyMessageTitle = L10n.tr("Localizable", "Scene.HomeTimeline.EmptyState.ListEmptyMessageTitle", fallback: "This list is empty")
+      }
       public enum TimelineMenu {
         /// Following
         public static let following = L10n.tr("Localizable", "Scene.HomeTimeline.TimelineMenu.Following", fallback: "Following")

--- a/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
+++ b/MastodonSDK/Sources/MastodonLocalization/Resources/Base.lproj/Localizable.strings
@@ -303,6 +303,7 @@ uploaded to Mastodon.";
 "Scene.Follower.Title" = "follower";
 "Scene.Following.Footer" = "Follows from other servers are not displayed.";
 "Scene.Following.Title" = "following";
+"Scene.HomeTimeline.EmptyState.ListEmptyMessageTitle" = "This list is empty";
 "Scene.HomeTimeline.TimelineMenu.Following" = "Following";
 "Scene.HomeTimeline.TimelineMenu.LocalCommunity" = "Local";
 "Scene.HomeTimeline.TimelineMenu.Lists.Title" = "Lists";

--- a/WidgetExtension/Variants/Hashtag/HashtagWidget.swift
+++ b/WidgetExtension/Variants/Hashtag/HashtagWidget.swift
@@ -43,7 +43,7 @@ extension HashtagWidgetProvider {
         let desiredHashtag: String
 
         if let hashtag = configuration.hashtag {
-            desiredHashtag = hashtag
+            desiredHashtag = hashtag.replacingOccurrences(of: "#", with: "")
         } else {
             return completion(.notFound("hashtag"))
         }


### PR DESCRIPTION
* Adds missing #-symbol in Hashtag Widgets and Timeline Views
* Removes activity indicator in case loading ended on timeline (e.g. when loading list contents)
* Adds different empty view for lists