### PR TITLE
Fix notification filters touches plural string

### DIFF
--- a/Mastodon/Scene/Notification/Notification Filtering/Requests/NotificationRequestTableViewCell.swift
+++ b/Mastodon/Scene/Notification/Notification Filtering/Requests/NotificationRequestTableViewCell.swift
@@ -53,7 +53,8 @@ class NotificationRequestTableViewCell: UITableViewCell {
         labelStackView.axis = .vertical
         labelStackView.alignment = .leading
         labelStackView.spacing = 4
-
+        labelStackView.isUserInteractionEnabled = false
+        
         acceptNotificationRequestButton = HighlightDimmableButton()
         acceptNotificationRequestButton.translatesAutoresizingMaskIntoConstraints = false
         acceptNotificationRequestButton.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
@@ -117,6 +118,7 @@ class NotificationRequestTableViewCell: UITableViewCell {
         avatarStackView.axis = .horizontal
         avatarStackView.alignment = .center
         avatarStackView.spacing = 12
+        avatarStackView.isUserInteractionEnabled = false
 
         contentStackView = UIStackView(arrangedSubviews: [avatarStackView, buttonStackView])
         contentStackView.translatesAutoresizingMaskIntoConstraints = false

--- a/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
+++ b/MastodonSDK/Sources/MastodonLocalization/Generated/Strings.swift
@@ -1993,7 +1993,7 @@ public enum L10n {
     public enum FilteredNotificationBanner {
       /// Plural format key: "%#@number_of_requests@"
       public static func subtitle(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "plural.filtered_notification_banner.subtitle", p1, fallback: "Plural format key: \"%#@number_of_requests@\"")
+        return L10n.tr("Localizable", "plural.filtered_notification_banner.subtitle", p1, fallback: "%ld people you may know")
       }
     }
   }


### PR DESCRIPTION
This PR fixes the following issues:

* Pluralized string on Notification Filters is not showing fallback value
* Taps on avatar or user/username labels are intercepted on notification filters list