### PR TITLE
Fix link char count (IOS-285)

### DIFF
--- a/MastodonSDK/Sources/MastodonCore/MastodonAuthentication.swift
+++ b/MastodonSDK/Sources/MastodonCore/MastodonAuthentication.swift
@@ -5,6 +5,8 @@ import CoreDataStack
 import MastodonSDK
 
 public struct MastodonAuthentication: Codable, Hashable, UserIdentifier {
+    public static let fallbackCharactersReservedPerURL = 23
+
     public enum InstanceConfiguration: Codable, Hashable {
         case v1(Mastodon.Entity.Instance)
         case v2(Mastodon.Entity.V2.Instance, TranslationLanguages)
@@ -37,6 +39,15 @@ public struct MastodonAuthentication: Codable, Hashable, UserIdentifier {
                 version = instance.version
             }
             return version?.majorServerVersion(greaterThanOrEquals: 4) ?? false // following Tags is support beginning with Mastodon v4.0.0
+        }
+        
+        public var charactersReservedPerURL: Int {
+            switch self {
+            case let .v1(instance):
+                return instance.configuration?.statuses?.charactersReservedPerURL ?? fallbackCharactersReservedPerURL
+            case let .v2(instance, _):
+                return instance.configuration?.statuses?.charactersReservedPerURL ?? fallbackCharactersReservedPerURL
+            }
         }
     }
     

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
@@ -343,7 +343,7 @@ extension ComposeContentViewModel {
                     .charactersReservedPerURL ?? MastodonAuthentication.fallbackCharactersReservedPerURL
                 return lengthWithoutLinks + (matches.count * charactersReservedPerURL)
             }
-            .receive(on: RunLoop.main)
+            .receive(on: DispatchQueue.main)
             .assign(to: &$contentWeightedLength)
         
         Publishers.CombineLatest(

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
@@ -324,6 +324,7 @@ extension ComposeContentViewModel {
         
         // bind text
         $content
+            .receive(on: DispatchQueue.global(qos: .background))
             .map { [weak self] input in
                 guard let self, let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
                     return input.count
@@ -342,6 +343,7 @@ extension ComposeContentViewModel {
                     .charactersReservedPerURL ?? MastodonAuthentication.fallbackCharactersReservedPerURL
                 return lengthWithoutLinks + (matches.count * charactersReservedPerURL)
             }
+            .receive(on: RunLoop.main)
             .assign(to: &$contentWeightedLength)
         
         Publishers.CombineLatest(

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/ComposeContentViewModel.swift
@@ -324,7 +324,24 @@ extension ComposeContentViewModel {
         
         // bind text
         $content
-            .map { $0.count }
+            .map { [weak self] input in
+                guard let self, let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+                    return input.count
+                }
+                let matches = detector.matches(in: input, options: [], range: NSRange(location: 0, length: input.count))
+                let lengthWithoutLinks = input.count - matches.map({ match in
+                    guard let range = Range(match.range, in: input) else {
+                        return 0
+                    }
+                    let url = input[range]
+                    return url.count
+                }).reduce(0, +)
+                let charactersReservedPerURL = authContext.mastodonAuthenticationBox
+                    .authentication
+                    .instanceConfiguration?
+                    .charactersReservedPerURL ?? MastodonAuthentication.fallbackCharactersReservedPerURL
+                return lengthWithoutLinks + (matches.count * charactersReservedPerURL)
+            }
             .assign(to: &$contentWeightedLength)
         
         Publishers.CombineLatest(


### PR DESCRIPTION
This PR fixes the link char count which should be static (by default 23 chars per link) rather than the length of the link itself.