### PR TITLE
Show profile view when tapped author name in home feed

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/StatusAuthorView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/StatusAuthorView.swift
@@ -128,7 +128,7 @@ extension StatusAuthorView {
 
         // avatar button
         avatarButton.addTarget(self, action: #selector(StatusAuthorView.authorAvatarButtonDidPressed(_:)), for: .touchUpInside)
-        authorNameLabel.isUserInteractionEnabled = false
+        authorNameLabel.isUserInteractionEnabled = true
         authorUsernameLabel.isUserInteractionEnabled = false
 
         // contentSensitiveeToggleButton
@@ -136,6 +136,7 @@ extension StatusAuthorView {
 
         // dateLabel
         dateLabel.isUserInteractionEnabled = false
+        self.addTapGestureToAuthorName()
     }
 }
 
@@ -215,10 +216,20 @@ extension StatusAuthorView {
         return (menu, accessibilityActions)
     }
 
+    private func addTapGestureToAuthorName() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(StatusAuthorView.authorNameDidPressed(_:)))
+        authorNameLabel.addGestureRecognizer(tapGesture)
+    }
 }
 
 extension StatusAuthorView {
     @objc private func authorAvatarButtonDidPressed(_ sender: UIButton) {
+        guard let statusView = statusView else { return }
+
+        statusView.delegate?.statusView(statusView, authorAvatarButtonDidPressed: avatarButton)
+    }
+
+    @objc private func authorNameDidPressed(_ sender: UIButton) {
         guard let statusView = statusView else { return }
 
         statusView.delegate?.statusView(statusView, authorAvatarButtonDidPressed: avatarButton)


### PR DESCRIPTION
Issue: https://github.com/mastodon/mastodon-ios/issues/1379

**Description:**
    This PR fixed issue an showing profile view when tapped author name in home feed.
    