### PR TITLE
Enable tap action to meta label(user name) in search results

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/View/Content/CondensedUserView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/CondensedUserView.swift
@@ -39,6 +39,8 @@ public class CondensedUserView: UIView {
 
         displayNameLabel = MetaLabel(style: .statusName)
         displayNameLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        displayNameLabel.translatesAutoresizingMaskIntoConstraints = false
+        displayNameLabel.isUserInteractionEnabled = false
         displayNameLabel.setContentHuggingPriority(.required, for: .horizontal)
 
         acctLabel = UILabel()


### PR DESCRIPTION
Issue: https://github.com/mastodon/mastodon-ios/issues/1390

When tap the user name in search results and search history, should display the user profile view