### PR TITLE
support for focus point in image

### DIFF
--- a/Mastodon/Protocol/Provider/DataSourceFacade+Media.swift
+++ b/Mastodon/Protocol/Provider/DataSourceFacade+Media.swift
@@ -92,8 +92,13 @@ extension DataSourceFacade {
             
             let mediaView = previewContext.mediaView
 
-            item.initialFrame = {
+            item.initialContainerFrame = {
                 let initialFrame = mediaView.superview!.convert(mediaView.frame, to: nil)
+                assert(initialFrame != .zero)
+                return initialFrame
+            }()
+            item.initialFrame = {
+                let initialFrame = mediaView.contentView().frame
                 assert(initialFrame != .zero)
                 return initialFrame
             }()

--- a/Mastodon/Scene/MediaPreview/Image/MediaPreviewImageViewController.swift
+++ b/Mastodon/Scene/MediaPreview/Image/MediaPreviewImageViewController.swift
@@ -180,7 +180,10 @@ extension MediaPreviewImageViewController {
 extension MediaPreviewImageViewController: MediaPreviewTransitionViewController {
     var mediaPreviewTransitionContext: MediaPreviewTransitionContext? {
         let imageView = previewImageView.imageView
-        let _snapshot: UIView? = imageView.snapshotView(afterScreenUpdates: false)
+        // We must hide liveTextInteraction's view from snapshot
+        previewImageView.liveTextInteraction.setSupplementaryInterfaceHidden(true, animated: false)
+        let _snapshot: UIView? = imageView.snapshotView(afterScreenUpdates: true)
+        previewImageView.liveTextInteraction.setSupplementaryInterfaceHidden(false, animated: false)
         
         guard let snapshot = _snapshot else {
             return nil

--- a/Mastodon/Scene/Transition/MediaPreview/MediaPreviewTransitionItem.swift
+++ b/Mastodon/Scene/Transition/MediaPreview/MediaPreviewTransitionItem.swift
@@ -17,7 +17,6 @@ class MediaPreviewTransitionItem: Identifiable {
     
     // source
     var image: UIImage?
-    var imageFocusPoint: CGPoint?
     var aspectRatio: CGSize?
     var initialContainerFrame: CGRect? = nil
     var initialFrame: CGRect? = nil

--- a/Mastodon/Scene/Transition/MediaPreview/MediaPreviewTransitionItem.swift
+++ b/Mastodon/Scene/Transition/MediaPreview/MediaPreviewTransitionItem.swift
@@ -17,18 +17,23 @@ class MediaPreviewTransitionItem: Identifiable {
     
     // source
     var image: UIImage?
+    var imageFocusPoint: CGPoint?
     var aspectRatio: CGSize?
+    var initialContainerFrame: CGRect? = nil
     var initialFrame: CGRect? = nil
     var sourceImageView: UIImageView?
     var sourceImageViewCornerRadius: CGFloat?
     
     // target
+    var containerTargetFrame: CGRect? = nil
     var targetFrame: CGRect? = nil
     
     // transitioning
     var transitionView: UIView?
     var snapshotRaw: UIView?
+    var containerSnapshotTransitioning: UIView?
     var snapshotTransitioning: UIView?
+    var containerTouchOffset: CGVector = CGVector.zero
     var touchOffset: CGVector = CGVector.zero
     var interactiveTransitionMaskView: UIView?
     var interactiveTransitionMaskLayer: CAShapeLayer?

--- a/Mastodon/Scene/Transition/MediaPreview/MediaPreviewableViewController.swift
+++ b/Mastodon/Scene/Transition/MediaPreview/MediaPreviewableViewController.swift
@@ -9,22 +9,50 @@ import UIKit
 
 protocol MediaPreviewableViewController: UIViewController {
     var mediaPreviewTransitionController: MediaPreviewTransitionController { get }
-    func sourceFrame(transitionItem: MediaPreviewTransitionItem, index: Int) -> CGRect?
+    func sourceFrame(transitionItem: MediaPreviewTransitionItem, index: Int) -> SourceFrameProvider?
+}
+
+struct SourceFrameProvider {
+    let containerSourceFrame: CGRect
+    let contentSourceFrame: CGRect?
 }
 
 extension MediaPreviewableViewController {
-    func sourceFrame(transitionItem: MediaPreviewTransitionItem, index: Int) -> CGRect? {
+    func sourceFrame(transitionItem: MediaPreviewTransitionItem, index: Int) -> SourceFrameProvider? {
+        var sourceFrameProvider: SourceFrameProvider?
         switch transitionItem.source {
         case .attachment(let mediaView):
-            return mediaView.superview?.convert(mediaView.frame, to: nil)
+            if let superview = mediaView.superview {
+                sourceFrameProvider = SourceFrameProvider(
+                    containerSourceFrame: superview.convert(mediaView.frame, to: nil),
+                    contentSourceFrame: mediaView.contentView().frame
+                )
+            }
         case .attachments(let mediaGridContainerView):
-            guard index < mediaGridContainerView.mediaViews.count else { return nil }
+            guard index < mediaGridContainerView.mediaViews.count else { break }
             let mediaView = mediaGridContainerView.mediaViews[index]
-            return mediaView.superview?.convert(mediaView.frame, to: nil)
+            if let superview = mediaView.superview {
+                sourceFrameProvider = SourceFrameProvider(
+                    containerSourceFrame: superview.convert(mediaView.frame, to: nil),
+                    contentSourceFrame: mediaView.contentView().frame
+                )
+            }
         case .profileAvatar(let profileHeaderView):
-            return profileHeaderView.avatarButton.superview?.convert(profileHeaderView.avatarButton.frame, to: nil)
+            if let superview = profileHeaderView.avatarButton.superview {
+                let rect = superview.convert(profileHeaderView.avatarButton.frame, to: nil)
+                sourceFrameProvider = SourceFrameProvider(
+                    containerSourceFrame: rect, contentSourceFrame: nil
+                )
+            }
         case .profileBanner(let profileHeaderView):
-            return profileHeaderView.bannerImageView.superview?.convert(profileHeaderView.bannerImageView.frame, to: nil)
+            if let superview = profileHeaderView.bannerImageView.superview {
+                let rect = superview.convert(profileHeaderView.bannerImageView.frame, to: nil)
+                sourceFrameProvider = SourceFrameProvider(
+                    containerSourceFrame: rect, contentSourceFrame: nil
+                )
+            }
         }
+
+        return sourceFrameProvider
     }
 }

--- a/MastodonSDK/Sources/MastodonCore/Extension/CoreDataStack/Attachment+Array.swift
+++ b/MastodonSDK/Sources/MastodonCore/Extension/CoreDataStack/Attachment+Array.swift
@@ -32,11 +32,17 @@ extension [Mastodon.Entity.Attachment]? {
                 durationMS = nil;
             }
 
+            let focus: CGPoint? = if let focus = media.meta?.focus {
+                CGPoint(x: focus.x, y: focus.y)
+            } else {
+                nil
+            }
+
             return MastodonAttachment(
                 id: media.id,
                 kind: kind,
                 size: CGSize(width: width, height: height),
-                focus: nil,    // TODO:
+                focus: focus,
                 blurhash: media.blurhash,
                 assetURL: media.url,
                 previewURL: media.previewURL,

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView+Configuration.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView+Configuration.swift
@@ -109,15 +109,18 @@ extension MediaView.Configuration {
         public let aspectRadio: CGSize
         public let assetURL: String?
         public let altDescription: String?
+        public let focus: CGPoint?
         
         public init(
             aspectRadio: CGSize,
             assetURL: String?,
-            altDescription: String?
+            altDescription: String?,
+            focus: CGPoint?
         ) {
             self.aspectRadio = aspectRadio
             self.assetURL = assetURL
             self.altDescription = altDescription
+            self.focus = focus
         }
     }
     
@@ -199,7 +202,8 @@ extension MediaView {
                     let info = MediaView.Configuration.ImageInfo(
                         aspectRadio: attachment.size,
                         assetURL: attachment.assetURL,
-                        altDescription: attachment.altDescription
+                        altDescription: attachment.altDescription,
+                        focus: attachment.focus
                     )
                     return .init(
                         info: .image(info: info),
@@ -277,10 +281,16 @@ extension MediaView {
                 switch attachment.attachmentKind {
                 case .image:
                     guard let aspectRatio = aspectRatio(from: attachment) else { return nil }
+                    let focus: CGPoint? = if let focus = attachment.meta?.focus {
+                        CGPoint(x: focus.x, y: focus.y)
+                    } else {
+                        nil
+                    }
                     let info = MediaView.Configuration.ImageInfo(
                         aspectRadio: aspectRatio,
                         assetURL: attachment.url,
-                        altDescription: attachment.description
+                        altDescription: attachment.description,
+                        focus: focus
                     )
                     return .init(
                         info: .image(info: info),

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -71,13 +71,9 @@ public final class MediaView: UIView {
 
     public override func layoutSubviews() {
         super.layoutSubviews()
-        
-        // According to Apple's docs, layoutSubviews calculates the constraints-based layout here.
-        // At this point, the container frame might have a size of zero.
-        // However, since we use pinToParent() to pin the container to the bounds,
-        // we can rely on the frame size of MediaView(self).
-        layoutImageUsingFocus(in: blurhashImageView, container: self)
-        layoutImageUsingFocus(in: imageView, container: self)
+
+        layoutImageUsingFocus(in: blurhashImageView, container: container.bounds)
+        layoutImageUsingFocus(in: imageView, container: container.bounds)
     }
 }
 
@@ -251,37 +247,36 @@ extension MediaView {
         overlayViewController.view.pinToParent()
     }
     
-    private func layoutImageUsingFocus(in imageView: UIImageView, container: UIView) {
+    private func layoutImageUsingFocus(in imageView: UIImageView, container: CGRect) {
         guard let configuration, case let .image(image) = configuration.info,
            let focus = image.focus, let image = imageView.image else {
-            imageView.frame = container.bounds
+            imageView.frame = container
             return
         }
 
-        let containerSize = container.bounds.size
         let imageAspect = image.size.width / image.size.height
-        let containerAspect = containerSize.width / containerSize.height
+        let containerAspect = container.size.width / container.size.height
 
         let scaledSize: CGSize = if imageAspect > containerAspect {
             CGSize(
-                width: image.size.width * containerSize.height / image.size.height,
-                height: containerSize.height
+                width: image.size.width * container.size.height / image.size.height,
+                height: container.size.height
             )
         } else {
             CGSize(
-                width: containerSize.width,
-                height: image.size.height * containerSize.width / image.size.width
+                width: container.size.width,
+                height: image.size.height * container.size.width / image.size.width
             )
         }
 
         let focusOffset = CGPoint(
             x: max(
-                min(0, (containerSize.width / 2 - scaledSize.width / 2) * (1 + focus.x)),
-                containerSize.width - scaledSize.width
+                min(0, (container.size.width / 2 - scaledSize.width / 2) * (1 + focus.x)),
+                container.size.width - scaledSize.width
             ),
             y: max(
-                min(0, (containerSize.height / 2 - scaledSize.height / 2) * (1 + focus.y)),
-                containerSize.height - scaledSize.height
+                min(0, (container.size.height / 2 - scaledSize.height / 2) * (1 + focus.y)),
+                container.size.height - scaledSize.height
             )
         )
 

--- a/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/MediaView.swift
@@ -29,7 +29,6 @@ public final class MediaView: UIView {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFill
         imageView.isUserInteractionEnabled = false
-        imageView.layer.masksToBounds = true    // clip overflow
         imageView.backgroundColor = .gray
         imageView.isOpaque = true
         return imageView
@@ -39,7 +38,6 @@ public final class MediaView: UIView {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFill
         imageView.isUserInteractionEnabled = false
-        imageView.layer.masksToBounds = true    // clip overflow
         return imageView
     }()
     
@@ -70,7 +68,17 @@ public final class MediaView: UIView {
         super.init(coder: coder)
         _init()
     }
-    
+
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        // According to Apple's docs, layoutSubviews calculates the constraints-based layout here.
+        // At this point, the container frame might have a size of zero.
+        // However, since we use pinToParent() to pin the container to the bounds,
+        // we can rely on the frame size of MediaView(self).
+        layoutImageUsingFocus(in: blurhashImageView, container: self)
+        layoutImageUsingFocus(in: imageView, container: self)
+    }
 }
 
 extension MediaView {
@@ -83,7 +91,10 @@ extension MediaView {
     public func thumbnail() -> UIImage? {
         return imageView.image ?? configuration?.previewImage
     }
-    
+
+    public func contentView() -> UIView {
+        return imageView
+    }
 }
 
 extension MediaView {
@@ -123,9 +134,9 @@ extension MediaView {
     }
     
     private func layoutImage() {
-        imageView.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(imageView)
-        imageView.pinToParent()
+        container.clipsToBounds = true
+
         layoutAlt()
     }
     
@@ -146,6 +157,7 @@ extension MediaView {
                 (previewImage ?? blurhashImage ?? MediaView.placeholderImage) :
                 (blurhashImage ?? MediaView.placeholderImage)
             self.imageView.image = image
+            self.setNeedsLayout()
         }
         .store(in: &_disposeBag)
 
@@ -201,7 +213,8 @@ extension MediaView {
         let imageInfo = Configuration.ImageInfo(
             aspectRadio: info.aspectRadio,
             assetURL: info.previewURL,
-            altDescription: info.altDescription
+            altDescription: info.altDescription,
+            focus: nil
         )
         bindImage(configuration: configuration, info: imageInfo)
     }
@@ -221,9 +234,7 @@ extension MediaView {
     }
 
     private func layoutBlurhash() {
-        blurhashImageView.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(blurhashImageView)
-        blurhashImageView.pinToParent()
     }
     
     private func bindBlurhash(configuration: Configuration) {
@@ -238,6 +249,43 @@ extension MediaView {
         overlayViewController.view.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(overlayViewController.view)
         overlayViewController.view.pinToParent()
+    }
+    
+    private func layoutImageUsingFocus(in imageView: UIImageView, container: UIView) {
+        guard let configuration, case let .image(image) = configuration.info,
+           let focus = image.focus, let image = imageView.image else {
+            imageView.frame = container.bounds
+            return
+        }
+
+        let containerSize = container.bounds.size
+        let imageAspect = image.size.width / image.size.height
+        let containerAspect = containerSize.width / containerSize.height
+
+        let scaledSize: CGSize = if imageAspect > containerAspect {
+            CGSize(
+                width: image.size.width * containerSize.height / image.size.height,
+                height: containerSize.height
+            )
+        } else {
+            CGSize(
+                width: containerSize.width,
+                height: image.size.height * containerSize.width / image.size.width
+            )
+        }
+
+        let focusOffset = CGPoint(
+            x: max(
+                min(0, (containerSize.width / 2 - scaledSize.width / 2) * (1 + focus.x)),
+                containerSize.width - scaledSize.width
+            ),
+            y: max(
+                min(0, (containerSize.height / 2 - scaledSize.height / 2) * (1 + focus.y)),
+                containerSize.height - scaledSize.height
+            )
+        )
+
+        imageView.frame = CGRect(origin: focusOffset, size: scaledSize)
     }
     
     @MainActor

--- a/MastodonSDK/Sources/MastodonUI/View/Content/NewsView+Configuration.swift
+++ b/MastodonSDK/Sources/MastodonUI/View/Content/NewsView+Configuration.swift
@@ -36,7 +36,8 @@ extension NewsView {
             info: .image(info: .init(
                 aspectRadio: CGSize(width: link.width, height: link.height),
                 assetURL: link.image,
-                altDescription: nil
+                altDescription: nil,
+                focus: nil
             )),
             blurhash: link.blurhash,
             index: 1,


### PR DESCRIPTION
Added support for focus point in image
Size and offset calc are taken from [here](https://github.com/jonom/jquery-focuspoint)

<img width="1224" alt="Screenshot 2025-01-02 at 11 38 33" src="https://github.com/user-attachments/assets/0db1153b-c4a1-4771-958d-105a5b988cb5" />



Closes https://github.com/mastodon/mastodon-ios/issues/868