### PR TITLE
Apply different cell styles for navigations/actions in About screen

### DIFF
--- a/Mastodon/Scene/Settings/About Mastodon/AboutMastodonTableViewCell.swift
+++ b/Mastodon/Scene/Settings/About Mastodon/AboutMastodonTableViewCell.swift
@@ -7,12 +7,28 @@ class AboutMastodonTableViewCell: UITableViewCell {
     static let reuseIdentifier = "AboutMastodonTableViewCell"
 
     func configure(with entry: AboutSettingsEntry) {
-        var contentConfiguration = UIListContentConfiguration.valueCell()
+        switch entry.type {
+        case .navigation:
+            var contentConfiguration = UIListContentConfiguration.cell()
 
-        contentConfiguration.text = entry.text
-        contentConfiguration.secondaryText = entry.secondaryText
-        contentConfiguration.textProperties.color = Asset.Colors.Brand.blurple.color
+            contentConfiguration.text = entry.text
+            contentConfiguration.secondaryText = entry.secondaryText
+            contentConfiguration.textProperties.color = .label
 
-        self.contentConfiguration = contentConfiguration
+            accessoryType = .disclosureIndicator
+
+            self.contentConfiguration = contentConfiguration
+
+        case .action:
+            var contentConfiguration = UIListContentConfiguration.valueCell()
+
+            contentConfiguration.text = entry.text
+            contentConfiguration.secondaryText = entry.secondaryText
+            contentConfiguration.textProperties.color = Asset.Colors.Brand.blurple.color
+
+            accessoryType = .none
+
+            self.contentConfiguration = contentConfiguration
+        }
     }
 }

--- a/Mastodon/Scene/Settings/About Mastodon/AboutSettings.swift
+++ b/Mastodon/Scene/Settings/About Mastodon/AboutSettings.swift
@@ -9,6 +9,11 @@ struct AboutSettingsSection: Hashable {
 }
 
 enum AboutSettingsEntry: Hashable {
+    enum EntryType {
+        case navigation
+        case action
+    }
+
     case evenMoreSettings
     case contributeToMastodon
     case privacyPolicy
@@ -34,6 +39,15 @@ enum AboutSettingsEntry: Hashable {
             return nil
         case .clearMediaCache(let mediaStorage):
             return AppContext.byteCountFormatter.string(fromByteCount: Int64(mediaStorage))
+        }
+    }
+
+    var type: EntryType {
+        switch self {
+        case .evenMoreSettings, .contributeToMastodon, .privacyPolicy:
+            return .navigation
+        case .clearMediaCache(_):
+            return .action
         }
     }
 }


### PR DESCRIPTION
The settings “About” screen should visually differentiate navigation cells from action cells, following Apple’s Human Interface Guidelines.

## Before/After

<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-01-26 at 17 48 37" src="https://github.com/user-attachments/assets/f88e4485-3e5a-4285-b599-74e5ca9ca470">
<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-01-26 at 18 21 33" src="https://github.com/user-attachments/assets/1b96ffa9-92c1-4559-a4df-351ca995610d">

Thank you for considering this pull request 🙌 