### PR TITLE
Fix authentication check to use identifier instead of userID

### DIFF
--- a/Mastodon/Scene/Account/AccountListViewModel.swift
+++ b/Mastodon/Scene/Account/AccountListViewModel.swift
@@ -127,7 +127,7 @@ extension AccountListViewModel {
         cell.badgeButton.setBadge(number: count)
         
         // checkmark
-        let isActive = activeAuthentication.userID == authentication.userID
+        let isActive = activeAuthentication.identifier == authentication.identifier
         cell.tintColor = .label
         cell.checkmarkImageView.isHidden = !isActive
         if isActive {


### PR DESCRIPTION
Fix for https://github.com/mastodon/mastodon-ios/issues/1413

| before | after |
| - | - |
| ![image](https://github.com/user-attachments/assets/fc67d10a-4b04-4ead-828d-20b9d2d07d74) | ![image](https://github.com/user-attachments/assets/aaefc2f1-8b56-4552-b9ce-f277bb62362e) |
