### PR TITLE
Make language variants available in language picker

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/Language.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/Language.swift
@@ -17,8 +17,8 @@ public struct Language: Identifiable {
     }
     
     init?(id: String) {
-        guard let endonym = Locale(identifier: id).localizedString(forLanguageCode: id),
-              let exonym = Locale.current.localizedString(forLanguageCode: id)
+        guard let endonym = Locale(identifier: id).localizedString(forIdentifier: id),
+              let exonym = Locale.current.localizedString(forIdentifier: id)
         else { return nil }
         self.endonym = endonym
         self.exonym = exonym

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/LanguagePicker.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/LanguagePicker.swift
@@ -51,15 +51,28 @@ public struct LanguagePicker: View {
     public static func availableLanguages() -> [Language] {
         let locales = Locale.availableIdentifiers.map(Locale.init(identifier:))
         var languages: [String: Language] = [:]
+
+        // these script and variant codes are supported by the server side and are to be kept in list
+        // see SUPPORTED_LOCALES in Mastodon source for more details
+        let variantMappings = [
+            "ms-Arab": "ms-Arab",
+            "zh_CN": "zh-CN",
+            "zh_HK": "zh-HK",
+            "zh_TW": "zh-TW",
+        ]
+
         for locale in locales {
-            if let code = locale.language.languageCode?.identifier,
-               let endonym = locale.localizedString(forLanguageCode: code),
-               let exonym = Locale.current.localizedString(forLanguageCode: code) {
-                // don’t overwrite the “base” language
-                if let lang = languages[code], !(lang.localeId ?? "").contains("_") { continue }
-                languages[code] = Language(endonym: endonym, exonym: exonym, id: code, localeId: locale.identifier)
+            let code = locale.identifier
+            if let endonym = locale.localizedString(forIdentifier: code),
+               let exonym = Locale.current.localizedString(forIdentifier: code) {
+                if let mappedCode = variantMappings[code] {
+                    languages[mappedCode] = Language(endonym: endonym, exonym: exonym, id: mappedCode, localeId: code)
+                } else if !code.contains(#/[\-_]/#) {   // otherwise, only keep the “base” language
+                    languages[code] = Language(endonym: endonym, exonym: exonym, id: code, localeId: code)
+                }
             }
         }
+
         return languages.values.sorted(using: KeyPathComparator(\.id))
     }
     


### PR DESCRIPTION
This PR fixes mastodon/mastodon#28884 by changing how `LanguagePicker` populates its list of available languages.

### What the problem is

Currently, the language picker in Mastodon iOS app builds its list of languages by looping through `Locale.availableIdentifiers`, skipping any regional variants (contains `_` in the locale identifier) and extract only the `languageCode`. This creates several problems:

1) **Languages with multiple script forms overriding each other;**
    - e.g.,`yue-Hans` incorrectly overwrites `yue`, causing Cantonese to be localized in script-specific Simplified Cantonese.
2) **Language families with variants differed enough to be supported [server-side](https://github.com/mastodon/mastodon/blob/main/app/helpers/languages_helper.rb) cannot be honored;**
    - it is impossible to pick `ms-Arab` (Arabic Malay) or `zh-TW` (Taiwanese Mandarin Chinese), for example.
3) **Incorrectly offering 121 unsupported languages;**
    - posts labeled in `ain` (Ainu language) are stripped of their language tags on server-side.
4) **Missing support for 41 languages available [on Mastodon web](https://github.com/mastodon/mastodon/blob/main/app/helpers/languages_helper.rb);**
    - these include Afar, Abkhaz, Avestan, Bislama, Scots, Southern Sami, or Kalmyk.

### What this PR does

To make changes as minimal as possible, this PR only addresses issue (1) and (2). The new iteration algorithm explicitly specifies script and regional locales to be kept and filter out all other non-“base” language variants.

### Other notes

To support (3) or (4) requires us to synchronize language lists across platforms. I’d rather avoid explicitly excluding languages as there might be future support happening on Mastodon Web; it is possible to implement (4) if we polyfill those 41 language locales though (this shall be a separate PR).