### PR TITLE
Implemented hashable properly to adhere to strict equality

### DIFF
--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Account.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Account.swift
@@ -90,19 +90,14 @@ extension Mastodon.Entity.Account: Codable {
 }
 
 //MARK: - Hashable
-extension Mastodon.Entity.Account: Hashable {
+extension Mastodon.Entity.Account: Hashable, Equatable {
     public func hash(into hasher: inout Hasher) {
-        // The URL seems to be the only thing that doesn't change across instances.
-        hasher.combine(url)
+        hasher.combine(id)
+        hasher.combine(acct)
     }
-
-}
-
-//MARK: - Equatable
-extension Mastodon.Entity.Account: Equatable {
+    
     public static func == (lhs: Mastodon.Entity.Account, rhs: Mastodon.Entity.Account) -> Bool {
-        // The URL seems to be the only thing that doesn't change across instances.
-        return lhs.url == rhs.url
+        return lhs.id == rhs.id && lhs.acct == rhs.acct
     }
 }
 


### PR DESCRIPTION
This PR is for issue1434 App crashes when user enters "oh' into search bar. The problem was with how the hashable was being implemented. It wasn't checking for strict equality between account id & account. These never change but the url could, which was causing the issue.