### PR TITLE
Fix compiling MastodonTests.swift around APIService

### DIFF
--- a/MastodonTests/MastodonTests.swift
+++ b/MastodonTests/MastodonTests.swift
@@ -11,33 +11,9 @@ import MastodonCore
 
 @MainActor
 class MastodonTests: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
-}
-
-extension MastodonTests {
     func testWebFinger() {
         let expectation = expectation(description: "webfinger")
-        let cancellable = AppContext.shared.apiService.webFinger(domain: "pawoo.net")
+        let cancellable = APIService.shared.webFinger(domain: "pawoo.net")
             .sink { completion in
                 expectation.fulfill()
             } receiveValue: { domain in


### PR DESCRIPTION
# Description

- Fix ability to compile the MastodonTests unit test target (Product > Build For > Testing ⇧⌘U)
- Remove unused example XCTestCase functions