### PR TITLE
Fix MetricFormatterTests

### DIFF
--- a/Mastodon/Mastodon.xctestplan
+++ b/Mastodon/Mastodon.xctestplan
@@ -85,11 +85,6 @@
   },
   "testTargets" : [
     {
-      "skippedTests" : [
-        "MastodonTests",
-        "MastodonTests\/testConnectOnion()",
-        "MastodonTests\/testWebFinger()"
-      ],
       "target" : {
         "containerPath" : "container:Mastodon.xcodeproj",
         "identifier" : "DB427DE725BAA00100D1B89D",

--- a/Mastodon/Mastodon.xctestplan
+++ b/Mastodon/Mastodon.xctestplan
@@ -85,6 +85,9 @@
   },
   "testTargets" : [
     {
+      "skippedTests" : [
+        "MastodonTests\/testConnectOnion()"
+      ],
       "target" : {
         "containerPath" : "container:Mastodon.xcodeproj",
         "identifier" : "DB427DE725BAA00100D1B89D",

--- a/MastodonSDK/Sources/MastodonUI/Helper/MastodonMetricFormatter.swift
+++ b/MastodonSDK/Sources/MastodonUI/Helper/MastodonMetricFormatter.swift
@@ -31,12 +31,24 @@ public final class MastodonMetricFormatter: Formatter {
     private let ten_thousands = DecimalUnit.thousand.asInt * 10
     private let ten_millions = DecimalUnit.million.asInt * 10
     
+    ///
+    private let numberFormatter = NumberFormatter()
+    
+    /// MastodonMetricFormatter first converts to decimel _then_ displays the value.
+    /// Do not assign the groupingSeparator.
+    public var abbreviatedGroupingSeparator: String {
+        get {
+            numberFormatter.decimalSeparator
+        }
+        set {
+            numberFormatter.decimalSeparator = newValue
+        }
+    }
+    
     public func string(from number: Int) -> String? {
         let isPositive = number >= 0
         let symbol = isPositive ? "" : "-"
      
-        let numberFormatter = NumberFormatter()
-
         let value = abs(number)
         let metric: String
         

--- a/MastodonSDK/Sources/MastodonUI/Helper/MastodonMetricFormatter.swift
+++ b/MastodonSDK/Sources/MastodonUI/Helper/MastodonMetricFormatter.swift
@@ -25,17 +25,18 @@ enum DecimalUnit: Int {
     }
 }
 
-
+/// Abbreviate a given number into the highest significant digits and a unit (K for thousands)
 public final class MastodonMetricFormatter: Formatter {
     
     private let ten_thousands = DecimalUnit.thousand.asInt * 10
     private let ten_millions = DecimalUnit.million.asInt * 10
     
-    ///
+    /// The number formatter instance that will be used. May be customized through ``abbreviatedGroupingSeparator``.
     private let numberFormatter = NumberFormatter()
-    
+
     /// MastodonMetricFormatter first converts to decimel _then_ displays the value.
-    /// Do not assign the groupingSeparator.
+    /// Use this instead of the NumberFormatter.groupingSeparator.
+    /// Ex: "1,5K" in the EU, and "1.5K" in the US.
     public var abbreviatedGroupingSeparator: String {
         get {
             numberFormatter.decimalSeparator
@@ -44,7 +45,7 @@ public final class MastodonMetricFormatter: Formatter {
             numberFormatter.decimalSeparator = newValue
         }
     }
-    
+
     public func string(from number: Int) -> String? {
         let isPositive = number >= 0
         let symbol = isPositive ? "" : "-"

--- a/MastodonTests/MastodonTests.swift
+++ b/MastodonTests/MastodonTests.swift
@@ -25,6 +25,7 @@ class MastodonTests: XCTestCase {
         }
     }
 
+    // TODO: Find a new reachable example onion server
     func testConnectOnion() async throws {
         let request = URLRequest(
             url: URL(string: "http://a232ncr7jexk2chvubaq2v6qdizbocllqap7mnn7w7vrdutyvu32jeyd.onion/@k0gen")!,
@@ -36,7 +37,7 @@ class MastodonTests: XCTestCase {
             print(data)
         } catch {
             debugPrint(error)
-            assertionFailure(error.localizedDescription)
+            XCTFail(error.localizedDescription)
         }
     }
 }

--- a/MastodonTests/MastodonTests.swift
+++ b/MastodonTests/MastodonTests.swift
@@ -14,10 +14,11 @@ class MastodonTests: XCTestCase {
     func testWebFinger() {
         let expectation = expectation(description: "webfinger")
         let cancellable = APIService.shared.webFinger(domain: "pawoo.net")
+            .receive(on: DispatchQueue.main)
             .sink { completion in
                 expectation.fulfill()
             } receiveValue: { domain in
-                expectation.fulfill()
+                print("\(#function) identified domain: \(domain)")
             }
         withExtendedLifetime(cancellable) {
             wait(for: [expectation], timeout: 10)

--- a/MastodonTests/MetricFormatterTests.swift
+++ b/MastodonTests/MetricFormatterTests.swift
@@ -3,8 +3,7 @@
 import XCTest
 @testable import MastodonUI
 
-class MetricFormatterTests: XCTestCase {
-    
+class MetricFormatterTests: XCTestCase {    
     func test_tensFormat() {
         let formatter = MastodonMetricFormatter()
         let value = formatter.string(from: 12)
@@ -33,15 +32,27 @@ class MetricFormatterTests: XCTestCase {
         XCTAssertEqual(value, "1K")
     }
     
-    func test_thousandNinetynineFormat() {
+    func test_thousandNinetynineFormat_EU() {
         let formatter = MastodonMetricFormatter()
+        formatter.abbreviatedGroupingSeparator = ","
         let value = formatter.string(from: 1099)
-        
+
         XCTAssertEqual(value, "1,1K")
     }
+
+    func test_thousandNinetynineFormat_US() {
+        let formatter = MastodonMetricFormatter()
+        formatter.abbreviatedGroupingSeparator = "."
+        let value = formatter.string(from: 1099)
+
+        XCTAssertEqual(value, "1.1K")
+    }
     
+    // TODO: Test US and EU formatters
+
     func test_thousandNinehundredFormat() {
         let formatter = MastodonMetricFormatter()
+        formatter.abbreviatedGroupingSeparator = ","
         let value = formatter.string(from: 1900)
         
         XCTAssertEqual(value, "1,9K")
@@ -49,6 +60,7 @@ class MetricFormatterTests: XCTestCase {
     
     func test_thousandsFormat() {
         let formatter = MastodonMetricFormatter()
+        formatter.abbreviatedGroupingSeparator = ","
         let value = formatter.string(from: 1234)
         
         XCTAssertEqual(value, "1,2K")
@@ -56,6 +68,7 @@ class MetricFormatterTests: XCTestCase {
     
     func test_sixThousandsFormat() {
         let formatter = MastodonMetricFormatter()
+        formatter.abbreviatedGroupingSeparator = ","
         let value = formatter.string(from: 6666)
         
         XCTAssertEqual(value, "6,7K")
@@ -63,6 +76,7 @@ class MetricFormatterTests: XCTestCase {
     
     func test_millionsFormat_oneTwoThreeMillion() {
         let formatter = MastodonMetricFormatter()
+        formatter.abbreviatedGroupingSeparator = ","
         let value = formatter.string(from: 1_234_567)
         
         XCTAssertEqual(value, "1,2M")

--- a/MastodonTests/MetricFormatterTests.swift
+++ b/MastodonTests/MetricFormatterTests.swift
@@ -3,7 +3,7 @@
 import XCTest
 @testable import MastodonUI
 
-class MetricFormatterTests: XCTestCase {    
+class MetricFormatterTests: XCTestCase {
     func test_tensFormat() {
         let formatter = MastodonMetricFormatter()
         let value = formatter.string(from: 12)
@@ -32,20 +32,18 @@ class MetricFormatterTests: XCTestCase {
         XCTAssertEqual(value, "1K")
     }
     
-    func test_thousandNinetynineFormat_EU() {
-        let formatter = MastodonMetricFormatter()
-        formatter.abbreviatedGroupingSeparator = ","
-        let value = formatter.string(from: 1099)
+    func test_thousandNinetynineFormat() {
+        let formatter_EU = MastodonMetricFormatter()
+        formatter_EU.abbreviatedGroupingSeparator = ","
+        let value_EU = formatter_EU.string(from: 1099)
 
-        XCTAssertEqual(value, "1,1K")
-    }
+        XCTAssertEqual(value_EU, "1,1K")
 
-    func test_thousandNinetynineFormat_US() {
-        let formatter = MastodonMetricFormatter()
-        formatter.abbreviatedGroupingSeparator = "."
-        let value = formatter.string(from: 1099)
+        let formatter_US = MastodonMetricFormatter()
+        formatter_US.abbreviatedGroupingSeparator = "."
+        let value_US = formatter_US.string(from: 1099)
 
-        XCTAssertEqual(value, "1.1K")
+        XCTAssertEqual(value_US, "1.1K")
     }
     
     // TODO: Test US and EU formatters


### PR DESCRIPTION
# Description

- `MastodonMetricFormatter` accepts a number such as 1234, and converts it to an abbreviated form: "1.2K" in the US and "1,2K" in the EU.
    - Add MastodonMetricFormatter.abbreviatedGroupingSeparator to allow changing the separator.
    - The default values of abbreviatedGroupingSeparator are: period in the US and comma in the EU.
    - Update the unit tests to explicitly assign abbreviatedGroupingSeparator = "," for EU-styled test assertions.
    - Update the `test_thousandNinetynineFormat()` test function to explicitly test abbreviatedGroupingSeparator with both EU (,) and US (.) separators.
- Fix MastodonTests.testWebFinger() to fulfill the test expectation exactly once, and on the main thread.
- Update MastodonTests.testConnectOnion() to report an XCTFail() instead of an assertion failure so that the process can exit cleanly and report the test failure instead of halting.
    - testConnectOnion is currently failing, there may be additional servers that this works with but I haven't been able to run a passing test.