### PR TITLE
Update Xcode from 16 to 26

### DIFF
--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -28,6 +28,6 @@ jobs:
           NotificationEndpointRelease: ${{ secrets.NotificationEndpointRelease }}
         run: exec ./.github/scripts/setup.sh
       - name: Select required Xcode version
-        run: sudo xcode-select -switch /Applications/Xcode_16.4.app
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app
       - name: Build App
         run: bundle exec fastlane ios build_only

--- a/.github/workflows/deploy-appstore.yml
+++ b/.github/workflows/deploy-appstore.yml
@@ -25,7 +25,7 @@ jobs:
           NotificationEndpointRelease: ${{ secrets.NotificationEndpointRelease }}
         run: exec ./.github/scripts/setup.sh
       - name: Select required Xcode version
-        run: sudo xcode-select -switch /Applications/Xcode_16.4.app
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app
       - name: Confirm Xcode and Swift versions
         run: |
           xcodebuild -version

--- a/Documentation/Setup.md
+++ b/Documentation/Setup.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- Xcode 16+
+- Xcode 26+
 - Swift 5.7+
 - iOS 17.0+
 


### PR DESCRIPTION
Xcode 26 has been available as the latest stable version for over a month. Let's keep this code base updated.

I confirm that no tests or source code changes are required. 
* I could launch `MastodonUITests/testSmoke()` successfully from Xcode. 
* `bundle exec fastlane ios build_only` is also successful: https://github.com/clarmso/mastodon-ios/actions/runs/18991315068