### PR TITLE
Update bundler version. Ensure capability with ruby 3.4+

### DIFF
--- a/Documentation/Setup.md
+++ b/Documentation/Setup.md
@@ -40,7 +40,6 @@ which ruby
 rbenv install
 
 # install gem dependencies
-gem install bundler:2.7.2
 bundle install
 ```
 

--- a/Documentation/Setup.md
+++ b/Documentation/Setup.md
@@ -40,6 +40,7 @@ which ruby
 rbenv install
 
 # install gem dependencies
+gem install bundler:2.7.2
 bundle install
 ```
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "xcpretty"
+gem "abbrev" # Required for Ruby 3.4+ compatibility
 
 # Fastlane
 gem "fastlane"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,4 +229,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   2.5.23
+   2.7.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       base64
       nkf
       rexml
+    abbrev (0.1.2)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     artifactory (3.0.17)
@@ -222,6 +223,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  abbrev
   fastlane
   fastlane-plugin-versioning
   xcpretty


### PR DESCRIPTION
Added `abbrev` because Ruby 3.4+ has removed this gem in the default installation.

`bundle` 2.5.23 does not allow me to run `bundle exec fastlane ios build_only` successfully. 2.7.2 now works for me.

Note that I'm trying to set up the development environment with macos 15 (Sequoia), Xcode 26.0.1 and ruby 3.4.7 installed.