### PR TITLE
Fix Unicode regex patterns to support international characters

### DIFF
--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Helper/MastodonRegex.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Helper/MastodonRegex.swift
@@ -11,7 +11,7 @@ public enum MastodonRegex {
     /// mention,  hashtag.
     /// @...
     /// #...
-    public static let highlightPattern = "(?:@([a-zA-Z0-9_]+)(@[a-zA-Z0-9_.-]+)?|#([^\\s.]+))"
+    public static let highlightPattern = "(?:@([\\p{L}\\p{M}\\p{N}_]+)(@[\\p{L}\\p{M}\\p{N}_.-]+)?|#([^\\s.]+))"
     /// emoji
     /// :shortcode:
     /// accept ^\B: or \s: but not accept \B: to force user input a space to make emoji take effect
@@ -21,7 +21,7 @@ public enum MastodonRegex {
     /// @…
     /// #…
     /// :…
-    public static let autoCompletePattern = "(?:@([a-zA-Z0-9_]+)(@[a-zA-Z0-9_.-]+)?|#([^\\s.]+))|(^\\B:|\\s:)([a-zA-Z0-9_]+)"
+    public static let autoCompletePattern = "(?:@([\\p{L}\\p{M}\\p{N}_]+)(@[\\p{L}\\p{M}\\p{N}_.-]+)?|#([^\\s.]+))|(^\\B:|\\s:)([a-zA-Z0-9_]+)"
 
     public enum Search {
         public static let username = "^@?[a-z0-9_-]+(@[\\S]+)?$"

--- a/MastodonTests/MastodonRegexTests.swift
+++ b/MastodonTests/MastodonRegexTests.swift
@@ -1,0 +1,180 @@
+//
+//  MastodonRegexTests.swift
+//  MastodonTests
+//
+//  Created by Assistant on 2025-11-02.
+//
+
+import XCTest
+@testable import Mastodon
+import MastodonUI
+
+final class MastodonRegexTests: XCTestCase {
+
+    func testExample() throws {
+        XCTAssertTrue(true)
+    }
+
+    func testUnicodeRegexPatterns() throws {
+        // Test that our regex patterns correctly match Unicode characters with combining marks
+        let highlightPattern = MastodonRegex.highlightPattern
+        let autoCompletePattern = MastodonRegex.autoCompletePattern
+
+        let testCases = [
+            "@café@examplë.com",
+            "@unikonstanz@bawü.social",
+            "@user@täst.de",
+            "@björn@exämple.com"
+        ]
+
+        // Test highlight pattern
+        let highlightRegex = try NSRegularExpression(pattern: highlightPattern, options: [])
+        for testCase in testCases {
+            let nsString = testCase as NSString
+            let range = NSRange(location: 0, length: nsString.length)
+            let matches = highlightRegex.matches(in: testCase, options: [], range: range)
+
+            XCTAssertEqual(matches.count, 1, "Highlight pattern should match \(testCase)")
+        }
+
+        // Test autocomplete pattern
+        let autoCompleteRegex = try NSRegularExpression(pattern: autoCompletePattern, options: [])
+        for testCase in testCases {
+            let nsString = testCase as NSString
+            let range = NSRange(location: 0, length: nsString.length)
+            let matches = autoCompleteRegex.matches(in: testCase, options: [], range: range)
+
+            XCTAssertEqual(matches.count, 1, "Autocomplete pattern should match \(testCase)")
+        }
+    }
+
+    func testHighlightPatternWithUnicodeCharacters() throws {
+        let highlightPattern = MastodonRegex.highlightPattern
+        let regex = try NSRegularExpression(pattern: highlightPattern, options: [])
+
+        // Test cases with unicode characters
+        let testCases = [
+            "@unikonstanz@bawü.social",
+            "@user@täst.de",
+            "@björn@exämple.com",
+            "@用户@example.com",
+            "@example@例え.テスト",
+            "@café@examplë.com"  // Test with combining marks
+        ]
+
+        for testCase in testCases {
+            let nsString = testCase as NSString
+            let range = NSRange(location: 0, length: nsString.length)
+            let matches = regex.matches(in: testCase, options: [], range: range)
+
+            // Should find exactly one match
+            XCTAssertEqual(matches.count, 1, "Failed to match \(testCase)")
+
+            if let match = matches.first {
+                // The full match should cover the entire string
+                XCTAssertEqual(match.range.location, 0)
+                XCTAssertEqual(match.range.length, nsString.length)
+
+                // The first capture group should be the username part
+                let usernameRange = match.range(at: 1)
+                if usernameRange.location != NSNotFound {
+                    let username = nsString.substring(with: usernameRange)
+                    XCTAssertTrue(username.count > 0, "Username capture group is empty for \(testCase)")
+                }
+
+                // The second capture group should be the domain part (if present)
+                let domainRange = match.range(at: 2)
+                if domainRange.location != NSNotFound {
+                    let domain = nsString.substring(with: domainRange)
+                    XCTAssertTrue(domain.count > 0, "Domain capture group is empty for \(testCase)")
+                }
+            }
+        }
+    }
+
+    func testAutoCompletePatternWithUnicodeCharacters() throws {
+        let autoCompletePattern = MastodonRegex.autoCompletePattern
+        let regex = try NSRegularExpression(pattern: autoCompletePattern, options: [])
+
+        // Test cases with unicode characters
+        let testCases = [
+            "@unikonstanz@bawü.social",
+            "@user@täst.de",
+            "@björn@exämple.com",
+            "@用户@example.com",
+            "@example@例え.テスト",
+            "@café@examplë.com"  // Test with combining marks
+        ]
+
+        for testCase in testCases {
+            let nsString = testCase as NSString
+            let range = NSRange(location: 0, length: nsString.length)
+            let matches = regex.matches(in: testCase, options: [], range: range)
+
+            // Should find exactly one match
+            XCTAssertEqual(matches.count, 1, "Failed to match \(testCase)")
+
+            if let match = matches.first {
+                // The full match should cover the entire string
+                XCTAssertEqual(match.range.location, 0)
+                XCTAssertEqual(match.range.length, nsString.length)
+            }
+        }
+    }
+
+    func testHighlightPatternWithAsciiCharacters() throws {
+        let highlightPattern = MastodonRegex.highlightPattern
+        let regex = try NSRegularExpression(pattern: highlightPattern, options: [])
+
+        // Test cases with ASCII characters (should still work)
+        let testCases = [
+            "@user@example.com",
+            "@test@domain.org",
+            "@simple@site.net",
+            "@café@example.com"  // Test with combining marks
+        ]
+
+        for testCase in testCases {
+            let nsString = testCase as NSString
+            let range = NSRange(location: 0, length: nsString.length)
+            let matches = regex.matches(in: testCase, options: [], range: range)
+
+            // Should find exactly one match
+            XCTAssertEqual(matches.count, 1, "Failed to match \(testCase)")
+
+            if let match = matches.first {
+                // The full match should cover the entire string
+                XCTAssertEqual(match.range.location, 0)
+                XCTAssertEqual(match.range.length, nsString.length)
+            }
+        }
+    }
+
+    func testAutoCompletePatternWithAsciiCharacters() throws {
+        let autoCompletePattern = MastodonRegex.autoCompletePattern
+        let regex = try NSRegularExpression(pattern: autoCompletePattern, options: [])
+
+        // Test cases with ASCII characters (should still work)
+        let testCases = [
+            "@user@example.com",
+            "@test@domain.org",
+            "@simple@site.net",
+            "@café@example.com"  // Test with combining marks
+        ]
+
+        for testCase in testCases {
+            let nsString = testCase as NSString
+            let range = NSRange(location: 0, length: nsString.length)
+            let matches = regex.matches(in: testCase, options: [], range: range)
+
+            // Should find exactly one match
+            XCTAssertEqual(matches.count, 1, "Failed to match \(testCase)")
+
+            if let match = matches.first {
+                // The full match should cover the entire string
+                XCTAssertEqual(match.range.location, 0)
+                XCTAssertEqual(match.range.length, nsString.length)
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Fix Unicode Regex Patterns to Support International Characters

Fixes https://github.com/mastodon/mastodon-ios/issues/1420

## Summary
- Updated MastodonRegex.swift to replace ASCII-only character classes `[a-zA-Z0-9_]` with Unicode character classes `[\\p{L}\\p{M}\\p{N}_]` in both highlightPattern and autoCompletePattern regex patterns
- This aligns with the pattern used for hashtags in https://github.com/mastodon/mastodon-ios/blob/19b6947dee375346bca042fe1c0c4404cb670efb/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Helper/MastodonRegex.swift#L31
- Added comprehensive test cases in MastodonRegexTests.swift to verify the regex patterns correctly match Unicode characters with combining marks and other international characters
- This ensures proper matching of usernames and domains with Unicode characters, such as café@examplë.com, German umlauts, Chinese characters, and Japanese characters

## Problem
The current regex patterns in MastodonRegex.swift were using ASCII-only character classes `[a-zA-Z0-9_]` which don't properly match international Unicode characters. This meant that usernames and domains containing characters with combining marks (like café or examplë.com) or other Unicode characters (like Chinese or Japanese characters) would be cut off prematurely, as these characters were not being recognized as valid parts of the username or domain.

## Solution
Updated both regex patterns to use comprehensive Unicode character classes:
- `highlightPattern`: Changed from `@([a-zA-Z0-9_]+)` to `@([\\p{L}\\p{M}\\p{N}_]+)`
- `autoCompletePattern`: Changed from `@([a-zA-Z0-9_]+)` to `@([\\p{L}\\p{M}\\p{N}_]+)`

The new character classes include:
- `\\p{L}` - Unicode letters from any language
- `\\p{M}` - Combining marks (accents, umlauts, etc.)
- `\\p{N}` - Unicode numbers
- `_` - Underscore (preserved from original pattern)

This change allows the regex to properly recognize a much broader range of characters as valid parts of usernames and domains, including but not limited to:
- Characters with combining marks: é, ë, ü, ñ, etc.
- Characters from other languages: Chinese, Japanese, Arabic, etc.
- All previously supported ASCII characters

## Tests
Added comprehensive test suite in MastodonRegexTests.swift with test cases including:
- `@café@examplë.com` (characters with combining marks)
- `@unikonstanz@bawü.social` (German umlauts)
- `@user@täst.de` (another example with umlauts)
- `@björn@exämple.com` (multiple combining marks)
- `@用户@example.com` (Chinese characters)
- `@example@例え.テスト` (Japanese characters)
- Various ASCII test cases to ensure existing functionality still works

All tests verify that the regex patterns correctly match the full username and domain, including all Unicode characters.