### PR TITLE
apply `.widgetAccentedRenderingMode(.fullColor)` to avatars

### DIFF
--- a/WidgetExtension/Variants/FollowersCount/FollowersCountWidgetView.swift
+++ b/WidgetExtension/Variants/FollowersCount/FollowersCountWidgetView.swift
@@ -41,11 +41,19 @@ struct FollowersCountWidgetView: View {
     private func viewForSmallWidgetNoChart(_ account: FollowersEntryAccountable) -> some View {
         HStack {
             VStack(alignment: .leading, spacing: 0) {
-                Image(uiImage: account.avatarImage)
-                    .resizable()
-                    .frame(width: 50, height: 50)
-                    .cornerRadius(12)
-                    .padding(.bottom, 8)
+                Group {
+                    if #available(iOS 18, *) {
+                        Image(uiImage: account.avatarImage)
+                            .resizable()
+                            .widgetAccentedRenderingMode(.fullColor)
+                    } else {
+                        Image(uiImage: account.avatarImage)
+                            .resizable()
+                    }
+                }
+                .frame(width: 50, height: 50)
+                .cornerRadius(12)
+                .padding(.bottom, 8)
 
                 Text(account.followersCount.asAbbreviatedCountString())
                     .font(.largeTitle)

--- a/WidgetExtension/Variants/FollowersCount/FollowersCountWidgetView.swift
+++ b/WidgetExtension/Variants/FollowersCount/FollowersCountWidgetView.swift
@@ -81,10 +81,18 @@ struct FollowersCountWidgetView: View {
     private func viewForSmallWidgetYesChart(_ account: FollowersEntryAccountable) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
-                Image(uiImage: account.avatarImage)
-                    .resizable()
-                    .frame(width: 23, height: 23)
-                    .cornerRadius(5)
+                Group {
+                    if #available(iOS 18, *) {
+                        Image(uiImage: account.avatarImage)
+                            .resizable()
+                            .widgetAccentedRenderingMode(.fullColor)
+                    } else {
+                        Image(uiImage: account.avatarImage)
+                            .resizable()
+                    }
+                }
+                .frame(width: 23, height: 23)
+                .cornerRadius(5)
                 VStack(alignment: .leading) {
                     Text(account.displayNameWithFallback)
                         .font(.caption)

--- a/WidgetExtension/Variants/LatestFollowers/LatestFollowersWidgetView.swift
+++ b/WidgetExtension/Variants/LatestFollowers/LatestFollowersWidgetView.swift
@@ -90,7 +90,12 @@ struct LatestFollowersWidgetView: View {
                 Text(L10n.Widget.LatestFollowers.title)
                     .font(.system(size: UIFontMetrics.default.scaledValue(for: 16)))
                 Spacer()
-                Image("BrandIconColored")
+                if #available(iOS 18, *) {
+                    Image("BrandIconColored")
+                        .widgetAccentedRenderingMode(.fullColor)
+                } else {
+                    Image("BrandIconColored")
+                }
             }
             
             ForEach(accounts, id: \.acct) { account in

--- a/WidgetExtension/Variants/LatestFollowers/LatestFollowersWidgetView.swift
+++ b/WidgetExtension/Variants/LatestFollowers/LatestFollowersWidgetView.swift
@@ -45,10 +45,18 @@ struct LatestFollowersWidgetView: View {
             
             ForEach(accounts, id: \.acct) { account in
                 HStack {
-                    Image(uiImage: account.avatarImage)
-                        .resizable()
-                        .frame(width: 32, height: 32)
-                        .cornerRadius(5)
+                    Group {
+                        if #available(iOS 18, *) {
+                            Image(uiImage: account.avatarImage)
+                                .resizable()
+                                .widgetAccentedRenderingMode(.fullColor)
+                        } else {
+                            Image(uiImage: account.avatarImage)
+                                .resizable()
+                        }
+                    }
+                    .frame(width: 32, height: 32)
+                    .cornerRadius(5)
                     VStack(alignment: .leading) {
                         
                     Text(account.displayNameWithFallback)

--- a/WidgetExtension/Variants/LatestFollowers/LatestFollowersWidgetView.swift
+++ b/WidgetExtension/Variants/LatestFollowers/LatestFollowersWidgetView.swift
@@ -95,10 +95,18 @@ struct LatestFollowersWidgetView: View {
             
             ForEach(accounts, id: \.acct) { account in
                 HStack {
-                    Image(uiImage: account.avatarImage)
-                        .resizable()
-                        .frame(width: 32, height: 32)
-                        .cornerRadius(5)
+                    Group {
+                        if #available(iOS 18, *) {
+                            Image(uiImage: account.avatarImage)
+                                .resizable()
+                                .widgetAccentedRenderingMode(.fullColor)
+                        } else {
+                            Image(uiImage: account.avatarImage)
+                                .resizable()
+                        }
+                    }
+                    .frame(width: 32, height: 32)
+                    .cornerRadius(5)
                     VStack(alignment: .leading) {
                         
                         HStack {

--- a/WidgetExtension/Variants/MultiFollowersCount/MultiFollowersCountWidgetView.swift
+++ b/WidgetExtension/Variants/MultiFollowersCount/MultiFollowersCountWidgetView.swift
@@ -33,10 +33,18 @@ struct MultiFollowersCountWidgetView: View {
         VStack(alignment: .leading, spacing: 0) {
             ForEach(accounts, id: \.acct) { account in
                 HStack {
-                    Image(uiImage: account.avatarImage)
-                        .resizable()
-                        .frame(width: 32, height: 32)
-                        .cornerRadius(5)
+                    Group {
+                        if #available(iOS 18, *) {
+                            Image(uiImage: account.avatarImage)
+                                .resizable()
+                                .widgetAccentedRenderingMode(.fullColor)
+                        } else {
+                            Image(uiImage: account.avatarImage)
+                                .resizable()
+                        }
+                    }
+                    .frame(width: 32, height: 32)
+                    .cornerRadius(5)
                     VStack(alignment: .leading) {
                         Text(account.followersCount.asAbbreviatedCountString())
                             .font(.title2)

--- a/WidgetExtension/Variants/MultiFollowersCount/MultiFollowersCountWidgetView.swift
+++ b/WidgetExtension/Variants/MultiFollowersCount/MultiFollowersCountWidgetView.swift
@@ -75,10 +75,18 @@ struct MultiFollowersCountWidgetView: View {
             ]) {
                 ForEach(accounts, id: \.acct) { account in
                     HStack {
-                        Image(uiImage: account.avatarImage)
-                            .resizable()
-                            .frame(width: 32, height: 32)
-                            .cornerRadius(5)
+                        Group {
+                            if #available(iOS 18, *) {
+                                Image(uiImage: account.avatarImage)
+                                    .resizable()
+                                    .widgetAccentedRenderingMode(.fullColor)
+                            } else {
+                                Image(uiImage: account.avatarImage)
+                                    .resizable()
+                            }
+                        }
+                        .frame(width: 32, height: 32)
+                        .cornerRadius(5)
                         VStack(alignment: .leading) {
                             Text(account.followersCount.asAbbreviatedCountString())
                                 .font(.title2)


### PR DESCRIPTION
The Pull Request’s goal is to improve readability of widgets in additional contexts.

`WidgetRenderingMode.accented`
--------------------------------

before:
<img width="1176" height="894" alt="image" src="https://github.com/user-attachments/assets/8e1d63cd-2bad-436e-b31f-785833ecce8e" />
after:
<img width="1176" height="894" alt="image" src="https://github.com/user-attachments/assets/596d1c47-8867-487c-b927-f7039a0cfe03" />