### PR TITLE
Add haptic feedback

### DIFF
--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/StatefulActionButton.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/StatefulActionButton.swift
@@ -38,14 +38,14 @@ struct StatefulCountedActionButton: View {
     private let iconFont: Font = .body
     
     var body: some View {
-        Button(action: {
+        Button {
             if type == .reply {
                 // Immediate haptic feedback on tap rather than waiting for the state changes
                 let generator = UIImpactFeedbackGenerator(style: .light)
                 generator.impactOccurred()
             }
             doAction?()
-        }) {
+        } label: {
             HStack(spacing: 4) {
                 imageComponent
                 countLabelComponent

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/StatefulActionButton.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/StatefulActionButton.swift
@@ -38,12 +38,33 @@ struct StatefulCountedActionButton: View {
     private let iconFont: Font = .body
     
     var body: some View {
-        Button(action: { doAction?() }) {
+        Button(action: {
+            if type == .reply {
+                // Immediate haptic feedback on tap rather than waiting for the state changes
+                let generator = UIImpactFeedbackGenerator(style: .light)
+                generator.impactOccurred()
+            }
+            doAction?()
+        }) {
             HStack(spacing: 4) {
                 imageComponent
                 countLabelComponent
             }
         }
+        .sensoryFeedback({ () -> SensoryFeedback in
+            switch actionState.isSelected {
+            case .isTrue:
+                switch type {
+                case .boost: return .impact(weight: .heavy)
+                case .favourite: return .impact(weight: .medium)
+                case .reply, .bookmark: return .impact(weight: .light)
+                }
+            case .isFalse:
+                return .impact(weight: .light)
+            default:
+                return .impact(weight: .light)
+            }
+        }(), trigger: actionState.isSelected)
         .buttonStyle(.borderless) // Without this, all the buttons in the row activate when one is tapped.  What a remarkably unexpected result with no documentation.
         .fontWeight(actionState.isSelected == .isTrue ? .semibold : .regular)
         .foregroundStyle(color)
@@ -100,4 +121,3 @@ struct StatefulCountedActionButton: View {
     }
 
 }
-


### PR DESCRIPTION
Enhances user experience by providing tactile responses for different button actions.

Fixes #1439 

Haptic feedback works and tested on `iPhone 15 Pro`