### PR TITLE
Add CI step to build test target Mastodon.xcodeproj unit tests

### DIFF
--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -31,3 +31,5 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app
       - name: Build App
         run: bundle exec fastlane ios build_only
+      - name: Build Tests
+        run: bundle exec fastlane ios build_tests

--- a/Mastodon.xcodeproj/xcshareddata/xcschemes/Mastodon.xcscheme
+++ b/Mastodon.xcodeproj/xcshareddata/xcschemes/Mastodon.xcscheme
@@ -32,9 +32,6 @@
             reference = "container:Mastodon/Mastodon.xctestplan"
             default = "YES">
          </TestPlanReference>
-         <TestPlanReference
-            reference = "container:AppStoreSnapshotTestPlan copy.xctestplan">
-         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -57,7 +57,7 @@ platform :ios do
   end
 
   lane :build_tests do
-    destination = "platform=iOS Simulator,name=iPhone 17 Pro"
+    destination = "platform=iOS Simulator,name=iPhone 16 Pro"
     # Mastodon iOS Tests
     scan(
       build_for_testing: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -60,6 +60,16 @@ platform :ios do
     )
   end
 
+  lane :build_tests do
+    destination = "platform=iOS Simulator,name=iPhone 17 Pro"
+    # Mastodon iOS Tests
+    scan(
+      build_for_testing: true,
+      destination: destination,
+      scheme: "Mastodon"
+    )
+  end
+
   desc " Build and deploy the App to App Store Connect & TestFlight"
   lane :deploy_appstore do
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -50,10 +50,6 @@ platform :ios do
   lane :build_only do
     xcodebuild(
       clean: true,
-      destination: "platform=iOS Simulator,name=iPhone 16 Pro",
-      scheme: "#{$appName}"
-    )
-    xcodebuild(
       build: true,
       destination: "platform=iOS Simulator,name=iPhone 16 Pro",
       scheme: "#{$appName}"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -39,6 +39,14 @@ Update devices
 
 
 
+### ios build_tests
+
+```sh
+[bundle exec] fastlane ios build_tests
+```
+
+
+
 ### ios deploy_appstore
 
 ```sh


### PR DESCRIPTION
# Description

- Add CI step to build Mastodon.xcodeproj tests to catch regressions that would block/fail-to-build unit tests.
- _does not run_ tests
- Fastlane Scan documentation https://docs.fastlane.tools/getting-started/ios/running-tests/