### PR TITLE
Update CropViewController package from 2.6.1 to 3.1.1

### DIFF
--- a/Mastodon/Scene/Profile/Header/ProfileHeaderViewController.swift
+++ b/Mastodon/Scene/Profile/Header/ProfileHeaderViewController.swift
@@ -225,10 +225,9 @@ extension ProfileHeaderViewController {
             cropController.delegate = self
             switch self.currentImageType {
             case .banner:
-                cropController.customAspectRatio = CGSize(width: 3, height: 1)
-                cropController.setAspectRatioPreset(.presetCustom, animated: true)
+                cropController.setAspectRatioPreset(CGSize(width: 3, height: 1), animated: true)
             case .avatar:
-                cropController.setAspectRatioPreset(.presetSquare, animated: true)
+                cropController.setAspectRatioPreset(CGSize(width: 1, height: 1), animated: true)
             }
             cropController.aspectRatioPickerButtonHidden = true
             cropController.aspectRatioLockEnabled = true

--- a/MastodonSDK/Package.swift
+++ b/MastodonSDK/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
         .package(url: "https://github.com/Flipboard/FLAnimatedImage.git", from: "1.0.0"),
         .package(url: "https://github.com/kean/Nuke.git", from: "10.3.1"),
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", from: "4.2.2"),
-        .package(url: "https://github.com/TimOliver/TOCropViewController.git", from: "2.6.1"),
+        .package(url: "https://github.com/TimOliver/TOCropViewController.git", from: "3.1.1"),
         .package(url: "https://github.com/mastodon/MetaTextKit.git", branch: "2.2.5-xcode16"),
         .package(url: "https://github.com/TwidereProject/TabBarPager.git", from: "0.1.0"),
         .package(url: "https://github.com/uias/Tabman", from: "2.13.0"),


### PR DESCRIPTION
# Description

- `CropViewController.customAspectRatio` is no longer available
- `CropViewController.setAspectRatioPreset(size: animated:)` now accepts CGSize
- Major changes occurred in aspect ratio usage as detailed in https://github.com/TimOliver/TOCropViewController/commit/83298c5801a81857f9711a0ed176f7ccd46b39f3
- Releases from 2.6.1 to 3.1.1 list bug fixes and other improvements https://github.com/TimOliver/TOCropViewController/releases