### PR TITLE
Fix WelcomeViewController join/pick/learn/sign-in for bold text & button shapes

### DIFF
--- a/Mastodon/Scene/Onboarding/Welcome/BorderShapeButtonConfiguration.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/BorderShapeButtonConfiguration.swift
@@ -1,0 +1,24 @@
+// Copyright © 2026 Mastodon gGmbH. All rights reserved.
+
+import UIKit
+
+extension UIButton.Configuration {
+    @discardableResult
+    mutating func welcomeBorderedShapeConfiguration() -> UIButton.Configuration {
+        background.cornerRadius = 14
+        background.strokeColor = UIColor.white.withAlphaComponent(0.6)
+        background.strokeWidth = 1
+        baseBackgroundColor = .clear
+        baseForegroundColor = .white
+        return self
+    }
+
+    @discardableResult
+    mutating func defaultWelcome() -> UIButton.Configuration {
+        let plainConfig = UIButton.Configuration.plain()
+        background = plainConfig.background
+        baseBackgroundColor = plainConfig.baseForegroundColor
+        baseForegroundColor = .white
+        return self
+    }
+}

--- a/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Mastodon/Scene/Onboarding/Welcome/WelcomeViewController.swift
@@ -65,12 +65,20 @@ final class WelcomeViewController: UIViewController {
                                                   trailing: WelcomeViewController.actionButtonPadding.right)
 
         let button = UIButton(configuration: buttonConfiguration)
-
+        // Respond to runtime Accessibility > Display & Text Size > Bold Text changes
+        button.registerForTraitChanges([UITraitLegibilityWeight.self]) { (button: UIButton, previousTraitCollection: UITraitCollection) in
+            let updatedAttributes = UIFontMetrics(forTextStyle: .headline).scaledFont(for: .systemFont(ofSize: 17, weight: .semibold))
+            if let characters = button.configuration?.attributedTitle?.characters {
+                let priorString = String(characters)
+                button.configuration?.attributedTitle = AttributedString(
+                    priorString, attributes: .init([.font: updatedAttributes])
+                )
+            }
+        }
         return button
     }()
 
     private(set) lazy var pickOtherServerButton: UIButton = {
-
         var buttonConfiguration = UIButton.Configuration.borderedTinted()
         buttonConfiguration.attributedTitle = AttributedString(
             L10n.Scene.Welcome.pickServer,
@@ -192,6 +200,8 @@ extension WelcomeViewController {
         view.overrideUserInterfaceStyle = .light
         
         setupOnboardingAppearance()
+        observeLegibilityTraitChanges()
+        observeButtonShapesNotification()
 
         view.addSubview(welcomeIllustrationView)
         welcomeIllustrationView.translatesAutoresizingMaskIntoConstraints = false
@@ -279,12 +289,6 @@ extension WelcomeViewController {
         }
     }
     
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        
-        view.layoutIfNeeded()
-    }
-    
     private var computedTopAnchorInset: CGFloat {
         (navigationController?.navigationBar.bounds.height ?? UINavigationBar().bounds.height) + Constants.topAnchorInset
     }
@@ -358,12 +362,12 @@ extension WelcomeViewController {
         guard let domain else {
             joinDefaultServerButton.configuration?.showsActivityIndicator = isLoading
             joinDefaultServerButton.isEnabled = false
-            joinDefaultServerButton.configuration?.title = nil
+            joinDefaultServerButton.configuration?.attributedTitle = nil
             return
         }
         
         if isLoading {
-            joinDefaultServerButton.configuration?.title = nil
+            joinDefaultServerButton.configuration?.attributedTitle = nil
             joinDefaultServerButton.isEnabled = false
             joinDefaultServerButton.configuration?.showsActivityIndicator = true
         } else {
@@ -402,6 +406,60 @@ extension WelcomeViewController {
     @objc
     private func dismissBarButtonItemDidPressed(_ sender: UIButton) {
         dismiss(animated: true, completion: nil)
+    }
+}
+
+// MARK: - Accessibility
+
+extension WelcomeViewController {
+    func observeLegibilityTraitChanges() {
+        joinDefaultServerButton.registerForTraitChanges([UITraitLegibilityWeight.self]) { (button: UIButton, previousTraitCollection: UITraitCollection) in
+            let updatedAttributes = UIFontMetrics(forTextStyle: .headline).scaledFont(for: .systemFont(ofSize: 17, weight: .semibold))
+            if let characters = button.configuration?.attributedTitle?.characters {
+                let priorString = String(characters)
+                button.configuration?.attributedTitle = AttributedString(
+                    priorString, attributes: .init([.font: updatedAttributes])
+                )
+            }
+        }
+
+        pickOtherServerButton.registerForTraitChanges([UITraitLegibilityWeight.self]) { (button: UIButton, previousTraitCollection: UITraitCollection) in
+            button.configuration?.attributedTitle = AttributedString(
+                L10n.Scene.Welcome.pickServer,
+                attributes: .init([.font: UIFontMetrics(forTextStyle: .headline).scaledFont(for: .systemFont(ofSize: 17, weight: .semibold))])
+            )
+        }
+
+        signInButton.registerForTraitChanges([UITraitLegibilityWeight.self]) { (button: UIButton, previousTraitCollection: UITraitCollection) in
+            button.configuration?.attributedTitle = AttributedString(
+                L10n.Scene.Welcome.logIn,
+                attributes: .init([.font: UIFontMetrics(forTextStyle: .headline).scaledFont(for: .systemFont(ofSize: 17, weight: .semibold))])
+            )
+        }
+
+        learnMoreButton.registerForTraitChanges([UITraitLegibilityWeight.self]) { (button: UIButton, previousTraitCollection: UITraitCollection) in
+            button.configuration?.attributedTitle = AttributedString(
+                L10n.Scene.Welcome.learnMore,
+                attributes: .init([.font: UIFontMetrics(forTextStyle: .headline).scaledFont(for: .systemFont(ofSize: 17, weight: .semibold))])
+            )
+        }
+    }
+
+    /// https://developer.apple.com/videos/play/wwdc2020/10020/?time=194
+    func observeButtonShapesNotification() {
+        // Make buttons more visible by using shapes.
+        // If your default design does not include button shapes, observe this notification to make visual changes.
+        NotificationCenter.default.addObserver(self, selector: #selector(updateButtonShapes), name: UIAccessibility.buttonShapesEnabledStatusDidChangeNotification, object: nil)
+    }
+
+    @objc func updateButtonShapes() {
+        if UIAccessibility.buttonShapesEnabled {
+            learnMoreButton.configuration?.welcomeBorderedShapeConfiguration()
+            signInButton.configuration?.welcomeBorderedShapeConfiguration()
+        } else {
+            learnMoreButton.configuration?.defaultWelcome()
+            signInButton.configuration?.defaultWelcome()
+        }
     }
 }
 


### PR DESCRIPTION
# Description

- Tested against iOS 26.2 and 18.6 simulators
- Without this change the iOS 26 buttons display "Join        " / "Pick another     " / "Learn     " / "Log     " when Bold Text mode
- Without this change the Button Shapes accessibility setting is ignored by "Learn More" and "Log In" buttons.
- Access WelcomeViewController when already-logged by: tap and hold on the Account tab > Tap "+ Add Account"

Implement registerForTraitChanges + buttonShapesEnabled to fix all 4 main Welcome buttons

- Join mastodon.social / joinDefaultServerButton now respects Bold Text
- Pick another server now respects Bold Text
- Learn more now respects Bold Text and Button Shapes
- Log In now respects Bold Text and Button Shapes

Remove deprecated `traitCollectionDidChange()` to fix build warning

## Screencasts with fix and screenshots without fix

| iPhone Air 26.2 simulator with fix | without fix |
| -- | -- |
| <video src="https://github.com/user-attachments/assets/ad4ef33f-3699-49bb-92c5-0b961da213ee"/> | <img width="764" height="988" alt="Screenshot 2026-01-17 at 16 47 14" src="https://github.com/user-attachments/assets/61e91f42-b7b5-4f9d-ae6b-165f6bd6c7d1" /> |

| iPad 26.2 simulator | without fix |
| -- | -- |
| <video src="https://github.com/user-attachments/assets/1fd1b65b-b03f-4d9e-8efb-329c57754a92"/> | <img width="1183" height="875" alt="Screenshot 2026-01-17 at 16 45 56" src="https://github.com/user-attachments/assets/d1f17994-b655-45a2-a154-31ed1c3c507f" /> |


## iOS 18.6 Simulator

Note that iOS 18.6 does not have the truncation bug.

| iPad 18.6 simulator with fix | without fix |
| -- | -- |
| <img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2026-01-17 at 19 11 12" src="https://github.com/user-attachments/assets/b0003999-092c-41a5-8916-8b0609d19574" /> | <img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2026-01-17 at 19 13 30" src="https://github.com/user-attachments/assets/01753c86-6ad6-434e-940d-a52c0f28c038" /> |

| iOS 18.6 simulator with fix | without fix |
| -- | -- |
| <img width="750" height="991" alt="Screenshot 2026-01-17 at 19 09 04" src="https://github.com/user-attachments/assets/d0100a1a-501e-40d3-ba98-30bdadf55fba" /> | <img width="700" height="924" alt="Screenshot 2026-01-17 at 19 17 17" src="https://github.com/user-attachments/assets/17bf2227-3d6c-40d0-9599-a8815023cc16" /> |
