### PR TITLE
Fix UITraitCollection build warnings: Round 2

### DIFF
--- a/Mastodon/Scene/Account/View/BadgeButton.swift
+++ b/Mastodon/Scene/Account/View/BadgeButton.swift
@@ -30,12 +30,6 @@ extension BadgeButton {
         setAppearance()
     }
     
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        
-        setAppearance()
-    }
-    
     override func layoutSubviews() {
         super.layoutSubviews()
         

--- a/Mastodon/Scene/Compose/CollectionViewCell/ComposeStatusPollOptionCollectionViewCell.swift
+++ b/Mastodon/Scene/Compose/CollectionViewCell/ComposeStatusPollOptionCollectionViewCell.swift
@@ -114,13 +114,6 @@ extension ComposeStatusPollOptionCollectionViewCell {
         pollOptionView.checkmarkBackgroundView.layer.borderColor = SystemTheme.tableViewCellSelectionBackgroundColor.withAlphaComponent(0.3).cgColor
         pollOptionView.checkmarkBackgroundView.layer.borderWidth = 1
     }
-    
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        
-        setupBorderColor()
-    }
-    
 }
 
 extension ComposeStatusPollOptionCollectionViewCell {

--- a/Mastodon/Scene/MediaPreview/AltTextViewController.swift
+++ b/Mastodon/Scene/MediaPreview/AltTextViewController.swift
@@ -21,7 +21,7 @@ class AltTextViewController: UIViewController {
         textView.textContainerInset = UIEdgeInsets(top: 12, left: 8, bottom: 8, right: 8)
         textView.contentInsetAdjustmentBehavior = .always
         textView.verticalScrollIndicatorInsets.bottom = 4
-
+        textView.adjustsFontForContentSizeCategory = true
         return textView
     }()
 
@@ -64,11 +64,6 @@ class AltTextViewController: UIViewController {
                 height: size.height + 12 + (textView.textContainer.lineFragmentPadding) * 2
             )
         }
-    }
-    
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        textView.font = .preferredFont(forTextStyle: .callout)
     }
 }
 

--- a/Mastodon/Scene/Onboarding/ConfirmEmail/MastodonConfirmEmailViewController.swift
+++ b/Mastodon/Scene/Onboarding/ConfirmEmail/MastodonConfirmEmailViewController.swift
@@ -64,9 +64,9 @@ final class MastodonConfirmEmailViewController: UIViewController {
 extension MastodonConfirmEmailViewController {
 
     override func viewDidLoad() {
-
         setupOnboardingAppearance()
         configureMargin()
+        registerForTraitChanges([UITraitHorizontalSizeClass.self], action: #selector(configureMargin))
 
         subtitleLabel.text = L10n.Scene.ConfirmEmail.tapTheLinkWeEmailedToYouToVerifyYourAccount(viewModel.email)
 
@@ -135,12 +135,6 @@ extension MastodonConfirmEmailViewController {
         
         title = L10n.Scene.ConfirmEmail.title
     }
-    
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        
-        configureMargin()
-    }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
@@ -188,7 +182,7 @@ extension MastodonConfirmEmailViewController {
 }
 
 extension MastodonConfirmEmailViewController {
-    private func configureMargin() {
+    @objc func configureMargin() {
         switch traitCollection.horizontalSizeClass {
         case .regular:
             let margin = MastodonConfirmEmailViewController.viewEdgeMargin

--- a/Mastodon/Scene/Share/View/TableviewCell/ThreadReplyLoaderTableViewCell.swift
+++ b/Mastodon/Scene/Share/View/TableviewCell/ThreadReplyLoaderTableViewCell.swift
@@ -48,13 +48,6 @@ final class ThreadReplyLoaderTableViewCell: UITableViewCell {
         super.init(coder: coder)
         _init()
     }
-    
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        
-        resetSeparatorLineLayout()
-    }
-
 }
 
 extension ThreadReplyLoaderTableViewCell {
@@ -83,13 +76,14 @@ extension ThreadReplyLoaderTableViewCell {
             separatorLine.heightAnchor.constraint(equalToConstant: UIView.separatorLineHeight(of: contentView)),
         ])
         resetSeparatorLineLayout()
-        
+        registerForTraitChanges([UITraitHorizontalSizeClass.self, UITraitUserInterfaceIdiom.self], action: #selector(resetSeparatorLineLayout))
+
         loadMoreButton.addTarget(self, action: #selector(ThreadReplyLoaderTableViewCell.loadMoreButtonDidPressed(_:)), for: .touchUpInside)
 
         backgroundColor = .systemGroupedBackground
     }
     
-    private func resetSeparatorLineLayout() {
+    @objc func resetSeparatorLineLayout() {
         separatorLineToEdgeLeadingLayoutConstraint.isActive = false
         separatorLineToEdgeTrailingLayoutConstraint.isActive = false
         separatorLineToMarginLeadingLayoutConstraint.isActive = false


### PR DESCRIPTION
- Resolve 5 UITraitCollection warnings
##### traitCollectionDidChange

> iOS 8.0–17.0 Deprecated
> In Swift, use [registerForTraitChanges(_:handler:)](https://developer.apple.com/documentation/uikit/uitraitchangeobservable-67e94/registerfortraitchanges(_:handler:)) or [registerForTraitChanges(_:target:action:)](https://developer.apple.com/documentation/uikit/uitraitchangeobservable-67e94/registerfortraitchanges(_:target:action:)) instead. In Objective-C, use [registerForTraitChanges:withHandler:](https://developer.apple.com/documentation/uikit/uitraitchangeobservable-7qoet/registerfortraitchanges:withhandler:) or [registerForTraitChanges:withTarget:action:](https://developer.apple.com/documentation/uikit/uitraitchangeobservable-7qoet/registerfortraitchanges:withtarget:action:) instead.
— https://developer.apple.com/documentation/uikit/uitraitenvironment/traitcollectiondidchange(_:)

## Changes

- Remove trait collection from BadgeButton because no changes rely on trait sources, color already handles light/dark mode
- Remove trait collection from ComposeStatusPollOptionCollectionViewCell because no changes rely on trait sources, color already handles light/dark mode
- Replace trait collection with UITextView.adjustsFontForContentSizeCategory on AltTextViewController
    - Provides the same functionality automatically
    - Tap a post with alt-text media attached, tap the media to view it full-screen, tap the (ALT) button to see AltTextViewController
    - See: https://developer.apple.com/documentation/uikit/scaling-fonts-automatically
- Use modern registerForTraitChanges in MastodonConfirmEmailViewController 
    - Only horizontal size class is queries so we can register UITraitHorizontalSizeClass alone
- Use modern registerForTraitChanges in ThreadReplyLoaderTableViewCell
