### PR TITLE
feat: improve OAuth compatibility with non-Mastodon servers

### DIFF
--- a/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+OAuth.swift
+++ b/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+OAuth.swift
@@ -182,7 +182,7 @@ extension Mastodon.API.OAuth {
         
     }
     
-    public struct AccessTokenQuery: Codable, PostQuery {
+    public struct AccessTokenQuery: PostQuery {
         public init(
             clientID: String,
             clientSecret: String,

--- a/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+OAuth.swift
+++ b/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+OAuth.swift
@@ -208,19 +208,19 @@ extension Mastodon.API.OAuth {
         public let grantType: String
         
         var contentType: String? {
-            return Self.multipartContentType()
+            return Self.formEncodedContentType()
         }
         var body: Data? {
-            var data = Data()
-            
-            data.append(Data.multipart(key: "client_id", value: clientID))
-            data.append(Data.multipart(key: "client_secret", value: clientSecret))
-            data.append(Data.multipart(key: "redirect_uri", value: redirectURI))
-            scope.flatMap { data.append(Data.multipart(key: "scope", value: $0)) }
-            code.flatMap { data.append(Data.multipart(key: "code", value: $0)) }
-            data.append(Data.multipart(key: "grant_type", value: grantType))
-            data.append(Data.multipartEnd())
-            return data
+            var components = URLComponents()
+            var items: [URLQueryItem] = []
+            items.append(URLQueryItem(name: "client_id", value: clientID))
+            items.append(URLQueryItem(name: "client_secret", value: clientSecret))
+            items.append(URLQueryItem(name: "redirect_uri", value: redirectURI))
+            scope.flatMap { items.append(URLQueryItem(name: "scope", value: $0)) }
+            code.flatMap { items.append(URLQueryItem(name: "code", value: $0)) }
+            items.append(URLQueryItem(name: "grant_type", value: grantType))
+            components.queryItems = items
+            return components.url?.query(percentEncoded: true)?.data(using: .utf8)
         }
     }
 

--- a/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+OAuth.swift
+++ b/MastodonSDK/Sources/MastodonSDK/API/Mastodon+API+OAuth.swift
@@ -206,15 +206,21 @@ extension Mastodon.API.OAuth {
         public let scope: String?
         public let code: String?
         public let grantType: String
-
-        enum CodingKeys: String, CodingKey {
-            case clientID = "client_id"
-            case clientSecret = "client_secret"
-            case redirectURI = "redirect_uri"
-            case scope
-            case code
-            case grantType = "grant_type"
+        
+        var contentType: String? {
+            return Self.multipartContentType()
+        }
+        var body: Data? {
+            var data = Data()
             
+            data.append(Data.multipart(key: "client_id", value: clientID))
+            data.append(Data.multipart(key: "client_secret", value: clientSecret))
+            data.append(Data.multipart(key: "redirect_uri", value: redirectURI))
+            scope.flatMap { data.append(Data.multipart(key: "scope", value: $0)) }
+            code.flatMap { data.append(Data.multipart(key: "code", value: $0)) }
+            data.append(Data.multipart(key: "grant_type", value: grantType))
+            data.append(Data.multipartEnd())
+            return data
         }
     }
 

--- a/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Token.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Entity/Mastodon+Entity+Token.swift
@@ -21,7 +21,7 @@ extension Mastodon.Entity {
         public let accessToken: String
         public let tokenType: String
         public let scope: String
-        public let createdAt: Date
+        public let createdAt: Date?
 
         public init(accessToken: String, tokenType: String, scope: String, createdAt: Date) {
             self.accessToken = accessToken

--- a/MastodonSDK/Sources/MastodonSDK/Query/Query.swift
+++ b/MastodonSDK/Sources/MastodonSDK/Query/Query.swift
@@ -22,6 +22,9 @@ extension RequestQuery {
     static func multipartContentType(boundary: String = Multipart.boundary) -> String {
         return "multipart/form-data; charset=utf-8; boundary=\"\(boundary)\""
     }
+    static func formEncodedContentType() -> String {
+        return "application/x-www-form-urlencoded"
+    }
 }
 
 // An `Encodable` query provides its body by encoding itself


### PR DESCRIPTION
Refactor AccessTokenQuery to use multipart/form-data for OAuth POST requests, enhancing compatibility with servers expecting this format. Additionally, make the `createdAt` field in the Token entity optional to accommodate instances where this information is unavailable.