### PR TITLE
New profile editing view

### DIFF
--- a/Mastodon.xcodeproj/project.pbxproj
+++ b/Mastodon.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 				"Common Components/Views/MastodonTimelineOverlayView/BoostOrQuoteDialog.swift",
 				"Common Components/Views/MastodonTimelineOverlayView/ZoomableBlurhashImageView.swift",
 				"Common Components/Views/MetaTextInputField.swift",
+				"Common Components/Views/PhotoCropperView.swift",
 				"Common Components/Views/StatefulActionButton.swift",
 				"Common Components/Views/TextViewWithCustomEmoji.swift",
 				"Common Components/Views/TimelineRowViews/AccountRowView.swift",

--- a/Mastodon.xcodeproj/project.pbxproj
+++ b/Mastodon.xcodeproj/project.pbxproj
@@ -431,6 +431,7 @@
 				Notifications/NotificationInfo.swift,
 				Notifications/NotificationsCacheManager.swift,
 				Profile/NestedScrollViews.swift,
+				Profile/ProfileEditingView.swift,
 				Profile/ProfileView.swift,
 				Timeline/CentralPostViewModelCache.swift,
 				Timeline/PrecalculatedRowHeights.swift,

--- a/Mastodon/Coordinator/SceneCoordinator.swift
+++ b/Mastodon/Coordinator/SceneCoordinator.swift
@@ -452,13 +452,18 @@ private extension SceneCoordinator {
                 if UserDefaults.standard.useBetaProfileView {
                     let controller = ProfileHostingViewController(wrapInNavigationController: false)
                     let account = MastodonAccount.fromEntity(profileType.accountToDisplay)
-                    controller.set(account: account, relationship: .isNotMe(nil))
-                    Task {
-                        let relationshipFetchID = profileType.accountToDisplay.id
-                        if let authBox = AuthenticationServiceProvider.shared.currentActiveUser.value {
-                            Task {
-                                guard let relationship = try await APIService.shared.relationship(forAccountIds: [relationshipFetchID], authenticationBox: authBox).value.first else { return }
-                                controller.set(account: account, relationship: .isNotMe(MastodonAccount.RelationshipInfo(relationship, fetchedAt: .now)))
+                    if account.globallyUniqueUserIdentifier == AuthenticationServiceProvider.shared.currentActiveUser.value?.globallyUniqueUserIdentifier {
+                        controller.set(account: account, relationship: .isMe)
+                    } else {
+                        controller.set(account: account, relationship: .isNotMe(nil))
+                        
+                        Task {
+                            let relationshipFetchID = profileType.accountToDisplay.id
+                            if let authBox = AuthenticationServiceProvider.shared.currentActiveUser.value {
+                                Task {
+                                    guard let relationship = try await APIService.shared.relationship(forAccountIds: [relationshipFetchID], authenticationBox: authBox).value.first else { return }
+                                    controller.set(account: account, relationship: .isNotMe(MastodonAccount.RelationshipInfo(relationship, fetchedAt: .now)))
+                                }
                             }
                         }
                     }

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/AlignmentGuides.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/AlignmentGuides.swift
@@ -45,3 +45,7 @@ extension HorizontalAlignment {
     
     static let gutterAlign = HorizontalAlignment(GutterAlign.self)
 }
+
+extension Color {
+    static var dimmingBackground = Color.black.opacity(0.6)
+}

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/GlassEffectIfAvailable.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/GlassEffectIfAvailable.swift
@@ -4,12 +4,12 @@ import SwiftUI
 
 struct GlassEffectIfAvailable: ViewModifier {
     
-    //let shape: any Shape
+    let shape: any Shape
     
     func body(content: Content) -> some View {
         if #available(iOS 26.0, *) {
             content
-                .glassEffect(.clear.interactive())
+                .glassEffect(.clear.interactive(), in: shape)
         } else {
             content
         }
@@ -17,9 +17,52 @@ struct GlassEffectIfAvailable: ViewModifier {
 }
 
 extension View {
-    func glassEffectIfAvailable() -> some View {
+    func glassEffectIfAvailable(in shape: any Shape) -> some View {
         modifier (
-            GlassEffectIfAvailable()
+            GlassEffectIfAvailable(shape: shape)
+        )
+    }
+}
+
+struct GlassButtonStyleIfAvailable: ViewModifier {
+    let prominent: Bool
+    
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            if prominent {
+                content
+                    .buttonStyle(.glassProminent)
+            } else {
+                content
+                    .buttonStyle(.glass)
+            }
+        } else {
+            content
+                .buttonStyle(.borderedProminent)
+        }
+    }
+}
+
+extension View {
+    func glassButtonStyleIfAvailable(prominent: Bool) -> some View {
+        modifier (
+            GlassButtonStyleIfAvailable(prominent: prominent)
+        )
+    }
+}
+
+struct TintedBlurBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(.ultraThinMaterial)
+            .environment(\.colorScheme, .dark)
+    }
+}
+
+extension View {
+    func tintedBlurBackground() -> some View {
+        modifier (
+            TintedBlurBackground()
         )
     }
 }

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/MetaTextInputField.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/MetaTextInputField.swift
@@ -9,12 +9,14 @@ import MetaTextKit
 import MastodonMeta
 import SDWebImageSwiftUI
 import MastodonAsset
+import Combine
 
 @MainActor
 @Observable public class MetaTextInputFieldViewModel: NSObject /* for conformance to UITextViewDelegate */ {
     
     var authenticationBox: MastodonAuthenticationBox? // required for custom emojis
-    public var autoCompleteInfo: AutoCompleteInfo?
+    public var isEditing: Bool = false
+    private var autoCompleteSuggestionViewModel: AutoCompleteSuggestionViewModel?
     
     public var stringContent: String {
         didSet {
@@ -48,41 +50,84 @@ import MastodonAsset
     let characterLimit: CharacterLimit
     public private(set) var characterCount: Int = 0
     
+    func setMetaContent(_ content: MetaContent) {
+        contentMetaText?.configure(content: content)
+    }
+    
     // emoji
     var isEmojiActive = false
     let customEmojiPickerInputViewModel: CustomEmojiPickerInputViewModel
     let autoCompleteViewModel: AutoCompleteViewModel?
     var isLoadingCustomEmoji = false
     
-    public init(stringContent: String?, placeholder: String, characterLimit: CharacterLimit) {
+    public init(stringContent: String?, placeholder: String, characterLimit: CharacterLimit, autocompleteMastodonItems: Bool) {
         self.stringContent = stringContent ?? ""
         self.placeholder = placeholder
         self.characterLimit = characterLimit
         customEmojiPickerInputViewModel = CustomEmojiPickerInputViewModel()
         
-        if let authentication = AuthenticationServiceProvider.shared.currentActiveUser.value?.authentication {
-            let authBox = MastodonAuthenticationBox(authentication: authentication)
-            self.authenticationBox = authBox
-            autoCompleteViewModel = AutoCompleteViewModel(authenticationBox: authBox)
-        } else {
+        guard autocompleteMastodonItems, let authentication = AuthenticationServiceProvider.shared.currentActiveUser.value?.authentication else {
             autoCompleteViewModel = nil
+            autoCompleteSuggestionViewModel = nil
+            return
         }
+
+        let authBox = MastodonAuthenticationBox(authentication: authentication)
+        self.authenticationBox = authBox
+        autoCompleteViewModel = AutoCompleteViewModel(authenticationBox: authBox)
+        autoCompleteSuggestionViewModel = AutoCompleteSuggestionViewModel(autoCompleteViewModel)
     }
     
-    @ViewBuilder public func autoCompleteSuggestionView(pinToTopOfKeyboard: Bool) -> some View {
-        if let autoCompleteItems = autoCompleteViewModel?.autoCompleteItems.value, !autoCompleteItems.isEmpty {
+    @ViewBuilder func autoCompleteSuggestionView(pinToTopOfKeyboard: Bool) -> some View {
+        if let autoCompleteSuggestionViewModel {
+            AutoCompleteSuggestionView(pinToTopOfKeyboard: pinToTopOfKeyboard) { [weak self] item in
+                self?.didSelectAutocomplete(item: item)
+            }
+            .environment(autoCompleteSuggestionViewModel)
+        }
+    }
+}
+
+@MainActor
+@Observable class AutoCompleteSuggestionViewModel {
+    private var autoCompleteSuggestionsSubscription: AnyCancellable?
+    private var autoCompleteViewModel: AutoCompleteViewModel?
+    public var autoCompleteSuggestions: [AutoCompleteItem] = []
+    var autoCompleteInfo: MetaTextInputFieldViewModel.AutoCompleteInfo?
+    
+    init(_ viewModel: AutoCompleteViewModel?) {
+        autoCompleteViewModel = viewModel
+        subscribeToAutoComplete()
+    }
+    
+    func subscribeToAutoComplete() {
+        autoCompleteSuggestionsSubscription = autoCompleteViewModel?.autoCompleteItems
+            .sink(receiveValue: { [weak self] items in
+                self?.autoCompleteSuggestions = items
+            })
+    }
+}
+ 
+struct AutoCompleteSuggestionView: View {
+    let pinToTopOfKeyboard: Bool
+    @Environment(AutoCompleteSuggestionViewModel.self) var autoCompleteViewModel
+    let didSelectAutoCompleteItem: (AutoCompleteItem)->()
+    
+    var body: some View {
+        let autoCompleteItems = autoCompleteViewModel.autoCompleteSuggestions
+        if !autoCompleteItems.isEmpty {
             VStack(spacing: tinySpacing) {
                 if pinToTopOfKeyboard {
-                        Spacer()
-                            .frame(maxHeight: .infinity)
-                        Divider()
+                    Spacer()
+                        .frame(maxHeight: .infinity)
+                    Divider()
                 }
                 ScrollView(.horizontal) {
                     HStack {
                         ForEach(autoCompleteItems, id: \.self) { item in
                             AutoCompleteCard(item: item)
                                 .onTapGesture {
-                                    self.didSelectAutocomplete(item: item)
+                                    self.didSelectAutoCompleteItem(item)
                                 }
                         }
                     }
@@ -98,6 +143,9 @@ import MastodonAsset
 }
 
 extension MetaTextInputFieldViewModel: UITextViewDelegate {
+    public func textViewDidBeginEditing(_ textView: UITextView) {
+        isEditing = true
+    }
     
     public func textViewDidChange(_ textView: UITextView) {
         // update model
@@ -109,8 +157,12 @@ extension MetaTextInputFieldViewModel: UITextViewDelegate {
         setupAutoComplete(for: textView)
     }
     
+    public func textViewDidEndEditing(_ textView: UITextView) {
+       isEditing = false
+    }
+    
     public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        if text == " ", let autoCompleteInfo = self.autoCompleteInfo {
+        if text == " ", let autoCompleteInfo = self.autoCompleteSuggestionViewModel?.autoCompleteInfo {
             let isHandled = handleAutoComplete(autoCompleteInfo)
             return !isHandled
         }
@@ -142,15 +194,15 @@ extension MetaTextInputFieldViewModel: MetaTextDelegate {
 
 extension MetaTextInputFieldViewModel {
     private func setupAutoComplete(for textView: UITextView) {
-        guard var autoCompletion = MetaTextInputFieldViewModel.scanAutoCompleteInfo(textView: textView) else {
+        guard let autoCompletion = MetaTextInputFieldViewModel.scanAutoCompleteInfo(textView: textView) else {
             autoCompleteViewModel?.inputText.send("")
-            self.autoCompleteInfo = nil
+            self.autoCompleteSuggestionViewModel?.autoCompleteInfo = nil
             return
         }
         
         autoCompleteViewModel?.inputText.send(String(autoCompletion.inputText))
         
-        autoCompleteInfo = autoCompletion
+        autoCompleteSuggestionViewModel?.autoCompleteInfo = autoCompletion
     }
     
     private static func scanAutoCompleteInfo(textView: UITextView) -> AutoCompleteInfo? {
@@ -264,7 +316,7 @@ extension MetaTextInputFieldViewModel {
         
         let range = NSRange(info.toHighlightEndRange, in: currentText)
         metaText.textStorage.replaceCharacters(in: range, with: replacedText)
-        autoCompleteInfo = nil
+        autoCompleteSuggestionViewModel?.autoCompleteInfo = nil
         
         // set selected range
         let newRange = NSRange(location: range.location + (replacedText as NSString).length, length: 0)
@@ -280,7 +332,7 @@ extension MetaTextInputFieldViewModel {
     }
     
     func didSelectAutocomplete(item: AutoCompleteItem) {
-        guard let info = autoCompleteInfo else { return }
+        guard let info = autoCompleteSuggestionViewModel?.autoCompleteInfo else { return }
         let _ = applyAutoComplete(info, item: item, skipHashtags: false)
     }
 }

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/MetaTextInputField.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/MetaTextInputField.swift
@@ -339,7 +339,7 @@ struct AutoCompleteCard: View {
         HStack {
             switch item {
             case .account(let account):
-                AvatarView(size: .small, authorAvatarUrl: account.avatarImageURL(), goToProfile: nil)
+                AvatarView(size: .small, avatarSource: .url(account.avatarImageURL()), goToProfile: nil)
                 Text("@\(account.acct)")
                     .foregroundColor(Asset.Colors.accent.swiftUIColor)
                     .font(.subheadline)

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/MetaTextInputField.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/MetaTextInputField.swift
@@ -341,10 +341,12 @@ extension MetaTextInputFieldViewModel {
 
 public struct MetaTextInputField: View {
     @Environment(MetaTextInputFieldViewModel.self) var viewModel
+    let allowScroll: Bool
     let margin: CGFloat = 8
     let autoCompleteHeight: CGFloat = 60
     
-    public init() {
+    public init(allowScroll: Bool) {
+        self.allowScroll = allowScroll
     }
     
     public var body: some View {
@@ -356,6 +358,7 @@ public struct MetaTextInputField: View {
                         set: { newValue in viewModel.stringContent = newValue }
                     ),
                     width: geo.size.width - margin - margin,
+                    allowScroll: allowScroll,
                     configurationHandler: { metaText in
                         viewModel.contentMetaText = metaText
                         metaText.textView.attributedPlaceholder = {
@@ -371,8 +374,8 @@ public struct MetaTextInputField: View {
                         metaText.delegate = viewModel
                     }
                 )
-                .frame(width: geo.size.width - margin - margin)
                 .padding(.horizontal, margin)
+                .frame(width: geo.size.width, height: geo.size.height)
                 .background(
                     MastodonSecondaryBackground(fillInDarkModeOnly: true)
                 )

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/MetaTextInputField.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/MetaTextInputField.swift
@@ -16,6 +16,7 @@ import Combine
     
     var authenticationBox: MastodonAuthenticationBox? // required for custom emojis
     public var isEditing: Bool = false
+    public var contentDidChange: (()->())?
     private var autoCompleteSuggestionViewModel: AutoCompleteSuggestionViewModel?
     
     public var stringContent: String {
@@ -162,6 +163,7 @@ extension MetaTextInputFieldViewModel: UITextViewDelegate {
     }
     
     public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        defer { contentDidChange?() }
         if text == " ", let autoCompleteInfo = self.autoCompleteSuggestionViewModel?.autoCompleteInfo {
             let isHandled = handleAutoComplete(autoCompleteInfo)
             return !isHandled

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PhotoCropperView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PhotoCropperView.swift
@@ -1,0 +1,201 @@
+// Copyright © 2026 Mastodon gGmbH. All rights reserved.
+
+import PhotosUI
+import SwiftUI
+
+struct PhotoCropperView: View {
+    public let originalImage: UIImage
+    public let completion: (UIImage?)->()
+    
+    @State var croppedImage: Image?
+    
+    public init(originalImage: UIImage, completion: @escaping (UIImage?) -> Void) {
+        self.originalImage = originalImage
+        self.completion = completion
+    }
+    
+    private let cropSize = CGSize(width: 250, height: 250)
+    
+    private let maxScale: CGFloat = 4
+    private var minScale: CGFloat = 1
+    @State private var geoSize: CGSize = .zero
+    
+    @State private var scale: CGFloat = 1
+    @State private var offset: CGSize = .zero
+    
+    @GestureState private var currentGestureScale: CGFloat = 1
+    @GestureState private var currentGestureOffset: CGSize = .zero
+    
+    var liveUpdateOffset: CGSize {
+        let proposed = CGSize(
+            width: offset.width + currentGestureOffset.width,
+            height: offset.height + currentGestureOffset.height
+        )
+        return clampOffset(proposed)
+    }
+    
+    var liveUpdateScale: CGFloat {
+        let proposed = scale * currentGestureScale
+        return clampZoom(proposed)
+    }
+    
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: Alignment(horizontal: .trailing, vertical: .top)) {
+                ZStack {
+                    let baseSize = baseSize()
+                    Image(uiImage: originalImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: baseSize.width, height: baseSize.height)
+                        .scaleEffect(liveUpdateScale, anchor: .center)
+                        .offset(
+                            liveUpdateOffset
+                        )
+                    mask()
+                        .frame(width: geo.size.width, height: geo.size.height)
+                }
+                
+                HStack {
+                    if let croppedImage {
+                        croppedImage
+                            .resizable()
+                            .frame(width: 100, height: 100)
+                    }
+                    Button() {
+#if DEBUG && false
+                        if let cropped = getCroppedImage() {
+                            croppedImage = Image(uiImage: cropped)
+                        }
+#else
+                        completion(getCroppedImage())
+#endif
+                    } label: {
+                        Image(systemName: "checkmark")
+                            .font(.title)
+                            .padding()
+                            .tintedBlurBackground()
+                            .clipShape(.circle)
+                    }
+                    .glassEffectIfAvailable(in: .circle)
+                }
+            }
+            .gesture(zoomAndPan)
+            .preference(key: SizePreferenceKey.self,
+                        value: geo.size)
+            .onPreferenceChange(SizePreferenceKey.self) { newValue in
+                geoSize = newValue
+                offset = clampOffset(offset)
+                scale = clampZoom(scale)
+            }
+        }
+    }
+    
+    func clampOffset(_ proposedOffset: CGSize) -> CGSize {
+        let baseSize = baseSize()
+        let scaledSize = CGSize(width: baseSize.width * scale, height: baseSize.height * scale)
+        let restingOffsetFromCropArea = CGSize(width: (scaledSize.width - cropSize.width) / 2.0, height: (scaledSize.height - cropSize.height) / 2.0)
+        let maxOffset = CGSize(width: restingOffsetFromCropArea.width, height: restingOffsetFromCropArea.height)
+        let minOffset = CGSize(width: -(scaledSize.width - restingOffsetFromCropArea.width - cropSize.width), height: -(scaledSize.height - restingOffsetFromCropArea.height - cropSize.height))
+        let clamped = CGSize(width: max(minOffset.width, min(proposedOffset.width, maxOffset.width)), height: max(minOffset.height, min(proposedOffset.height, maxOffset.height)))
+        return clamped
+    }
+    
+    func clampZoom(_ proposedScale: CGFloat) -> CGFloat {
+        let clamped = min(maxScale, max(proposedScale, minScale))
+        return clamped
+    }
+    
+    @ViewBuilder func mask() -> some View {
+        ZStack {
+            ZStack {
+                Color.black
+                    .ignoresSafeArea()
+                RoundedRectangle(cornerRadius: cropSize.width * 0.2)
+                    .frame(width: cropSize.width, height: cropSize.height)
+                    .blendMode(.destinationOut)
+            }
+            .compositingGroup()
+            .opacity(0.5)
+            
+            RoundedRectangle(cornerRadius: cropSize.width * 0.2)
+                .stroke(.white, style: StrokeStyle(lineWidth: 1, lineCap: .round, dash: [8, 12]))
+                .frame(width: cropSize.width, height: cropSize.height)
+        }
+    }
+    
+    func baseSize() -> CGSize {
+        let aspect = originalImage.size.aspectRatio
+        if aspect < cropSize.aspectRatio {
+            // image is taller.  make the width fit.
+            return CGSize(width: cropSize.width, height: cropSize.height * aspect)
+        } else {
+            // image is squatter.  make the height fit.
+            return CGSize(width: cropSize.width * aspect, height: cropSize.height)
+        }
+    }
+    
+    var zoomAndPan: some Gesture {
+        SimultaneousGesture(
+            MagnificationGesture()
+                .updating($currentGestureScale) { value, state, _ in
+                    state = value
+                }
+                .onEnded { value in
+                    let proposedScale = scale * value
+                    scale = clampZoom(proposedScale)
+                },
+            
+            DragGesture()
+                .updating($currentGestureOffset) { value, state, _ in
+                    state = value.translation
+                }
+                .onEnded { value in
+                    let proposedOffest = CGSize(width:  offset.width + value.translation.width, height: offset.height + value.translation.height)
+                    offset = clampOffset(proposedOffest)
+                }
+        )
+    }
+    
+    func getCroppedImage() -> UIImage? {
+        let baseSize = baseSize()
+        let scaledSizeFromBase = CGSize(width: baseSize.width * scale, height: baseSize.height * scale)
+        let restingOffsetFromCropArea = CGSize(width: (scaledSizeFromBase.width - cropSize.width) / 2.0, height: (scaledSizeFromBase.height - cropSize.height) / 2.0)
+        let uiCroppingRect = CGRect(origin: CGPoint(x: restingOffsetFromCropArea.width - offset.width, y: restingOffsetFromCropArea.height - offset.height), size: cropSize)
+        
+        let scaleFromBaseSize = baseSize.width / originalImage.size.width
+        let totalScale = 1 / (scale * scaleFromBaseSize)
+        let imageCroppingRect = uiCroppingRect.applying(CGAffineTransform(scaleX: totalScale, y: totalScale))
+        let result = originalImage.cropped(to: imageCroppingRect)
+        return result
+    }
+}
+
+extension UIImage {
+    func cropped(to rect: CGRect) -> UIImage? {
+        let normalized = normalizedOrientation()
+        guard let cgImage = normalized.cgImage else { return nil }
+        guard let cropped = cgImage.cropping(to: rect) else { return nil }
+        return UIImage(cgImage: cropped)
+    }
+
+    func normalizedOrientation() -> UIImage {
+        if imageOrientation == .up {
+            return self
+        }
+        
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        draw(in: CGRect(origin: .zero, size: size))
+        let normalized = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return normalized!
+    }
+}
+
+struct SizePreferenceKey: PreferenceKey {
+    static var defaultValue: CGSize = .zero
+    
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        value = nextValue()
+    }
+}

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PhotoCropperView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PhotoCropperView.swift
@@ -109,14 +109,13 @@ struct PhotoCropperView: View {
     @ViewBuilder func mask() -> some View {
         ZStack {
             ZStack {
-                Color.black
+                Color.dimmingBackground
                     .ignoresSafeArea()
                 RoundedRectangle(cornerRadius: cropSize.width * 0.2)
                     .frame(width: cropSize.width, height: cropSize.height)
                     .blendMode(.destinationOut)
             }
             .compositingGroup()
-            .opacity(0.5)
             
             RoundedRectangle(cornerRadius: cropSize.width * 0.2)
                 .stroke(.white, style: StrokeStyle(lineWidth: 1, lineCap: .round, dash: [8, 12]))

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/AccountRowView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/AccountRowView.swift
@@ -13,7 +13,7 @@ struct AccountRowView: View {
     var body: some View {
         VStack(alignment: .gutterAlign, spacing: 0) {  // gutterAlign keeps the content properly aligned with the gap between avatar and content
             HStack(alignment: .top, spacing: spacingBetweenGutterAndContent) {
-                AvatarView(size: .large, authorAvatarUrl: viewModel.account.avatarURL, goToProfile: nil)
+                AvatarView(size: .large, avatarSource: .url(viewModel.account.avatarURL), goToProfile: nil)
                     .accessibilityHidden(true)
                 
                 VStack(alignment: .leading, spacing: 0) {

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/MastodonPostRowView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/MastodonPostRowView.swift
@@ -62,7 +62,7 @@ struct MastodonPostRowView: View {
             HStack(alignment: .top, spacing: spacingBetweenGutterAndContent) {
                 // MARK: Avatar
                 VStack(spacing: 0) {
-                    AvatarView(size: .large, authorAvatarUrl: author?.avatarURL ?? viewModel.initialDisplayInfo.actionableAuthorStaticAvatar, goToProfile: {
+                    AvatarView(size: .large, avatarSource: .url(author?.avatarURL ?? viewModel.initialDisplayInfo.actionableAuthorStaticAvatar), goToProfile: {
                         goToProfile(author)
                     })
                     if let threadedContext, threadedContext.drawsLineBelow {

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/AvatarView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/AvatarView.swift
@@ -31,8 +31,13 @@ struct AvatarView: View {
         }
     }
     
+    enum AvatarSource {
+        case url(URL?)
+        case local(Image)
+    }
+    
     let size: Size
-    let authorAvatarUrl: URL?
+    let avatarSource: AvatarSource?
     let goToProfile: (() async throws -> ())?
     
     private var viewDimension: CGFloat {
@@ -50,32 +55,49 @@ struct AvatarView: View {
     
     var body: some View {
         ZStack {
-            if let authorAvatarUrl {
-                WebImage(
-                    url: authorAvatarUrl,
-                    content: { image in
-                        image.resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .clipShape(avatarShape)
-                    },
-                    placeholder: {
+            if let avatarSource {
+                switch avatarSource {
+                case .url(let url):
+                    if let url {
+                        WebImage(
+                            url: url,
+                            content: { image in
+                                image.resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .clipShape(avatarShape)
+                            },
+                            placeholder: {
+                                avatarShape
+                                    .foregroundStyle(
+                                        Color(UIColor.secondarySystemFill))
+                            }
+                        )
+                        .overlay {
+                            switch size {
+                            case .extraLarge:
+                                avatarShape.stroke(.background, lineWidth: 2)
+                            default:
+                                avatarShape.stroke(.separator, lineWidth: 0.3)
+                            }
+                        }
+                    } else {
                         avatarShape
                             .foregroundStyle(
                                 Color(UIColor.secondarySystemFill))
                     }
-                )
-                .overlay {
-                    switch size {
-                    case .extraLarge:
-                        avatarShape.stroke(.background, lineWidth: 2)
-                    default:
-                        avatarShape.stroke(.separator, lineWidth: 0.3)
-                    }
+                case .local(let image):
+                    image.resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .clipShape(avatarShape)
+                        .overlay {
+                            switch size {
+                            case .extraLarge:
+                                avatarShape.stroke(.background, lineWidth: 2)
+                            default:
+                                avatarShape.stroke(.separator, lineWidth: 0.3)
+                            }
+                        }
                 }
-            } else {
-                avatarShape
-                    .foregroundStyle(
-                        Color(UIColor.secondarySystemFill))
             }
             
             if isNavigating {

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/LinkPreviewCard.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/LinkPreviewCard.swift
@@ -203,7 +203,7 @@ struct LinkPreviewCard: View {
                     navigateToScene(.profile(profileType), .show)
                 } label: {
                     HStack(spacing: tinySpacing) {
-                        AvatarView(size: .tiny, authorAvatarUrl: account.avatarURL, goToProfile: nil)
+                        AvatarView(size: .tiny, avatarSource: .url(account.avatarURL), goToProfile: nil)
                         MastodonContentView.header(html: account.displayNameWithFallback, emojis: account.emojis, style: .linkPreviewCardAuthorButton)
                             .lineLimit(1)
                     }

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
@@ -10,7 +10,7 @@ import Combine
 import MastodonAsset
 import SDWebImageSwiftUI
 
-let buttonBackgroundColor = Color.black.opacity(0.6)
+let buttonBackgroundColor = Color.dimmingBackground
 let maxHeightForHiddenMedia: CGFloat = 100
 
 class GenericMastodonAttachment: Identifiable {

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/RelationshipButtonType.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/RelationshipButtonType.swift
@@ -13,8 +13,10 @@ enum RelationshipButtonType {
     case iDoNotFollowThem(theyFollowMe: Bool, theirAccountIsLocked: Bool)
     case iFollowThem(theyFollowMe: Bool)
     case iHaveRequestedToFollowThem
+    case edit
     
     enum RelationshipAction {
+        case editProfile
         case follow
         case unfollow
         case unmute
@@ -31,7 +33,7 @@ enum RelationshipButtonType {
                 return .unmute
             case .unblock:
                 return .unblockUser
-            case .noAction:
+            case .noAction, .editProfile:
                 return nil
             }
         }
@@ -55,6 +57,8 @@ enum RelationshipButtonType {
     
     var description: String {
         switch self {
+        case .edit:
+            return "edit"
         case .updating:
             return "updating"
         case .error:
@@ -84,6 +88,8 @@ enum RelationshipButtonType {
     
     func buttonText(isLarge: Bool) -> String? {
         switch self {
+        case .edit:
+            return L10nLookup.Common.Controls.editProfileButton
         case .iDoNotFollowThem(let theyFollowMe, let theirAccountIsLocked):
             if theirAccountIsLocked {
                 return L10nLookup.Common.Controls.RelationshipAction.requestToFollow(longForm: isLarge)
@@ -109,6 +115,8 @@ enum RelationshipButtonType {
     
     var buttonAction: RelationshipAction {
         switch self {
+        case .edit:
+            return .editProfile
         case .iDoNotFollowThem:
             return .follow
         case .iFollowThem, .iHaveRequestedToFollowThem:

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/NotificationRowView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/NotificationRowView.swift
@@ -885,7 +885,7 @@ struct RelationshipButtonStyle: ButtonStyle {
     
     private var backgroundColor: Color {
         switch action {
-        case .follow:
+        case .follow, .editProfile:
             return Asset.Colors.Button.userFollow.swiftUIColor
         case .unfollow, .unmute, .unblock:
             return Asset.Colors.Button.userFollowing.swiftUIColor
@@ -896,7 +896,7 @@ struct RelationshipButtonStyle: ButtonStyle {
     
     private var textColor: Color {
         switch action {
-        case .follow:
+        case .follow, .editProfile:
             return .white
         case .unfollow, .unmute, .unblock:
             return Asset.Colors.Button.userFollowingTitle.swiftUIColor
@@ -907,7 +907,7 @@ struct RelationshipButtonStyle: ButtonStyle {
 
     private var fontWeight: SwiftUICore.Font.Weight {
         switch action {
-        case .follow:
+        case .follow, .editProfile:
             return isLarge ? .bold : .regular
         case .unfollow, .unmute, .unblock:
             return isLarge ? .regular : .light

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/NotificationRowView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/NotificationRowView.swift
@@ -558,7 +558,7 @@ struct NotificationRowView: View {
                     ForEach(
                         accountInfo.accounts.prefix(maxAvatarCount), id: \.self.id
                     ) { account in
-                        AvatarView(size: .small, authorAvatarUrl: account.avatarURL, goToProfile: { try await viewModel.navigateToProfile(account) })
+                        AvatarView(size: .small, avatarSource: .url(account.avatarURL), goToProfile: { try await viewModel.navigateToProfile(account) })
                             .onTapGesture {
                                 Task {
                                     try await viewModel.navigateToProfile(account)

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/RelationshipViewModel.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/RelationshipViewModel.swift
@@ -11,9 +11,13 @@ import SwiftUI
     
     public func prepareForDisplay(relationship: MastodonAccount.Relationship, theirAccountIsLocked: Bool) {
         self.relationship = relationship
-        if let entity = relationship.info?._legacyEntity {
+        switch relationship {
+        case .isNotMe(let info):
+            guard let entity = info?._legacyEntity else { break }
             let updatedButton = RelationshipButtonType(relationship: entity, theirAccountIsLocked: theirAccountIsLocked)
             button = updatedButton
+        case .isMe:
+            button = .edit
         }
     }
     
@@ -26,6 +30,10 @@ import SwiftUI
         do {
             button = .updating
             switch action {
+            case .editProfile:
+                throw AppError.unexpected(
+                    "editProfile action cannot be handled by the RelationshipViewModel"
+                )
             case .follow:
                 try await actionHandler?.doAction(.follow, forAccount: account)
             case .unfollow:

--- a/Mastodon/In Progress New Layout and Datamodel/GenericMastodonPost and Subclasses/MastodonAccount.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/GenericMastodonPost and Subclasses/MastodonAccount.swift
@@ -9,6 +9,7 @@ public struct MastodonAccount: Identifiable, Codable {
     let metadata: MetaData
     let displayInfo: DisplayInfo
     let metrics: Metrics
+    let bio: String
     let _legacyEntity: Mastodon.Entity.Account
 }
 
@@ -97,7 +98,7 @@ extension MastodonAccount: FromAccountEntityDerivable {
             metadata: MetaData.fromEntity(entity),
             displayInfo: DisplayInfo.fromEntity(
                 entity),
-            metrics: Metrics.fromEntity(entity),
+            metrics: Metrics.fromEntity(entity), bio: entity.note,
             _legacyEntity: entity
         )
     }

--- a/Mastodon/In Progress New Layout and Datamodel/GenericMastodonPost and Subclasses/MastodonAccount.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/GenericMastodonPost and Subclasses/MastodonAccount.swift
@@ -56,6 +56,7 @@ extension MastodonAccount {
         let manuallyApprovesNewFollows: Bool
         let verifiedLink: String?
         let customFields: [Mastodon.Entity.Field]?
+        let isBot: Bool
     }
 }
 
@@ -106,7 +107,7 @@ extension MastodonAccount: FromAccountEntityDerivable {
 
 extension MastodonAccount.MetaData: FromAccountEntityDerivable {
     static func fromEntity(_ entity: Mastodon.Entity.Account) -> MastodonAccount.MetaData {
-        return MastodonAccount.MetaData(profileUrl: URL(string: entity.url), createdAt: entity.createdAt, manuallyApprovesNewFollows: entity.locked, verifiedLink: entity.verifiedLink?.value, customFields: entity.fields)
+        return MastodonAccount.MetaData(profileUrl: URL(string: entity.url), createdAt: entity.createdAt, manuallyApprovesNewFollows: entity.locked, verifiedLink: entity.verifiedLink?.value, customFields: entity.fields, isBot: entity.bot ?? false)
     }
 }
 

--- a/Mastodon/In Progress New Layout and Datamodel/GenericMastodonPost and Subclasses/MastodonAccount.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/GenericMastodonPost and Subclasses/MastodonAccount.swift
@@ -202,3 +202,13 @@ extension MastodonAccount {
         }
     }
 }
+
+extension MastodonAccount: UserIdentifier {
+    public var domain: String {
+        _legacyEntity.domain ?? ""
+    }
+    
+    public var userID: MastodonSDK.Mastodon.Entity.Account.ID {
+        id
+    }
+}

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
@@ -1,0 +1,62 @@
+// Copyright © 2026 Mastodon gGmbH. All rights reserved.
+
+import SwiftUI
+import MastodonUI
+import MastodonLocalization
+import MastodonAsset
+
+class ProfileEditHostingViewController: UIHostingController<AnyView> {
+    private let viewModel: ProfileViewModel
+
+    init(viewModel: ProfileViewModel) {
+        self.viewModel = viewModel
+        super.init(rootView: AnyView(ProfileEditingView().environment(viewModel).environment(viewModel.editingViewModel)))
+    }
+    
+    @MainActor @preconcurrency required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+struct ProfileEditingView: View {
+    @Environment(ProfileViewModel.self) var profileViewModel
+    @Environment(ProfileEditingViewModel.self) var editingViewModel
+    
+    @State var fieldEditingViewModel = MetaTextInputFieldViewModel(stringContent: "", placeholder: "Placeholder", characterLimit: .softLimit(200))
+    
+    var body: some View {
+        GeometryReader { geo in
+            VStack {
+                ProfileAvatarAndBannerView(width: geo.size.width)
+                    .environment(profileViewModel)
+                    .environment(editingViewModel)
+                MetaTextInputField()
+                    .environment(fieldEditingViewModel)
+                    .padding()
+                Spacer()
+                    .frame(maxHeight: .infinity)
+            }
+            .overlay {
+                fieldEditingViewModel.autoCompleteSuggestionView(pinToTopOfKeyboard: true)
+            }
+        }
+        .navigationTitle(L10nLookup.Scene.EditProfile.title)
+        .toolbar {
+            if editingViewModel.hasUnsavedChanges {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(L10n.Common.Controls.Actions.save) {
+                        assertionFailure("not implemented")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(Asset.Colors.accent.swiftUIColor)
+                }
+            }
+        }
+    }
+}
+
+@MainActor
+@Observable
+class ProfileEditingViewModel {
+    var hasUnsavedChanges: Bool = false
+}

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
@@ -26,26 +26,24 @@ struct ProfileEditingView: View {
     
     var body: some View {
         GeometryReader { geo in
-            VStack {
+            VStack(spacing: 0) {
                 ProfileAvatarAndBannerView(width: geo.size.width)
-                    .environment(profileViewModel)
-                    .environment(editingViewModel)
                 
-                VStack(alignment: .leading, spacing: tinySpacing) {
-                    inputLabel("Display name")
-                    MetaTextInputField()
-                        .environment(editingViewModel.displayNameFieldEditingViewModel)
-                        .frame(height: 36)
-                }
-                .padding()
+                nameAndBio
+                    .padding(.horizontal)
+                    .padding(.vertical, doublePadding)
                 
-                VStack(alignment: .leading, spacing: tinySpacing) {
-                    inputLabel("Bio")
-                    MetaTextInputField()
-                        .environment(editingViewModel.bioFieldEditingViewModel)
-                        .frame(height: 56)
-                }
-                .padding()
+                Divider()
+                
+                CustomProfileFieldsEditor()
+                    .padding(.horizontal)
+                    .padding(.vertical, doublePadding)
+                
+                Divider()
+                
+                DisplayPreferencesEditor()
+                    .padding(.horizontal)
+                    .padding(.vertical, doublePadding)
                 
                 Spacer()
                     .frame(maxHeight: .infinity)
@@ -84,12 +82,26 @@ struct ProfileEditingView: View {
                 }
             }
         }
+//        .safeAreaPadding()
     }
     
-    @ViewBuilder func inputLabel(_ text: String) -> some View {
-        Text(text)
-            .font(.subheadline)
-            .fontWeight(.semibold)
+    @ViewBuilder var nameAndBio: some View {
+        VStack(spacing: doublePadding) {
+            VStack(alignment: .leading, spacing: tinySpacing) {
+                inputHeading("Display name") // TODO: needs L10n
+                MetaTextInputField()
+                    .environment(editingViewModel.displayNameFieldEditingViewModel)
+                    .frame(height: 36)
+            }
+            
+            VStack(alignment: .leading, spacing: tinySpacing) {
+                inputHeading("Bio")  // TODO: needs L10n
+                inputSubheading("Introduce yourself. Recommended 220 character maximum.") // TODO: needs L10n
+                MetaTextInputField()
+                    .environment(editingViewModel.bioFieldEditingViewModel)
+                    .frame(height: 56)
+            }
+        }
     }
 }
 
@@ -183,3 +195,109 @@ func normalize(htmlString: String?) -> String? {
     let html = try? HTML(html: note, encoding: .utf8)
     return html?.text
 }
+
+enum ProfileSection {
+    case customFields
+    case displayPreferences
+    
+    var title: String? {
+        switch self {
+        case .customFields:
+            return "Custom fields" // TODO: needs L10n
+        case .displayPreferences:
+            return "Display preferences"// TODO: needs L10n
+        }
+    }
+    
+    var tipText: String? {
+        switch self {
+        case .customFields:
+            return "How to add a verified link"// TODO: needs L10n
+        case .displayPreferences:
+            return "Displays may vary across servers and apps."// TODO: needs L10n
+        }
+    }
+}
+
+struct ProfileSectionHeader: View {
+    let section: ProfileSection
+    
+    var body: some View {
+        if let title = section.title {
+            Text(title)
+                .font(.title3)
+                .fontWeight(.semibold)
+        }
+    }
+}
+
+@ViewBuilder func inputHeading(_ text: String) -> some View {
+    Text(text)
+        .font(.subheadline)
+        .fontWeight(.semibold)
+}
+
+@ViewBuilder func inputSubheading(_ text: String) -> some View {
+    Text(text)
+        .font(.footnote)
+        .foregroundColor(.secondary)
+}
+
+struct CustomProfileFieldsEditor: View {
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            ProfileSectionHeader(section: .customFields)
+            inputSubheading("Add your pronouns, external links, or anything else you’d like to share.") // TODO: needs L10n
+            infoButton(.customFields)
+            addFieldButton
+        }
+    }
+    
+    @ViewBuilder var addFieldButton: some View {
+        Button() {
+            // TODO: implement
+        } label: {
+            HStack(spacing: tinySpacing) {
+                Image(systemName: "plus")
+                Text("Add a field") // TODO: needs L10n
+            }
+            .font(.subheadline)
+            .padding(.vertical, tinySpacing)
+            .padding(.horizontal, standardPadding)
+            .background() {
+                Capsule()
+                    .fill(.quinary)
+            }
+        }
+    }
+}
+
+struct DisplayPreferencesEditor: View {
+    var body: some View {
+        VStack {
+            ProfileSectionHeader(section: .displayPreferences)
+            infoButton(.displayPreferences)
+            inputHeading("’Media’ tab settings")
+            inputSubheading("‘Media’ is an optional tab that shows your posts containing images or videos. ")
+        }
+    }
+}
+
+@ViewBuilder func infoButton(_ section: ProfileSection) -> some View {
+    if let text = section.tipText {
+        Button() {
+            // TODO: bring up tip
+        } label: {
+            HStack(spacing: tinySpacing) {
+                Image(systemName: "questionmark.circle")
+                Text(text)
+                    .font(.footnote)
+                    .fontWeight(.semibold)
+                    .underline()
+            }
+            .foregroundColor(.secondary)
+        }
+    }
+}
+

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
@@ -140,6 +140,9 @@ class ProfileEditingViewModel {
     var customFields: [Mastodon.Entity.Field]? = nil
     var emojis: [Mastodon.Entity.Emoji] = []
     
+    private var isAutomatedAccount: Bool = false
+    var isAutomatedAccountBinding = Binding<Bool>( get: { false }, set: {_ in})
+    
     private(set) var initialInfo: MastodonAccount? = nil
     
     init() {
@@ -184,6 +187,11 @@ class ProfileEditingViewModel {
                     }
                 }
             }
+        )
+        
+        isAutomatedAccountBinding = Binding<Bool>(
+            get: { self._isAutomatedAccount },
+            set: { newValue in self._isAutomatedAccount = newValue }
         )
     }
     
@@ -382,6 +390,7 @@ struct CustomProfileFieldsEditor: View {
 
 struct DisplayPreferencesEditor: View {
     @Environment(ProfileEditingViewModel.self) var viewModel
+    
     var body: some View {
         VStack(alignment: .leading, spacing: doublePadding) {
             VStack(alignment: .leading) {
@@ -437,9 +446,17 @@ struct DisplayPreferencesEditor: View {
 }
 
 struct AdvancedSettingsEditor: View {
+    @Environment(ProfileEditingViewModel.self) var viewModel
+    
     var body: some View {
         VStack(alignment: .leading) {
             ProfileSectionHeader(section: .advancedSettings)
+            Spacer()
+            SubsectionHeading(title: "Automated account", subtitle: "Informs others that most posts from this account are automated and won’t be monitored")
+            Toggle(isOn: viewModel.isAutomatedAccountBinding) {
+                Text("Mark as an automated account")
+            }
+            .tint(Asset.Colors.accent.swiftUIColor)
         }
     }
 }
@@ -516,4 +533,3 @@ struct RadioButtonArray: View {
 }
 
 let brandBackgroundColor: Color = Asset.Colors.Brand.lightBlurple.swiftUIColor.opacity(0.2)
-

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
@@ -171,14 +171,14 @@ struct ProfileEditingView: View {
         VStack(spacing: doublePadding) {
             VStack(alignment: .leading, spacing: tinySpacing) {
                 SubsectionHeading(title: "Display name", subtitle: nil) // TODO: needs L10n
-                MetaTextInputField()
+                MetaTextInputField(allowScroll: false)
                     .environment(editingViewModel.displayNameFieldEditingViewModel)
                     .frame(height: 36)
             }
             
             VStack(alignment: .leading, spacing: tinySpacing) {
                 SubsectionHeading(title: "Bio", subtitle: "Introduce yourself. Recommended 220 character maximum.") // TODO: needs L10n
-                MetaTextInputField()
+                MetaTextInputField(allowScroll: true)
                     .environment(editingViewModel.bioFieldEditingViewModel)
                     .frame(height: 56)
             }
@@ -201,14 +201,14 @@ struct ProfileEditingView: View {
                     
                     VStack(alignment: .leading, spacing: tinySpacing) {
                         SubsectionHeading(title: "Label", subtitle: nil)
-                        MetaTextInputField()
+                        MetaTextInputField(allowScroll: false)
                             .environment(editState.labelEditingModel)
                             .frame(height: 36)
                     }
                     
                     VStack(alignment: .leading, spacing: tinySpacing) {
                         SubsectionHeading(title: "Value", subtitle: nil)
-                        MetaTextInputField()
+                        MetaTextInputField(allowScroll: true)
                             .environment(editState.valueEditingModel)
                             .frame(height: 36)
                     }

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 import MastodonUI
 import MastodonLocalization
 import MastodonAsset
+import Kanna // for stripping the html from the account bio
 
 class ProfileEditHostingViewController: UIHostingController<AnyView> {
     private let viewModel: ProfileViewModel
@@ -23,22 +24,36 @@ struct ProfileEditingView: View {
     @Environment(ProfileViewModel.self) var profileViewModel
     @Environment(ProfileEditingViewModel.self) var editingViewModel
     
-    @State var fieldEditingViewModel = MetaTextInputFieldViewModel(stringContent: "", placeholder: "Placeholder", characterLimit: .softLimit(200))
-    
     var body: some View {
         GeometryReader { geo in
             VStack {
                 ProfileAvatarAndBannerView(width: geo.size.width)
                     .environment(profileViewModel)
                     .environment(editingViewModel)
-                MetaTextInputField()
-                    .environment(fieldEditingViewModel)
-                    .padding()
+                
+                VStack(alignment: .leading, spacing: tinySpacing) {
+                    inputLabel("Display name")
+                    MetaTextInputField()
+                        .environment(editingViewModel.displayNameFieldEditingViewModel)
+                        .frame(height: 36)
+                }
+                .padding()
+                
+                VStack(alignment: .leading, spacing: tinySpacing) {
+                    inputLabel("Bio")
+                    MetaTextInputField()
+                        .environment(editingViewModel.bioFieldEditingViewModel)
+                        .frame(height: 56)
+                }
+                .padding()
+                
                 Spacer()
                     .frame(maxHeight: .infinity)
             }
             .overlay {
-                fieldEditingViewModel.autoCompleteSuggestionView(pinToTopOfKeyboard: true)
+                if editingViewModel.bioFieldEditingViewModel.isEditing {
+                    editingViewModel.bioFieldEditingViewModel.autoCompleteSuggestionView(pinToTopOfKeyboard: true)
+                }
             }
             .sheet(isPresented: editingViewModel.showCroppingView) {
                 if let image = editingViewModel.avatarImageToCrop {
@@ -70,12 +85,20 @@ struct ProfileEditingView: View {
             }
         }
     }
+    
+    @ViewBuilder func inputLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.subheadline)
+            .fontWeight(.semibold)
+    }
 }
 
 @MainActor
 @Observable
 class ProfileEditingViewModel {
     var hasUnsavedChanges: Bool = false
+    let displayNameFieldEditingViewModel = MetaTextInputFieldViewModel(stringContent: "", placeholder: "", characterLimit: .softLimit(100), autocompleteMastodonItems: false)
+    let bioFieldEditingViewModel = MetaTextInputFieldViewModel(stringContent: "", placeholder: "Describe yourself and/or this account.", characterLimit: .softLimit(220), autocompleteMastodonItems: true)
     
     var selectedBannerImage: Binding<[PhotosPickerItem]>
     var bannerImagePhotosPickerItem: PhotosPickerItem?
@@ -86,14 +109,15 @@ class ProfileEditingViewModel {
     var avatarImageToCrop: UIImage?
     var avatarConfirmedCroppedImage: UIImage?
     
-    
     var showCroppingView: Binding<Bool>
+    
+    private(set) var initialInfo: MastodonAccount? = nil
     
     init() {
         selectedBannerImage = Binding<[PhotosPickerItem]>(get: {[]}, set: {_ in})
         selectedAvatar = Binding<[PhotosPickerItem]>(get: {[]}, set: {_ in})
         showCroppingView = Binding<Bool>(get: {false}, set: {_ in})
-    
+        
         showCroppingView = Binding<Bool>(
             get: { return self.avatarImageToCrop != nil },
             set: { newValue in }
@@ -133,4 +157,29 @@ class ProfileEditingViewModel {
             }
         )
     }
+    
+    func setAccount(_ account: MastodonAccount) {
+        initialInfo = account
+        updateAccountTextFields(account: account)
+    }
+    
+    func updateAccountTextFields(account: MastodonAccount) {
+        let displayNameContent = account.displayInfo.displayName
+        displayNameFieldEditingViewModel.stringContent = displayNameContent
+        
+        let bioContent = normalize(htmlString: account.bio)
+        bioFieldEditingViewModel.stringContent = bioContent ?? ""
+    }
+}
+
+func normalize(htmlString: String?) -> String? {
+    let _note = htmlString?.replacingOccurrences(of: "<br>|<br />", with: "\u{2028}", options: .regularExpression, range: nil)
+        .replacingOccurrences(of: "</p>", with: "</p>\u{2029}", range: nil)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let note = _note, !note.isEmpty else {
+        return nil
+    }
+    
+    let html = try? HTML(html: note, encoding: .utf8)
+    return html?.text
 }

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
@@ -136,6 +136,7 @@ struct ProfileEditingView: View {
 @Observable
 class ProfileEditingViewModel {
     var hasUnsavedChanges = false
+    var showVerifiedLinkTip = true
     
     let displayNameFieldEditingViewModel = MetaTextInputFieldViewModel(stringContent: "", placeholder: "", characterLimit: .softLimit(100), autocompleteMastodonItems: false)
     let bioFieldEditingViewModel = MetaTextInputFieldViewModel(stringContent: "", placeholder: "Describe yourself and/or this account.", characterLimit: .softLimit(220), autocompleteMastodonItems: true)
@@ -228,6 +229,9 @@ class ProfileEditingViewModel {
         updateAccountTextFields(account: account)
         updateCustomFields(account: account)
         updateMetaData(account: account)
+        if let verifiedField = customFields?.first(where: { $0.verifiedAt != nil }) {
+            showVerifiedLinkTip = false
+        }
     }
     
     func updateAccountTextFields(account: MastodonAccount) {
@@ -334,7 +338,9 @@ struct CustomProfileFieldsEditor: View {
                 Divider()
             }
             addFieldButton
-            verifiedLinksTipBox
+            if editingViewModel.showVerifiedLinkTip {
+                verifiedLinksTipBox
+            }
         }
     }
     
@@ -376,7 +382,9 @@ struct CustomProfileFieldsEditor: View {
             .font(.subheadline)
             
             Button() {
-                // TODO: close
+                withAnimation {
+                    editingViewModel.showVerifiedLinkTip = false
+                }
             } label: {
                 Image(systemName: "xmark")
             }

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
@@ -365,7 +365,7 @@ class ProfileEditingViewModel {
         case .edit(let field):
             fieldEditingState = .init(editingField: fieldType,
                                       labelEditingModel: MetaTextInputFieldViewModel(stringContent: field.name, placeholder: "", characterLimit: .softLimit(100), autocompleteMastodonItems: false),
-                                      valueEditingModel: MetaTextInputFieldViewModel(stringContent: "", placeholder: field.value, characterLimit: .softLimit(220), autocompleteMastodonItems: true))
+                                      valueEditingModel: MetaTextInputFieldViewModel(stringContent: field.value, placeholder: "", characterLimit: .softLimit(220), autocompleteMastodonItems: true))
         }
     }
     
@@ -537,7 +537,12 @@ struct CustomProfileFieldsEditor: View {
     @ViewBuilder func customFieldsList(_ customFields: [Mastodon.Entity.Field]) -> some View {
         VStack {
             ForEach(customFields, id: \.self) { field in
-                    customFieldRow(field, isDraggable: false)
+                customFieldRow(field, isDraggable: false)
+                    .onTapGesture {
+                        withAnimation {
+                            editingViewModel.beginEditingField(.edit(field))
+                        }
+                    }
             }
         }
     }

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
@@ -1,5 +1,6 @@
 // Copyright © 2026 Mastodon gGmbH. All rights reserved.
 
+import PhotosUI
 import SwiftUI
 import MastodonUI
 import MastodonLocalization
@@ -39,6 +40,22 @@ struct ProfileEditingView: View {
             .overlay {
                 fieldEditingViewModel.autoCompleteSuggestionView(pinToTopOfKeyboard: true)
             }
+            .sheet(isPresented: editingViewModel.showCroppingView) {
+                if let image = editingViewModel.avatarImageToCrop {
+                    PhotoCropperView(originalImage: image) { confirmedImage in
+                        defer {
+                            self.editingViewModel.avatarImageToCrop = nil
+                        }
+                        
+                        guard let confirmedImage else {
+                            self.editingViewModel.avatarConfirmedCroppedImage = nil
+                            return
+                        }
+                        
+                        self.editingViewModel.avatarConfirmedCroppedImage = Image(uiImage: confirmedImage)
+                    }
+                }
+            }
         }
         .navigationTitle(L10nLookup.Scene.EditProfile.title)
         .toolbar {
@@ -59,4 +76,38 @@ struct ProfileEditingView: View {
 @Observable
 class ProfileEditingViewModel {
     var hasUnsavedChanges: Bool = false
+    
+    var selectedAvatar: Binding<[PhotosPickerItem]>
+    
+    var avatarPhotosPickerItem: PhotosPickerItem?
+    var avatarImageToCrop: UIImage?
+    var avatarConfirmedCroppedImage: Image?
+    
+    var showCroppingView: Binding<Bool>
+    
+    init() {
+        selectedAvatar = Binding<[PhotosPickerItem]>(get: {[]}, set: {_ in})
+        showCroppingView = Binding<Bool>(get: {false}, set: {_ in})
+    
+        showCroppingView = Binding<Bool>(
+            get: { return self.avatarImageToCrop != nil },
+            set: { newValue in }
+        )
+        selectedAvatar = Binding<[PhotosPickerItem]>(
+            get: { [self.avatarPhotosPickerItem].compactMap { $0 } },
+            set: { newValue in
+                self.avatarPhotosPickerItem = newValue.first
+                if let item = self.avatarPhotosPickerItem {
+                    Task {
+                        if let data = try? await item.loadTransferable(type: Data.self),
+                           let image = UIImage(data: data) {
+                            self.avatarImageToCrop = image
+                        } else {
+                            print("Failed to load avatar image")
+                        }
+                    }
+                }
+            }
+        )
+    }
 }

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 import MastodonUI
 import MastodonLocalization
 import MastodonAsset
+import MastodonSDK
 import Kanna // for stripping the html from the account bio
 
 class ProfileEditHostingViewController: UIHostingController<AnyView> {
@@ -26,46 +27,56 @@ struct ProfileEditingView: View {
     
     var body: some View {
         GeometryReader { geo in
-            VStack(spacing: 0) {
-                ProfileAvatarAndBannerView(width: geo.size.width)
-                
-                nameAndBio
-                    .padding(.horizontal)
-                    .padding(.vertical, doublePadding)
-                
-                Divider()
-                
-                CustomProfileFieldsEditor()
-                    .padding(.horizontal)
-                    .padding(.vertical, doublePadding)
-                
-                Divider()
-                
-                DisplayPreferencesEditor()
-                    .padding(.horizontal)
-                    .padding(.vertical, doublePadding)
-                
-                Spacer()
-                    .frame(maxHeight: .infinity)
-            }
-            .overlay {
-                if editingViewModel.bioFieldEditingViewModel.isEditing {
-                    editingViewModel.bioFieldEditingViewModel.autoCompleteSuggestionView(pinToTopOfKeyboard: true)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    ProfileAvatarAndBannerView(width: geo.size.width)
+                    
+                    nameAndBio
+                        .padding(.horizontal)
+                        .padding(.vertical, doublePadding)
+                    
+                    Divider()
+                    
+                    CustomProfileFieldsEditor()
+                        .padding(.horizontal)
+                        .padding(.vertical, doublePadding)
+                    
+                    Divider()
+                    
+                    DisplayPreferencesEditor()
+                        .padding(.horizontal)
+                        .padding(.vertical, doublePadding)
+                    
+                    Divider()
+                    
+                    // ADVANCED SETTINGS
+                    
+                    AdvancedSettingsEditor()
+                        .padding(.horizontal)
+                        .padding(.vertical, doublePadding)
+                    
+                    Spacer()
+                        .frame(maxHeight: .infinity)
                 }
-            }
-            .sheet(isPresented: editingViewModel.showCroppingView) {
-                if let image = editingViewModel.avatarImageToCrop {
-                    PhotoCropperView(originalImage: image) { confirmedImage in
-                        defer {
-                            self.editingViewModel.avatarImageToCrop = nil
+                .overlay {
+                    if editingViewModel.bioFieldEditingViewModel.isEditing {
+                        editingViewModel.bioFieldEditingViewModel.autoCompleteSuggestionView(pinToTopOfKeyboard: true)
+                    }
+                }
+                .sheet(isPresented: editingViewModel.showCroppingView) {
+                    if let image = editingViewModel.avatarImageToCrop {
+                        PhotoCropperView(originalImage: image) { confirmedImage in
+                            defer {
+                                self.editingViewModel.avatarImageToCrop = nil
+                            }
+                            
+                            guard let confirmedImage else {
+                                self.editingViewModel.avatarConfirmedCroppedImage = nil
+                                return
+                            }
+                            
+                            self.editingViewModel.avatarConfirmedCroppedImage = confirmedImage
                         }
-                        
-                        guard let confirmedImage else {
-                            self.editingViewModel.avatarConfirmedCroppedImage = nil
-                            return
-                        }
-                        
-                        self.editingViewModel.avatarConfirmedCroppedImage = confirmedImage
                     }
                 }
             }
@@ -88,15 +99,14 @@ struct ProfileEditingView: View {
     @ViewBuilder var nameAndBio: some View {
         VStack(spacing: doublePadding) {
             VStack(alignment: .leading, spacing: tinySpacing) {
-                inputHeading("Display name") // TODO: needs L10n
+                SubsectionHeading(title: "Display name", subtitle: nil) // TODO: needs L10n
                 MetaTextInputField()
                     .environment(editingViewModel.displayNameFieldEditingViewModel)
                     .frame(height: 36)
             }
             
             VStack(alignment: .leading, spacing: tinySpacing) {
-                inputHeading("Bio")  // TODO: needs L10n
-                inputSubheading("Introduce yourself. Recommended 220 character maximum.") // TODO: needs L10n
+                SubsectionHeading(title: "Bio", subtitle: "Introduce yourself. Recommended 220 character maximum.") // TODO: needs L10n
                 MetaTextInputField()
                     .environment(editingViewModel.bioFieldEditingViewModel)
                     .frame(height: 56)
@@ -122,6 +132,13 @@ class ProfileEditingViewModel {
     var avatarConfirmedCroppedImage: UIImage?
     
     var showCroppingView: Binding<Bool>
+    
+    var mediaTabVisibilitySetting: MediaTabVisibilitySetting = .showMediaTab
+    var mediaTabRepliesSetting: MediaTabRepliesSetting = .showDirectPostsOnly
+    var featuredTabVisibilitySetting: FeaturedTabVisibilitySetting = .showFeaturedTab
+    
+    var customFields: [Mastodon.Entity.Field]? = nil
+    var emojis: [Mastodon.Entity.Emoji] = []
     
     private(set) var initialInfo: MastodonAccount? = nil
     
@@ -173,6 +190,7 @@ class ProfileEditingViewModel {
     func setAccount(_ account: MastodonAccount) {
         initialInfo = account
         updateAccountTextFields(account: account)
+        updateCustomFields(account: account)
     }
     
     func updateAccountTextFields(account: MastodonAccount) {
@@ -181,6 +199,28 @@ class ProfileEditingViewModel {
         
         let bioContent = normalize(htmlString: account.bio)
         bioFieldEditingViewModel.stringContent = bioContent ?? ""
+    }
+    
+    func updateCustomFields(account: MastodonAccount) {
+        customFields = account.metadata.customFields
+        emojis = account._legacyEntity.emojis
+    }
+}
+
+extension ProfileEditingViewModel {
+    enum MediaTabVisibilitySetting: Int {
+        case showMediaTab
+        case hideMediaTab
+    }
+    
+    enum MediaTabRepliesSetting: Int {
+        case showDirectPostsOnly
+        case includeMyRepliesToOthers
+    }
+    
+    enum FeaturedTabVisibilitySetting: Int {
+        case showFeaturedTab
+        case hideFeaturedTab
     }
 }
 
@@ -199,6 +239,7 @@ func normalize(htmlString: String?) -> String? {
 enum ProfileSection {
     case customFields
     case displayPreferences
+    case advancedSettings
     
     var title: String? {
         switch self {
@@ -206,6 +247,8 @@ enum ProfileSection {
             return "Custom fields" // TODO: needs L10n
         case .displayPreferences:
             return "Display preferences"// TODO: needs L10n
+        case .advancedSettings:
+            return "Advanced settings"
         }
     }
     
@@ -215,6 +258,8 @@ enum ProfileSection {
             return "How to add a verified link"// TODO: needs L10n
         case .displayPreferences:
             return "Displays may vary across servers and apps."// TODO: needs L10n
+        case .advancedSettings:
+            return "Informs others that most posts from this account are..."
         }
     }
 }
@@ -231,26 +276,21 @@ struct ProfileSectionHeader: View {
     }
 }
 
-@ViewBuilder func inputHeading(_ text: String) -> some View {
-    Text(text)
-        .font(.subheadline)
-        .fontWeight(.semibold)
-}
-
-@ViewBuilder func inputSubheading(_ text: String) -> some View {
-    Text(text)
-        .font(.footnote)
-        .foregroundColor(.secondary)
-}
-
 struct CustomProfileFieldsEditor: View {
+    @Environment(ProfileEditingViewModel.self) var editingViewModel
+    @State private var draggingField: Mastodon.Entity.Field?
     
     var body: some View {
         VStack(alignment: .leading) {
             ProfileSectionHeader(section: .customFields)
-            inputSubheading("Add your pronouns, external links, or anything else you’d like to share.") // TODO: needs L10n
             infoButton(.customFields)
+            SubsectionHeading(title: nil, subtitle: "Add your pronouns, external links, or anything else you’d like to share.") // TODO: needs L10n
+            if let customFields = editingViewModel.customFields, !customFields.isEmpty {
+                customFieldsList(customFields)
+                Divider()
+            }
             addFieldButton
+            verifiedLinksTipBox
         }
     }
     
@@ -271,15 +311,135 @@ struct CustomProfileFieldsEditor: View {
             }
         }
     }
+    
+    @ViewBuilder var verifiedLinksTipBox: some View {
+        HStack(alignment: .top) {
+            Image(systemName: "checkmark.seal")
+                .font(.subheadline)
+                .padding(tinySpacing)
+                .background() {
+                    Circle()
+                        .fill(brandBackgroundColor)
+                }
+            
+            VStack(alignment: .leading) {
+                Spacer()
+                    .frame(height: tinySpacing)
+                Text("Tip: Adding verified links")
+                    .fontWeight(.semibold)
+                Text("You can easily add credibility to your Mastodon account by verifying links to any websites you own.")
+            }
+            .font(.subheadline)
+            
+            Button() {
+                // TODO: close
+            } label: {
+                Image(systemName: "xmark")
+            }
+        }
+        .padding()
+        .background() {
+            RoundedRectangle(cornerRadius: CornerRadius.extraLarge)
+                .fill(brandBackgroundColor)
+        }
+    }
+    
+    @ViewBuilder func customFieldsList(_ customFields: [Mastodon.Entity.Field]) -> some View {
+        VStack {
+            ForEach(customFields, id: \.self) { field in
+                    customFieldRow(field, isDraggable: false)
+            }
+        }
+    }
+    
+    @ViewBuilder func customFieldRow(_ field: Mastodon.Entity.Field, isDraggable: Bool, isDragging: Bool) -> some View {
+        if isDragging {
+            customFieldRow(field, isDraggable: isDraggable)
+                .hidden()
+        } else {
+            customFieldRow(field, isDraggable: isDraggable)
+        }
+    }
+    
+    @ViewBuilder func customFieldRow(_ field: Mastodon.Entity.Field, isDraggable: Bool) -> some View {
+        HStack {
+            if isDraggable {
+                Image(systemName: "line.3.horizontal")
+            }
+            VStack(alignment: .leading) {
+                Text(field.name)
+                    .fixedSize()
+                Text(field.value)
+                    .fontWeight(.semibold)
+                    .fixedSize()
+            }
+            .font(.footnote)
+            Spacer()
+        }
+        .padding()
+    }
 }
 
 struct DisplayPreferencesEditor: View {
+    @Environment(ProfileEditingViewModel.self) var viewModel
     var body: some View {
-        VStack {
-            ProfileSectionHeader(section: .displayPreferences)
-            infoButton(.displayPreferences)
-            inputHeading("’Media’ tab settings")
-            inputSubheading("‘Media’ is an optional tab that shows your posts containing images or videos. ")
+        VStack(alignment: .leading, spacing: doublePadding) {
+            VStack(alignment: .leading) {
+                ProfileSectionHeader(section: .displayPreferences)
+                infoButton(.displayPreferences)
+            }
+            
+            // SHOW/HIDE MEDIA TAB
+            VStack(alignment: .leading) {
+                SubsectionHeading(title: "’Media’ tab settings", subtitle: "‘Media’ is an optional tab that shows your posts containing images or videos.")
+                RadioButtonArray(items: [(ProfileEditingViewModel.MediaTabVisibilitySetting.showMediaTab.rawValue, "Show ‘Media’ tab"), (ProfileEditingViewModel.MediaTabVisibilitySetting.hideMediaTab.rawValue, "Hide ‘Media’ tab")], selectedItem: Binding<Int>(
+                    get: { viewModel.mediaTabVisibilitySetting.rawValue },
+                    set: { newValue in viewModel.mediaTabVisibilitySetting = .init(rawValue: newValue) ?? .showMediaTab }
+                ))
+            }
+            
+            // INCLUDE REPLIES ON MEDIA TAB
+            VStack(alignment: .leading) {
+                SubsectionHeading(title: "Include replies on ’Media’ tab?", subtitle: nil)
+                RadioButtonArray(items: [(ProfileEditingViewModel.MediaTabRepliesSetting.showDirectPostsOnly.rawValue, "Only show my posts"), (ProfileEditingViewModel.MediaTabRepliesSetting.includeMyRepliesToOthers.rawValue, "Show my posts and replies to other people's posts")], selectedItem: Binding<Int>(
+                    get: { viewModel.mediaTabRepliesSetting.rawValue },
+                    set: { newValue in viewModel.mediaTabRepliesSetting = .init(rawValue: newValue) ?? .showDirectPostsOnly }
+                ))
+            }
+            
+            // FEATURED TAB SETTINGS
+            VStack(alignment: .leading) {
+                SubsectionHeading(title: "’Featured’ tab settings", subtitle: "’Featured’ is an optional tab where you can showcase other accounts and collections.")
+                RadioButtonArray(items: [(ProfileEditingViewModel.FeaturedTabVisibilitySetting.showFeaturedTab.rawValue, "Show ’Featured’ tab"), (ProfileEditingViewModel.FeaturedTabVisibilitySetting.hideFeaturedTab.rawValue, "Hide ’Featured’ tab")], selectedItem: Binding<Int>(
+                    get: { viewModel.featuredTabVisibilitySetting.rawValue },
+                    set: { newValue in viewModel.featuredTabVisibilitySetting = .init(rawValue: newValue) ?? .showFeaturedTab }
+                ))
+            }
+            
+            Divider()
+            
+            // FEATURED HASHTAGS
+            
+            HStack {
+                SubsectionHeading(title: "Featured hashtags", subtitle: "Help others identify, and have quick access to, your favorite topics")
+                HStack {
+                    Text("Manage")
+                    Image(systemName: "chevron.forward")
+                }
+                .font(.subheadline)
+                .fontWeight(.semibold)
+            }
+            .onTapGesture {
+                // TODO: navigate
+            }
+        }
+    }
+}
+
+struct AdvancedSettingsEditor: View {
+    var body: some View {
+        VStack(alignment: .leading) {
+            ProfileSectionHeader(section: .advancedSettings)
         }
     }
 }
@@ -300,4 +460,60 @@ struct DisplayPreferencesEditor: View {
         }
     }
 }
+
+struct SubsectionHeading: View {
+    let title: String?
+    let subtitle: String?
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            if let title {
+                Text(title)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+            }
+            if let subtitle {
+                Text(subtitle)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}
+
+struct RadioButtonArray: View {
+    let items: [(Int, String)]
+    var selectedItem: Binding<Int>
+    
+    let selectionIndicatorSize: CGFloat = 16
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            ForEach(items, id: \.self.1) { (index, item) in
+                HStack {
+                    selectionImage(selected: index == selectedItem.wrappedValue)
+                    Text(item)
+                }
+                .onTapGesture {
+                    selectedItem.wrappedValue = index % items.count
+                }
+            }
+        }
+    }
+    
+    @ViewBuilder func selectionImage(selected: Bool) -> some View {
+        ZStack {
+            Circle()
+                .stroke(selected ? .clear : .secondary)
+                .fill(selected ? Asset.Colors.accent.swiftUIColor : .clear)
+                .frame(width: selectionIndicatorSize, height: selectionIndicatorSize)
+            Circle()
+                .blendMode(.destinationOut)
+                .frame(width: selectionIndicatorSize - 8, height: selectionIndicatorSize - 8)
+        }
+        .compositingGroup()
+    }
+}
+
+let brandBackgroundColor: Color = Asset.Colors.Brand.lightBlurple.swiftUIColor.opacity(0.2)
 

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
@@ -25,6 +25,27 @@ struct ProfileEditingView: View {
     @Environment(ProfileViewModel.self) var profileViewModel
     @Environment(ProfileEditingViewModel.self) var editingViewModel
     
+    enum FieldEditType {
+        case create
+        case edit(Mastodon.Entity.Field)
+        
+        var title: String {
+            switch self {
+            case .create:
+                "Create custom field"
+            case .edit:
+                "Edit custom field"
+            }
+        }
+    }
+    
+    struct FieldEditingState {
+        let editingField: FieldEditType
+        let labelEditingModel: MetaTextInputFieldViewModel
+        let valueEditingModel: MetaTextInputFieldViewModel
+    }
+    
+    
     var body: some View {
         GeometryReader { geo in
             ScrollView {
@@ -93,6 +114,11 @@ struct ProfileEditingView: View {
                 }
             }
         }
+        .overlay() {
+            if let fieldEditingState = editingViewModel.fieldEditingState {
+                editFieldView(fieldEditingState)
+            }
+        }
         .onChange(of: editingViewModel.isAutomatedAccount) {
             editingViewModel.checkForChanges()
         }
@@ -130,6 +156,80 @@ struct ProfileEditingView: View {
             }
         }
     }
+    
+    @ViewBuilder func editFieldView(_ editState: ProfileEditingView.FieldEditingState) -> some View {
+        GeometryReader { _ in
+            ZStack {
+                Color.dimmingBackground
+                    .onTapGesture {
+                        self.editingViewModel.fieldEditingState = nil
+                    }
+                
+                VStack(alignment: .leading, spacing: doublePadding) {
+                    Text(editState.editingField.title)
+                        .fontWeight(.semibold)
+                    
+                    Divider()
+                    
+                    VStack(alignment: .leading, spacing: tinySpacing) {
+                        SubsectionHeading(title: "Label", subtitle: nil)
+                        MetaTextInputField()
+                            .environment(editState.labelEditingModel)
+                            .frame(height: 36)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: tinySpacing) {
+                        SubsectionHeading(title: "Value", subtitle: nil)
+                        MetaTextInputField()
+                            .environment(editState.valueEditingModel)
+                            .frame(height: 36)
+                    }
+                    
+                    HStack {
+                        Spacer()
+                            .frame(maxWidth: .infinity)
+                        
+                        Button() {
+                            withAnimation {
+                                editingViewModel.fieldEditingState = nil
+                            }
+                        } label: {
+                            Text("Cancel")
+                                .padding(.horizontal)
+                                .padding(.vertical, tinySpacing)
+                                .background() {
+                                    Capsule()
+                                        .stroke(.secondary)
+                                }
+                        }
+                        
+                        Button() {
+                            withAnimation {
+                                editingViewModel.commitEditingField()
+                            }
+                        } label: {
+                            Text("Save")
+                                .foregroundColor(.white)
+                                .padding(.horizontal)
+                                .padding(.vertical, tinySpacing)
+                                .background() {
+                                    Capsule()
+                                        .fill(Asset.Colors.accent.swiftUIColor)
+                                }
+                        }
+                    }
+                    .fontWeight(.semibold)
+                }
+                .frame(maxWidth: 300)
+                .padding(doublePadding)
+                .background() {
+                    RoundedRectangle(cornerRadius: CornerRadius.extraLarge)
+                        .fill(.background)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+        }
+    }
 }
 
 @MainActor
@@ -140,6 +240,8 @@ class ProfileEditingViewModel {
     
     let displayNameFieldEditingViewModel = MetaTextInputFieldViewModel(stringContent: "", placeholder: "", characterLimit: .softLimit(100), autocompleteMastodonItems: false)
     let bioFieldEditingViewModel = MetaTextInputFieldViewModel(stringContent: "", placeholder: "Describe yourself and/or this account.", characterLimit: .softLimit(220), autocompleteMastodonItems: true)
+    
+    var fieldEditingState: ProfileEditingView.FieldEditingState?
     
     var selectedBannerImage: Binding<[PhotosPickerItem]>
     var bannerImagePhotosPickerItem: PhotosPickerItem?
@@ -253,6 +355,40 @@ class ProfileEditingViewModel {
         featuredTabVisibilitySetting = .showFeaturedTab
         isAutomatedAccount = account.metadata.isBot
     }
+    
+    func beginEditingField(_ fieldType: ProfileEditingView.FieldEditType) {
+        switch fieldType {
+        case .create:
+            fieldEditingState = .init(editingField: fieldType,
+                                      labelEditingModel: MetaTextInputFieldViewModel(stringContent: "", placeholder: "", characterLimit: .softLimit(100), autocompleteMastodonItems: false),
+                                      valueEditingModel: MetaTextInputFieldViewModel(stringContent: "", placeholder: "", characterLimit: .softLimit(220), autocompleteMastodonItems: true))
+        case .edit(let field):
+            fieldEditingState = .init(editingField: fieldType,
+                                      labelEditingModel: MetaTextInputFieldViewModel(stringContent: field.name, placeholder: "", characterLimit: .softLimit(100), autocompleteMastodonItems: false),
+                                      valueEditingModel: MetaTextInputFieldViewModel(stringContent: "", placeholder: field.value, characterLimit: .softLimit(220), autocompleteMastodonItems: true))
+        }
+    }
+    
+    func commitEditingField() {
+        guard let fieldEditingState else { return }
+        let labelText = fieldEditingState.labelEditingModel.stringContent
+        let valueText = fieldEditingState.valueEditingModel.stringContent
+        guard !labelText.isEmpty, !valueText.isEmpty else { return }
+        
+        let newField = Mastodon.Entity.Field(name: labelText, value: valueText)
+        
+        switch fieldEditingState.editingField {
+        case .create:
+            customFields?.append(newField)
+        case .edit(let field):
+            if let replaceIndex = customFields?.firstIndex(of: field) {
+                customFields?[replaceIndex] = newField
+            } else {
+                customFields?.append(newField)
+            }
+        }
+        self.fieldEditingState = nil
+    }
 }
 
 extension ProfileEditingViewModel {
@@ -346,7 +482,9 @@ struct CustomProfileFieldsEditor: View {
     
     @ViewBuilder var addFieldButton: some View {
         Button() {
-            // TODO: implement
+            withAnimation {
+                editingViewModel.beginEditingField(.create)
+            }
         } label: {
             HStack(spacing: tinySpacing) {
                 Image(systemName: "plus")

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
@@ -6,6 +6,7 @@ import MastodonUI
 import MastodonLocalization
 import MastodonAsset
 import MastodonSDK
+import MastodonCore
 import Kanna // for stripping the html from the account bio
 
 class ProfileEditHostingViewController: UIHostingController<AnyView> {
@@ -44,8 +45,7 @@ struct ProfileEditingView: View {
         let labelEditingModel: MetaTextInputFieldViewModel
         let valueEditingModel: MetaTextInputFieldViewModel
     }
-    
-    
+
     var body: some View {
         GeometryReader { geo in
             ScrollView {
@@ -82,6 +82,12 @@ struct ProfileEditingView: View {
                 .overlay {
                     if editingViewModel.bioFieldEditingViewModel.isEditing {
                         editingViewModel.bioFieldEditingViewModel.autoCompleteSuggestionView(pinToTopOfKeyboard: true)
+                    } else if profileViewModel.editingStatus.showActivityIndicator {
+                        ZStack {
+                            Color.dimmingBackground
+                            ProgressView()
+                                .progressViewStyle(.circular)
+                        }
                     }
                 }
                 .sheet(isPresented: editingViewModel.showCroppingView) {
@@ -104,21 +110,43 @@ struct ProfileEditingView: View {
         }
         .navigationTitle(L10nLookup.Scene.EditProfile.title)
         .toolbar {
-            if editingViewModel.hasUnsavedChanges {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(L10n.Common.Controls.Actions.save) {
-                        assertionFailure("not implemented")
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .tint(Asset.Colors.accent.swiftUIColor)
-                }
-            }
+            saveButtonForToolbar
         }
         .overlay() {
             if let fieldEditingState = editingViewModel.fieldEditingState {
                 editFieldView(fieldEditingState)
             }
         }
+        .alert(editingViewModel.presentingAlert?.title ?? "",
+               isPresented: Binding<Bool>(
+                get: { editingViewModel.presentingAlert != nil },
+                set: { newValue in
+                    if newValue == false {
+                        editingViewModel.presentingAlert = nil
+                    }
+                }
+               ),
+               actions: {
+            Button(role: .cancel) {
+                withAnimation {
+                    editingViewModel.cancelDeleteCustomField()
+                }
+            } label: {
+                Text("Cancel")
+            }
+            Button(role: .destructive) {
+                withAnimation {
+                    editingViewModel.confirmDeleteCustomField()
+                }
+            } label: {
+                Text("Delete")
+            }
+        },
+               message: {
+            if let messageText = editingViewModel.presentingAlert?.messageText {
+                Text(messageText)
+            }
+        })
         .onChange(of: editingViewModel.isAutomatedAccount) {
             editingViewModel.checkForChanges()
         }
@@ -230,12 +258,37 @@ struct ProfileEditingView: View {
             }
         }
     }
+    
+    @ViewBuilder func alertContents(_ alert: ProfileEditingViewModel.ProfileEditingAlert) -> some View {
+        Color.red
+            .frame(width: 200, height: 50)
+    }
+    
+    @ToolbarContentBuilder var saveButtonForToolbar: some ToolbarContent {
+        if profileViewModel.editingStatus.showSaveButton {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(L10n.Common.Controls.Actions.save) {
+                    profileViewModel.editingStatus = .pushingChanges(success: nil)
+                    Task {
+                        do {
+                            try await profileViewModel.commitEdits()
+                            profileViewModel.editingStatus = .pushingChanges(success: true)
+                        } catch {
+                            profileViewModel.editingStatus = .pushingChanges(success: false)
+                        }
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Asset.Colors.accent.swiftUIColor)
+            }
+        }
+    }
 }
 
 @MainActor
 @Observable
 class ProfileEditingViewModel {
-    var hasUnsavedChanges = false
+    var editingStatusBinding: Binding<EditingStatus>?
     var showVerifiedLinkTip = true
     
     let displayNameFieldEditingViewModel = MetaTextInputFieldViewModel(stringContent: "", placeholder: "", characterLimit: .softLimit(100), autocompleteMastodonItems: false)
@@ -253,6 +306,7 @@ class ProfileEditingViewModel {
     var avatarConfirmedCroppedImage: UIImage?
     
     var showCroppingView: Binding<Bool>
+    var presentingAlert: ProfileEditingAlert?
     
     var mediaTabVisibilitySetting: MediaTabVisibilitySetting = .showMediaTab
     var mediaTabRepliesSetting: MediaTabRepliesSetting = .showDirectPostsOnly
@@ -315,15 +369,18 @@ class ProfileEditingViewModel {
             set: { newValue in self.isAutomatedAccount = newValue }
         )
         
-        displayNameFieldEditingViewModel.contentDidChange = { self.hasUnsavedChanges = true }
-        bioFieldEditingViewModel.contentDidChange = { self.hasUnsavedChanges = true }
+        displayNameFieldEditingViewModel.contentDidChange = { withAnimation { self.editingStatusBinding?.wrappedValue = .editing(hasChanges: true) } }
+        bioFieldEditingViewModel.contentDidChange = { withAnimation { self.editingStatusBinding?.wrappedValue = .editing(hasChanges: true) } }
     }
     
     func checkForChanges() {
         let hasChanges = confirmedBannerImage != nil ||
         avatarConfirmedCroppedImage != nil ||
-        (initialInfo != nil && isAutomatedAccount != initialInfo?.metadata.isBot)
-        hasUnsavedChanges = hasChanges
+        (initialInfo != nil && isAutomatedAccount != initialInfo?.metadata.isBot) ||
+        customFields != initialInfo?.metadata.customFields
+        if hasChanges {
+            withAnimation { editingStatusBinding?.wrappedValue = .editing(hasChanges: true) }
+        }
     }
     
     func setAccount(_ account: MastodonAccount) {
@@ -331,9 +388,15 @@ class ProfileEditingViewModel {
         updateAccountTextFields(account: account)
         updateCustomFields(account: account)
         updateMetaData(account: account)
-        if let verifiedField = customFields?.first(where: { $0.verifiedAt != nil }) {
+        if customFields?.first(where: { $0.verifiedAt != nil }) != nil {
             showVerifiedLinkTip = false
         }
+        avatarConfirmedCroppedImage = nil
+        avatarPhotosPickerItem = nil
+        avatarImageToCrop = nil
+        confirmedBannerImage = nil
+        bannerImagePhotosPickerItem = nil
+        presentingAlert = nil
     }
     
     func updateAccountTextFields(account: MastodonAccount) {
@@ -388,6 +451,51 @@ class ProfileEditingViewModel {
             }
         }
         self.fieldEditingState = nil
+        
+        checkForChanges()
+    }
+    
+    func requestDeleteCustomField(_ field: Mastodon.Entity.Field) {
+        presentingAlert = .deleteCustomField(field)
+    }
+    
+    func confirmDeleteCustomField() {
+        let deletingField: Mastodon.Entity.Field? = {
+            switch presentingAlert {
+            case .deleteCustomField(let field):
+                return field
+            case nil:
+                return nil
+            }
+        }()
+        guard let field = deletingField, let index = customFields?.firstIndex(of: field) else { return }
+        customFields?.remove(at: index)
+        presentingAlert = nil
+        checkForChanges()
+    }
+    
+    func cancelDeleteCustomField() {
+        presentingAlert = nil
+    }
+}
+
+extension ProfileEditingViewModel {
+    enum ProfileEditingAlert {
+        case deleteCustomField(Mastodon.Entity.Field)
+        
+        var title: String {
+            switch self {
+            case .deleteCustomField:
+                "Delete custom field?"
+            }
+        }
+        
+        var messageText: String {
+            switch self {
+            case .deleteCustomField:
+                "Are you sure you want to delete this custom field? This action can’t be undone."
+            }
+        }
     }
 }
 
@@ -561,6 +669,7 @@ struct CustomProfileFieldsEditor: View {
             if isDraggable {
                 Image(systemName: "line.3.horizontal")
             }
+            
             VStack(alignment: .leading) {
                 Text(field.name)
                     .fixedSize(horizontal: false, vertical: true)
@@ -568,7 +677,24 @@ struct CustomProfileFieldsEditor: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             .font(.footnote)
+            
             Spacer()
+            
+            Button() {
+                withAnimation {
+                    editingViewModel.requestDeleteCustomField(field)
+                }
+            } label: {
+                Image(systemName: "trash")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.red)
+                    .padding(standardPadding)
+                    .background() {
+                        Circle()
+                            .stroke(.quaternary)
+                    }
+            }
         }
         .padding()
     }
@@ -582,6 +708,8 @@ struct DisplayPreferencesEditor: View {
             VStack(alignment: .leading) {
                 ProfileSectionHeader(section: .displayPreferences)
                 infoButton(.displayPreferences)
+                Text("this section is waiting on backend implementation")
+                    .foregroundColor(.red)
             }
             
             // SHOW/HIDE MEDIA TAB
@@ -719,3 +847,51 @@ struct RadioButtonArray: View {
 }
 
 let brandBackgroundColor: Color = Asset.Colors.Brand.lightBlurple.swiftUIColor.opacity(0.2)
+
+extension ProfileViewModel {
+    func commitEdits() async throws {
+        guard let authentication = AuthenticationServiceProvider.shared.currentActiveUser.value?.authentication else { throw APIService.APIError.explicit(.authenticationMissing) }
+        
+        let authenticationBox = MastodonAuthenticationBox(authentication: authentication)
+        let domain = authenticationBox.domain
+        let authorization = authenticationBox.userAuthorization
+        
+        func sizeLimitedImage(_ image: UIImage?, noLargerThan targetPixelSize: CGSize) -> UIImage? {
+            guard let image else { return nil }
+            if image.size.width <= targetPixelSize.width && image.size.height <= targetPixelSize.height {
+                return image
+            } else {
+                let resized = image.af.imageScaled(to: targetPixelSize)
+                return resized
+            }
+        }
+        
+        let updatedAvatarImage = sizeLimitedImage(editingViewModel.avatarConfirmedCroppedImage, noLargerThan: avatarImageMaxSizeInPixels)
+        let updatedBannerImage = sizeLimitedImage(editingViewModel.confirmedBannerImage, noLargerThan: bannerImageMaxSizeInPixels)
+        
+        let customFieldsData = editingViewModel.customFields?.map { Mastodon.Entity.Field(name: $0.name, value: $0.value) }
+        
+        let query = Mastodon.API.Account.UpdateCredentialQuery(
+            discoverable: nil,
+            bot: editingViewModel.isAutomatedAccount,
+            displayName: editingViewModel.displayNameFieldEditingViewModel.stringContent,
+            note: editingViewModel.bioFieldEditingViewModel.stringContent,
+            avatar: updatedAvatarImage.flatMap { Mastodon.Query.MediaAttachment.png($0.pngData()) },
+            header: updatedBannerImage.flatMap { Mastodon.Query.MediaAttachment.png($0.pngData()) },
+            locked: nil,
+            source: nil,
+            fieldsAttributes: customFieldsData
+        )
+        let response = try await APIService.shared.accountUpdateCredentials(
+            domain: domain,
+            query: query,
+            authorization: authorization
+        )
+        let updatedAccount = MastodonAccount.fromEntity(response.value)
+        account = updatedAccount
+        editingViewModel.setAccount(updatedAccount)
+    }
+}
+
+let avatarImageMaxSizeInPixels = CGSize(width: 400, height: 400)
+let bannerImageMaxSizeInPixels = CGSize(width: 1500, height: 500)

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
@@ -93,7 +93,24 @@ struct ProfileEditingView: View {
                 }
             }
         }
-//        .safeAreaPadding()
+        .onChange(of: editingViewModel.isAutomatedAccount) {
+            editingViewModel.checkForChanges()
+        }
+        .onChange(of: editingViewModel.avatarConfirmedCroppedImage) {
+            editingViewModel.checkForChanges()
+        }
+        .onChange(of: editingViewModel.confirmedBannerImage) {
+            editingViewModel.checkForChanges()
+        }
+        .onChange(of: editingViewModel.mediaTabVisibilitySetting) {
+            editingViewModel.checkForChanges()
+        }
+        .onChange(of: editingViewModel.mediaTabRepliesSetting) {
+            editingViewModel.checkForChanges()
+        }
+        .onChange(of: editingViewModel.featuredTabVisibilitySetting) {
+            editingViewModel.checkForChanges()
+        }
     }
     
     @ViewBuilder var nameAndBio: some View {
@@ -118,7 +135,8 @@ struct ProfileEditingView: View {
 @MainActor
 @Observable
 class ProfileEditingViewModel {
-    var hasUnsavedChanges: Bool = false
+    var hasUnsavedChanges = false
+    
     let displayNameFieldEditingViewModel = MetaTextInputFieldViewModel(stringContent: "", placeholder: "", characterLimit: .softLimit(100), autocompleteMastodonItems: false)
     let bioFieldEditingViewModel = MetaTextInputFieldViewModel(stringContent: "", placeholder: "Describe yourself and/or this account.", characterLimit: .softLimit(220), autocompleteMastodonItems: true)
     
@@ -140,7 +158,7 @@ class ProfileEditingViewModel {
     var customFields: [Mastodon.Entity.Field]? = nil
     var emojis: [Mastodon.Entity.Emoji] = []
     
-    private var isAutomatedAccount: Bool = false
+    var isAutomatedAccount: Bool = false
     var isAutomatedAccountBinding = Binding<Bool>( get: { false }, set: {_ in})
     
     private(set) var initialInfo: MastodonAccount? = nil
@@ -190,15 +208,26 @@ class ProfileEditingViewModel {
         )
         
         isAutomatedAccountBinding = Binding<Bool>(
-            get: { self._isAutomatedAccount },
-            set: { newValue in self._isAutomatedAccount = newValue }
+            get: { self.isAutomatedAccount },
+            set: { newValue in self.isAutomatedAccount = newValue }
         )
+        
+        displayNameFieldEditingViewModel.contentDidChange = { self.hasUnsavedChanges = true }
+        bioFieldEditingViewModel.contentDidChange = { self.hasUnsavedChanges = true }
+    }
+    
+    func checkForChanges() {
+        let hasChanges = confirmedBannerImage != nil ||
+        avatarConfirmedCroppedImage != nil ||
+        (initialInfo != nil && isAutomatedAccount != initialInfo?.metadata.isBot)
+        hasUnsavedChanges = hasChanges
     }
     
     func setAccount(_ account: MastodonAccount) {
         initialInfo = account
         updateAccountTextFields(account: account)
         updateCustomFields(account: account)
+        updateMetaData(account: account)
     }
     
     func updateAccountTextFields(account: MastodonAccount) {
@@ -212,6 +241,13 @@ class ProfileEditingViewModel {
     func updateCustomFields(account: MastodonAccount) {
         customFields = account.metadata.customFields
         emojis = account._legacyEntity.emojis
+    }
+    
+    func updateMetaData(account: MastodonAccount) {
+        mediaTabVisibilitySetting = .showMediaTab
+        mediaTabRepliesSetting = .showDirectPostsOnly
+        featuredTabVisibilitySetting = .showFeaturedTab
+        isAutomatedAccount = account.metadata.isBot
     }
 }
 

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
@@ -52,7 +52,7 @@ struct ProfileEditingView: View {
                             return
                         }
                         
-                        self.editingViewModel.avatarConfirmedCroppedImage = Image(uiImage: confirmedImage)
+                        self.editingViewModel.avatarConfirmedCroppedImage = confirmedImage
                     }
                 }
             }
@@ -77,15 +77,20 @@ struct ProfileEditingView: View {
 class ProfileEditingViewModel {
     var hasUnsavedChanges: Bool = false
     
-    var selectedAvatar: Binding<[PhotosPickerItem]>
+    var selectedBannerImage: Binding<[PhotosPickerItem]>
+    var bannerImagePhotosPickerItem: PhotosPickerItem?
+    var confirmedBannerImage: UIImage?
     
+    var selectedAvatar: Binding<[PhotosPickerItem]>
     var avatarPhotosPickerItem: PhotosPickerItem?
     var avatarImageToCrop: UIImage?
-    var avatarConfirmedCroppedImage: Image?
+    var avatarConfirmedCroppedImage: UIImage?
+    
     
     var showCroppingView: Binding<Bool>
     
     init() {
+        selectedBannerImage = Binding<[PhotosPickerItem]>(get: {[]}, set: {_ in})
         selectedAvatar = Binding<[PhotosPickerItem]>(get: {[]}, set: {_ in})
         showCroppingView = Binding<Bool>(get: {false}, set: {_ in})
     
@@ -93,6 +98,24 @@ class ProfileEditingViewModel {
             get: { return self.avatarImageToCrop != nil },
             set: { newValue in }
         )
+        
+        selectedBannerImage = Binding<[PhotosPickerItem]>(
+            get: { [self.bannerImagePhotosPickerItem].compactMap { $0 } },
+            set: { newValue in
+                self.bannerImagePhotosPickerItem = newValue.first
+                if let item = self.bannerImagePhotosPickerItem {
+                    Task {
+                        if let data = try? await item.loadTransferable(type: Data.self),
+                           let image = UIImage(data: data) {
+                            self.confirmedBannerImage = image
+                        } else {
+                            print("Failed to load banner image")
+                        }
+                    }
+                }
+            }
+        )
+        
         selectedAvatar = Binding<[PhotosPickerItem]>(
             get: { [self.avatarPhotosPickerItem].compactMap { $0 } },
             set: { newValue in

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileEditingView.swift
@@ -412,10 +412,9 @@ struct CustomProfileFieldsEditor: View {
             }
             VStack(alignment: .leading) {
                 Text(field.name)
-                    .fixedSize()
-                Text(field.value)
-                    .fontWeight(.semibold)
-                    .fixedSize()
+                    .fixedSize(horizontal: false, vertical: true)
+                MastodonContentView.customProfileField(html: field.value, emojis: editingViewModel.emojis, bold: true)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .font(.footnote)
             Spacer()

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
@@ -4,6 +4,7 @@ import MastodonAsset
 import MastodonLocalization
 import SDWebImageSwiftUI
 import SwiftUI
+import PhotosUI
 import MastodonCore
 import MastodonSDK
 import Combine
@@ -273,12 +274,14 @@ struct ProfileAvatarAndBannerView: View {
         
                 HStack() {
                     ZStack {
-                        AvatarView(size: .extraLarge, authorAvatarUrl: profileViewModel.account?.avatarURL, goToProfile: nil)
+                        AvatarView(size: .extraLarge, avatarSource: editingViewModel.avatarConfirmedCroppedImage != nil ? .local(editingViewModel.avatarConfirmedCroppedImage!) : .url(profileViewModel.account?.avatarURL), goToProfile: nil)
                             .padding(.horizontal, doublePadding)
                             .frame(alignment: .leading)
                         switch profileViewModel.editingStatus {
                         case .editing:
-                            avatarEditButton
+                            // if the user has already chosen a new image, let them see it unobscured, but tapping the avatar will still bring up the photo picker
+                            avatarEditButton(showButton: editingViewModel.avatarConfirmedCroppedImage == nil)
+                                .frame(maxWidth: AvatarSize.extraLarge, maxHeight: AvatarSize.extraLarge)
                         case .cannotEdit, .notEditing, .none:
                             EmptyView()
                         }
@@ -325,18 +328,20 @@ struct ProfileAvatarAndBannerView: View {
         .foregroundStyle(.white)
     }
     
-    @ViewBuilder var avatarEditButton: some View {
-        Button() {
-            
-        } label: {
-            Image(systemName: "camera")
-                .font(.headline)
-                .padding()
-                .tintedBlurBackground()
-                .clipShape(Circle())
+    @ViewBuilder func avatarEditButton(showButton: Bool) -> some View {
+        PhotosPicker(selection: editingViewModel.selectedAvatar, maxSelectionCount: 1, matching: .images) {
+            if showButton {
+                Image(systemName: "camera")
+                    .font(.headline)
+                    .padding()
+                    .tintedBlurBackground()
+                    .clipShape(Circle())
+                    .glassEffectIfAvailable(in: .circle)
+                    .foregroundStyle(.white)
+            } else {
+                Color.clear
+            }
         }
-        .glassEffectIfAvailable(in: .circle)
-        .foregroundStyle(.white)
     }
 }
 

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
@@ -110,6 +110,16 @@ struct ProfileView: View {
                                 .environment(viewModel.editingViewModel)
                         }
                     }
+                    .onChange(of: viewModel.editingStatus) { oldValue, newValue in
+                        switch newValue {
+                        case .cannotEdit, .editing, .notEditing:
+                            break
+                        case .pushingChanges(let success):
+                            guard success == true else { break }
+                            viewModel.editingStatus = .notEditing
+                            navigationPath.removeLast()
+                        }
+                    }
             }
             
         } else {
@@ -265,7 +275,7 @@ struct ProfileAvatarAndBannerView: View {
                             bannerEditButton
                                 .padding(.horizontal, doublePadding)
                                 .padding(.vertical, standardPadding)
-                        case .cannotEdit, .notEditing, .none:
+                        case .cannotEdit, .notEditing, .pushingChanges:
                             EmptyView()
                         }
                     }
@@ -283,7 +293,7 @@ struct ProfileAvatarAndBannerView: View {
                             // if the user has already chosen a new image, let them see it unobscured, but tapping the avatar will still bring up the photo picker
                             avatarEditButton(showButton: editingViewModel.avatarConfirmedCroppedImage == nil)
                                 .frame(maxWidth: AvatarSize.extraLarge, maxHeight: AvatarSize.extraLarge)
-                        case .cannotEdit, .notEditing, .none:
+                        case .cannotEdit, .notEditing, .pushingChanges:
                             EmptyView()
                         }
                     }
@@ -763,10 +773,29 @@ enum ProfilePage: CaseIterable, Hashable {
     }
 }
 
-enum EditingStatus {
+enum EditingStatus: Equatable {
     case cannotEdit
     case notEditing
     case editing(hasChanges: Bool)
+    case pushingChanges(success: Bool?)
+    
+    var showSaveButton: Bool {
+        switch self {
+        case .cannotEdit, .notEditing, .pushingChanges:
+            return false
+        case .editing(let hasChanges):
+            return hasChanges
+        }
+    }
+    
+    var showActivityIndicator: Bool {
+        switch self {
+        case .pushingChanges(let success):
+            return success == nil
+        default:
+            return false
+        }
+    }
 }
 
 @MainActor
@@ -777,7 +806,7 @@ enum EditingStatus {
         ProfileEditingViewModel()
     }()
     
-    var editingStatus: EditingStatus?
+    var editingStatus: EditingStatus = .cannotEdit
     
     struct HandleDetails {
         let username: String
@@ -829,6 +858,11 @@ enum EditingStatus {
                 guard let self, let update else { return }
                 self.incorporateUpdate(update)
             }
+        
+        editingViewModel.editingStatusBinding = Binding<EditingStatus>(
+            get: { self.editingStatus },
+            set: { newValue in self.editingStatus = newValue }
+        )
     }
     
     @ToolbarContentBuilder func toolbar(relationship: MastodonAccount.Relationship) -> some ToolbarContent {

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
@@ -40,6 +40,7 @@ class ProfileHostingViewController: UIHostingController<AnyView> {
     
     func set(account: MastodonAccount, relationship: MastodonAccount.Relationship) {
         viewModel.account = account
+        viewModel.editingViewModel.setAccount(account)
         viewModel.relationship = relationship
         viewModel.postsViewModel = TimelineListViewModel(timeline: .userPosts(userID: account.id, queryFilter: .init(.userPosts)), asyncRefreshViewModel: AsyncRefreshViewModel())
         viewModel.mediaViewModel = TimelineListViewModel(timeline: .userPosts(userID: account.id, queryFilter: .init(.mediaOnly)), asyncRefreshViewModel: AsyncRefreshViewModel())

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
@@ -274,7 +274,7 @@ struct ProfileAvatarAndBannerView: View {
         
                 HStack() {
                     ZStack {
-                        AvatarView(size: .extraLarge, avatarSource: editingViewModel.avatarConfirmedCroppedImage != nil ? .local(editingViewModel.avatarConfirmedCroppedImage!) : .url(profileViewModel.account?.avatarURL), goToProfile: nil)
+                        AvatarView(size: .extraLarge, avatarSource: editingViewModel.avatarConfirmedCroppedImage != nil ? .local(Image(uiImage: editingViewModel.avatarConfirmedCroppedImage!)) : .url(profileViewModel.account?.avatarURL), goToProfile: nil)
                             .padding(.horizontal, doublePadding)
                             .frame(alignment: .leading)
                         switch profileViewModel.editingStatus {
@@ -295,7 +295,12 @@ struct ProfileAvatarAndBannerView: View {
     }
     
     @ViewBuilder func bannerView(width: CGFloat) -> some View {
-        if let bannerUrl = profileViewModel.account?.displayInfo.bannerImageUrl {
+        if let replacementImage = editingViewModel.confirmedBannerImage {
+            Image(uiImage: replacementImage)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: width)
+        } else if let bannerUrl = profileViewModel.account?.displayInfo.bannerImageUrl {
             WebImage(url: bannerUrl) { phase in
                 switch phase {
                 case .empty:
@@ -315,17 +320,15 @@ struct ProfileAvatarAndBannerView: View {
     }
     
     @ViewBuilder var bannerEditButton: some View {
-        Button() {
-            
-        } label: {
+        PhotosPicker(selection: editingViewModel.selectedBannerImage, maxSelectionCount: 1, matching: .images) {
             Text("Edit cover image")
                 .padding(.vertical, tinySpacing)
                 .padding(.horizontal)
                 .tintedBlurBackground()
                 .clipShape(.capsule)
+                .glassEffectIfAvailable(in: .capsule)
+                .foregroundStyle(.white)
         }
-        .glassEffectIfAvailable(in: .capsule)
-        .foregroundStyle(.white)
     }
     
     @ViewBuilder func avatarEditButton(showButton: Bool) -> some View {

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
@@ -8,6 +8,10 @@ import MastodonCore
 import MastodonSDK
 import Combine
 
+enum MastodonNavigationDestination: Hashable {
+    case editProfile
+}
+
 class ProfileHostingViewController: UIHostingController<AnyView> {
     let viewModel = ProfileViewModel()
     let nestedScrollViewModel = NestedScrollInteractionViewModel()
@@ -16,6 +20,17 @@ class ProfileHostingViewController: UIHostingController<AnyView> {
         let root = ProfileView(wrapInNavigationController: wrapInNavigationController).environment(viewModel).environment(viewModel.relationshipViewModel).environment(nestedScrollViewModel)
         super.init(rootView: AnyView(root))
         title = nil
+        
+        viewModel.navigationControllerNavigateToEditProfile = { [weak self] in
+            if wrapInNavigationController {
+                return
+            } else {
+                guard let self else { return }
+                self.viewModel.editingStatus = .editing(hasChanges: false)
+                let editViewController = ProfileEditHostingViewController(viewModel: self.viewModel)
+                self.navigationController?.pushViewController(editViewController, animated: true)
+            }
+        }
     }
     @MainActor @preconcurrency required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -37,6 +52,13 @@ class ProfileHostingViewController: UIHostingController<AnyView> {
         
         viewModel.relationshipViewModel.actionHandler = viewModel.postsViewModel
         
+        switch relationship {
+        case .isMe:
+            viewModel.editingStatus = .notEditing
+        case .isNotMe:
+            viewModel.editingStatus = .cannotEdit
+        }
+        
         Task {
             let handle = account.handle
             let handleComponents = handle.split(separator: "@").map { String($0) }
@@ -54,6 +76,7 @@ class ProfileHostingViewController: UIHostingController<AnyView> {
 }
 
 struct ProfileView: View {
+    @State private var navigationPath = NavigationPath()
     @Environment(ProfileViewModel.self) var viewModel
     @Environment(NestedScrollInteractionViewModel.self) var nestedScrollViewModel
     let wrapInNavigationController: Bool
@@ -69,11 +92,24 @@ struct ProfileView: View {
         case pages
     }
     
+    init(wrapInNavigationController: Bool) {
+        self.wrapInNavigationController = wrapInNavigationController
+    }
+    
     var body: some View {
         if wrapInNavigationController {
-            NavigationStack() {
+            NavigationStack(path: $navigationPath){
                 content
+                    .navigationDestination(for: MastodonNavigationDestination.self) { destination in
+                        switch destination {
+                        case .editProfile:
+                            ProfileEditingView()
+                                .environment(viewModel)
+                                .environment(viewModel.editingViewModel)
+                        }
+                    }
             }
+            
         } else {
             content
         }
@@ -127,7 +163,10 @@ struct ProfileView: View {
                         Spacer()
                             .frame(height: doublePadding)
                         
-                        ProfileActionBar()
+                        ProfileActionBar(navigationStackNavigateToEditProfile: {
+                            viewModel.editingStatus = .editing(hasChanges: false)
+                            navigationPath.append(MastodonNavigationDestination.editProfile)
+                        })
                             .padding(.horizontal, doublePadding)
                             .frame(width: min(maxFeedContentWidth, geo.size.width))
                             .background() {
@@ -159,7 +198,9 @@ struct ProfileView: View {
                 
                 VStack {
                     Spacer()
-                    ProfileActionBar()
+                    ProfileActionBar(navigationStackNavigateToEditProfile: {
+                        navigationPath.append(MastodonNavigationDestination.editProfile)
+                    })
                         .padding(.horizontal, doublePadding)
                         .frame(width: min(maxFeedContentWidth, geo.size.width))
                         .background() {
@@ -170,7 +211,7 @@ struct ProfileView: View {
                         }
                         .opacity(embeddedActionBarHasCaughtUpToFloatingActionBar ? 0.0 : 1.0)
                 }
-                .frame(width: min(maxFeedContentWidth, geo.size.width), height: geo.size.height - geo.safeAreaInsets.bottom - 90)
+                .frame(width: min(maxFeedContentWidth, geo.size.width), height: max(0, geo.size.height - geo.safeAreaInsets.bottom - 90))
             }
         }
         .ignoresSafeArea()
@@ -188,6 +229,7 @@ struct ProfileView: View {
         switch subviewType {
         case .bannerAndAvatar:
             ProfileAvatarAndBannerView(width: width)
+                .environment(viewModel.editingViewModel)
         case .bio:
             ProfileInfoView()
         case .customFieldsFlow:
@@ -203,23 +245,44 @@ struct ProfileView: View {
 
 let bannerFullHeight: CGFloat = 194
 struct ProfileAvatarAndBannerView: View {
-    @Environment(ProfileViewModel.self) var viewModel
+    @Environment(ProfileViewModel.self) var profileViewModel
+    @Environment(ProfileEditingViewModel.self) var editingViewModel
     var width: CGFloat
     
     var body: some View {
         VStack {
             ZStack(alignment: Alignment(horizontal: .leading, vertical: .bottom)) {
                 VStack(spacing: 0) {
-                    bannerView(width: width)
-                        .frame(height: bannerFullHeight)
-                        .clipped()
+                    ZStack(alignment: Alignment(horizontal: .trailing, vertical: .bottom)) {
+                        bannerView(width: width)
+                            .frame(height: bannerFullHeight)
+                            .clipped()
+                        
+                        switch profileViewModel.editingStatus {
+                        case .editing:
+                            bannerEditButton
+                                .padding(.horizontal, doublePadding)
+                                .padding(.vertical, standardPadding)
+                        case .cannotEdit, .notEditing, .none:
+                            EmptyView()
+                        }
+                    }
                     Spacer()
                         .frame(height: 16)
                 }
+        
                 HStack() {
-                    AvatarView(size: .extraLarge, authorAvatarUrl: viewModel.account?.avatarURL, goToProfile: nil)
-                        .padding(.horizontal, doublePadding)
-                        .frame(alignment: .leading)
+                    ZStack {
+                        AvatarView(size: .extraLarge, authorAvatarUrl: profileViewModel.account?.avatarURL, goToProfile: nil)
+                            .padding(.horizontal, doublePadding)
+                            .frame(alignment: .leading)
+                        switch profileViewModel.editingStatus {
+                        case .editing:
+                            avatarEditButton
+                        case .cannotEdit, .notEditing, .none:
+                            EmptyView()
+                        }
+                    }
                     Spacer()
                         .frame(maxWidth: .infinity)
                 }
@@ -229,7 +292,7 @@ struct ProfileAvatarAndBannerView: View {
     }
     
     @ViewBuilder func bannerView(width: CGFloat) -> some View {
-        if let bannerUrl = viewModel.account?.displayInfo.bannerImageUrl {
+        if let bannerUrl = profileViewModel.account?.displayInfo.bannerImageUrl {
             WebImage(url: bannerUrl) { phase in
                 switch phase {
                 case .empty:
@@ -246,6 +309,34 @@ struct ProfileAvatarAndBannerView: View {
                 }
             }
         }
+    }
+    
+    @ViewBuilder var bannerEditButton: some View {
+        Button() {
+            
+        } label: {
+            Text("Edit cover image")
+                .padding(.vertical, tinySpacing)
+                .padding(.horizontal)
+                .tintedBlurBackground()
+                .clipShape(.capsule)
+        }
+        .glassEffectIfAvailable(in: .capsule)
+        .foregroundStyle(.white)
+    }
+    
+    @ViewBuilder var avatarEditButton: some View {
+        Button() {
+            
+        } label: {
+            Image(systemName: "camera")
+                .font(.headline)
+                .padding()
+                .tintedBlurBackground()
+                .clipShape(Circle())
+        }
+        .glassEffectIfAvailable(in: .circle)
+        .foregroundStyle(.white)
     }
 }
 
@@ -298,29 +389,6 @@ struct ProfileInfoView: View {
             HStack {
                 Spacer()
                     .frame(maxWidth: .infinity)
-                if let relationship = viewModel.relationship {
-                    switch relationship {
-                    case .isMe:
-                        if #available(iOS 26.0, *) {
-                            Button {
-                                
-                            } label: {
-                                Text("Edit Info")
-                            }
-                            .tint(Asset.Colors.accent.swiftUIColor)
-                            .buttonStyle(.glassProminent)
-                        } else {
-                            Button {
-                                
-                            } label: {
-                                Text("Edit Info")
-                            }
-                            .tint(Asset.Colors.accent.swiftUIColor)
-                        }
-                    case .isNotMe:
-                        EmptyView()
-                    }
-                }
             }
         }
     }
@@ -541,13 +609,14 @@ struct ProfilePaginationControl: View {
                         .clipShape(RoundedRectangle(cornerRadius: CornerRadius.standard))
                     }
                 }
-                .glassEffectIfAvailable()
+                .glassEffectIfAvailable(in: RoundedRectangle(cornerRadius: CornerRadius.standard))
             }
         }
     }
 }
 
 struct ProfileActionBar: View {
+    let navigationStackNavigateToEditProfile: ()->()
     @Environment(ProfileViewModel.self) var viewModel
     @Environment(RelationshipViewModel.self) var relationshipViewModel
     
@@ -555,11 +624,9 @@ struct ProfileActionBar: View {
         HStack(spacing: standardPadding) {
             if let account = viewModel.account {
                 relationshipViewModel.button.largeButton {
-                    Task {
-                        try await relationshipViewModel.doRelationshipAction(relationshipViewModel.button.buttonAction, account: account)
-                    }
+                    navigationStackNavigateToEditProfile()
                 }
-                .glassEffectIfAvailable()
+                .glassEffectIfAvailable(in: .capsule)
                 
                 Button() {
                     
@@ -571,7 +638,7 @@ struct ProfileActionBar: View {
                         Image(systemName: "at")
                     }
                 }
-                .glassEffectIfAvailable()
+                .glassEffectIfAvailable(in: .circle)
                 
                 Button() {
                     
@@ -583,7 +650,7 @@ struct ProfileActionBar: View {
                         Image(systemName: "ellipsis")
                     }
                 }
-                .glassEffectIfAvailable()
+                .glassEffectIfAvailable(in: .circle)
             }
         }
     }
@@ -687,9 +754,21 @@ enum ProfilePage: CaseIterable, Hashable {
     }
 }
 
+enum EditingStatus {
+    case cannotEdit
+    case notEditing
+    case editing(hasChanges: Bool)
+}
+
 @MainActor
 @Observable class ProfileViewModel {
     let relationshipViewModel = RelationshipViewModel()
+    
+    let editingViewModel = {
+        ProfileEditingViewModel()
+    }()
+    
+    var editingStatus: EditingStatus?
     
     struct HandleDetails {
         let username: String
@@ -697,6 +776,7 @@ enum ProfilePage: CaseIterable, Hashable {
         let isMyDomain: Bool
     }
     var account: MastodonAccount?
+    var navigationControllerNavigateToEditProfile: (()->())?
     var relationship: MastodonAccount.Relationship?
     var postsViewModel: TimelineListViewModel? {
         didSet {

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
@@ -644,6 +644,7 @@ struct ProfileActionBar: View {
             if let account = viewModel.account {
                 relationshipViewModel.button.largeButton {
                     navigationStackNavigateToEditProfile()
+                    viewModel.navigationControllerNavigateToEditProfile?()
                 }
                 .glassEffectIfAvailable(in: .capsule)
                 

--- a/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
@@ -745,7 +745,7 @@ enum MastodonTimelineSheet {
         GeometryReader { geo in
             ZStack(alignment: .topLeading) {
                 ZStack {
-                    Color.black.opacity(0.6)
+                    Color.dimmingBackground
                         .ignoresSafeArea()
                         .onTapGesture { [weak self] in
                             self?.activeOverlay = nil

--- a/MastodonSDK/Sources/MastodonLocalization/Resources/L10nLookup.swift
+++ b/MastodonSDK/Sources/MastodonLocalization/Resources/L10nLookup.swift
@@ -69,6 +69,11 @@ public struct L10nLookup {
                     return result
                 }()
             }
+            
+            public static let editProfileButton: String = {
+                let result = tr("Localizable", "Common.Controls.EditProfileButton")
+                return result
+            }()
         }
     }
     
@@ -257,6 +262,13 @@ public struct L10nLookup {
                     return result
                 }()
             }
+        }
+        
+        public struct EditProfile {
+            public static let title: String = {
+                let result = tr("Localizable", "Scene.EditProfile.Title")
+                return result
+            }()
         }
     }
 

--- a/MastodonSDK/Sources/MastodonLocalization/Resources/Localizable.xcstrings
+++ b/MastodonSDK/Sources/MastodonLocalization/Resources/Localizable.xcstrings
@@ -34717,6 +34717,17 @@
         }
       }
     },
+    "Common.Controls.EditProfileButton" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Profile"
+          }
+        }
+      }
+    },
     "Common.Controls.Friendship.Block" : {
       "extractionState" : "migrated",
       "localizations" : {
@@ -152896,6 +152907,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "感謝您的貢獻！"
+          }
+        }
+      }
+    },
+    "Scene.EditProfile.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Profile"
           }
         }
       }

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/AutoComplete/AutoCompleteViewModel+State.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/AutoComplete/AutoCompleteViewModel+State.swift
@@ -115,7 +115,7 @@ extension AutoCompleteViewModel.State {
             }
 
             enter(state: Idle.self)
-            viewModel.autoCompleteItems.value = items
+            viewModel.autoCompleteItems.send(items)
         }
         
         private func queryRemoteEnitity(searchText: String) async {

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/View/ComposeContentView.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/View/ComposeContentView.swift
@@ -51,6 +51,7 @@ public struct ComposeContentView: View {
                     MetaTextViewRepresentable(
                         string: $viewModel.contentWarning,
                         width: viewModel.viewLayoutFrame.layoutFrame.width - ComposeContentView.margin * 2,
+                        allowScroll: false,
                         configurationHandler: { metaText in
                             viewModel.contentWarningMetaText = metaText
                             metaText.textView.attributedPlaceholder = {
@@ -96,6 +97,7 @@ public struct ComposeContentView: View {
                 MetaTextViewRepresentable(
                     string: $viewModel.content,
                     width: viewModel.viewLayoutFrame.layoutFrame.width - ComposeContentView.margin * 2,
+                    allowScroll: false,
                     configurationHandler: { metaText in
                         viewModel.contentMetaText = metaText
                         metaText.textView.attributedPlaceholder = {

--- a/MastodonSDK/Sources/MastodonUI/SwiftUI/MetaTextViewRepresentable.swift
+++ b/MastodonSDK/Sources/MastodonUI/SwiftUI/MetaTextViewRepresentable.swift
@@ -15,6 +15,7 @@ import MastodonCore
 public struct MetaTextViewRepresentable: UIViewRepresentable {
 
     let metaText = MetaText()
+    let allowScroll: Bool
     
     // input
     let string: Binding<String>
@@ -23,7 +24,8 @@ public struct MetaTextViewRepresentable: UIViewRepresentable {
     // handler
     let configurationHandler: (MetaText) -> Void
     
-    public init(string: Binding<String>, width: CGFloat, configurationHandler: @escaping (MetaText) -> Void) {
+    public init(string: Binding<String>, width: CGFloat, allowScroll: Bool, configurationHandler: @escaping (MetaText) -> Void) {
+        self.allowScroll = allowScroll
         self.string = string
         self.width = width
         self.configurationHandler = configurationHandler
@@ -61,6 +63,12 @@ public struct MetaTextViewRepresentable: UIViewRepresentable {
         configurationHandler(metaText)
             
         metaText.configure(content: PlaintextMetaContent(string: string.wrappedValue))
+        
+        if allowScroll {
+            metaText.textView.isScrollEnabled = true
+            metaText.textView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+            metaText.textView.setContentHuggingPriority(.defaultLow, for: .vertical)
+        }
         
         return textView
     }


### PR DESCRIPTION
This implements (most of) the new profile editing design in SwiftUI. There is some navigation complexity for now because until the main navigation of the app is moved to SwiftUI, the profile view may be contained in SwiftUI NavigationStack (when accessed via the profile button in the tabbar) or in a UIHostingController in a UINavigationController. 

Contributes to IOS-632