### PR TITLE
SwiftUI media viewer and profile improvements

### DIFF
--- a/Mastodon.xcodeproj/project.pbxproj
+++ b/Mastodon.xcodeproj/project.pbxproj
@@ -388,6 +388,7 @@
 				"Common Components/Views/MastodonTimelineOverlayView/BoostOrQuoteDialog.swift",
 				"Common Components/Views/MastodonTimelineOverlayView/ZoomableBlurhashImageView.swift",
 				"Common Components/Views/MetaTextInputField.swift",
+				"Common Components/Views/PageableImageGallery.swift",
 				"Common Components/Views/PhotoCropperView.swift",
 				"Common Components/Views/StatefulActionButton.swift",
 				"Common Components/Views/TextViewWithCustomEmoji.swift",

--- a/Mastodon.xcodeproj/project.pbxproj
+++ b/Mastodon.xcodeproj/project.pbxproj
@@ -383,6 +383,7 @@
 				"Common Components/ProportionalImageGridLayout.swift",
 				"Common Components/TimestampUpdater.swift",
 				"Common Components/Views/AccountStatsView.swift",
+				"Common Components/Views/AltTextOverlay.swift",
 				"Common Components/Views/DonationPromptBanner.swift",
 				"Common Components/Views/MastodonTimelineOverlayView/AltTextView.swift",
 				"Common Components/Views/MastodonTimelineOverlayView/BoostOrQuoteDialog.swift",

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Common Actions on Statuses and Accounts/MastodonPostMenuAction.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Common Actions on Statuses and Accounts/MastodonPostMenuAction.swift
@@ -27,7 +27,7 @@ protocol MastodonPostMenuActionHandler {
     func canTranslate(post: MastodonContentPost) -> Bool
     func translation(forContentPostId postId: Mastodon.Entity.Status.ID) -> Mastodon.Entity.Translation?
     func presentScene(_ scene: SceneCoordinator.Scene, fromPost postID: Mastodon.Entity.Status.ID?, transition: SceneCoordinator.Transition)
-    func showOverlay(_ modalView: MastodonTimelineOverlayView?)
+    var containerOverlayBinding: Binding<MastodonTimelineOverlayView?> { get }
     func showSheet(_ sheet: MastodonTimelineSheet?)
     func vote(poll: Mastodon.Entity.Poll, choices: [Int], containingPostID: Mastodon.Entity.Status.ID) async throws -> Mastodon.Entity.Poll
     var mediaPreviewableViewController: MediaPreviewableViewController? { get }

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/AltTextOverlay.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/AltTextOverlay.swift
@@ -1,0 +1,87 @@
+// Copyright © 2026 Mastodon gGmbH. All rights reserved.
+
+import MastodonUI
+import SwiftUI
+
+/// This view's body is empty if the altTextBinding is nil.
+/// This view expects to dismiss itself by setting the altTextBinding to nil. It does that when the background of the view is tapped or when the view is swiped down to a sufficient offset.
+struct AltTextOverlay: View {
+    let altTextBinding: Binding<String?>
+    @State var offset: CGSize = .zero
+    @GestureState var liveOffset: CGSize = .zero
+    
+    var body: some View {
+        if let altText = altTextBinding.wrappedValue {
+            GeometryReader { geo in
+                ZStack {
+                    Color.dimmingBackground
+                        .gesture(dismissGesture(forViewHeight: geo.size.height))
+                        .onDisappear() {
+                            offset = .zero
+                        }
+
+                    Text(altText)
+                        .foregroundColor(.white)
+                        .padding()
+                        .background {
+                            Color.dimmingBackground
+                        }
+                        .offset(offset + liveOffset)
+                }
+            }
+            .ignoresSafeArea()
+        }
+    }
+    
+    func dismissGesture(forViewHeight viewHeight: CGFloat) -> some Gesture {
+        SimultaneousGesture(
+            
+            TapGesture()
+                .onEnded { _ in
+                    self.altTextBinding.wrappedValue = nil
+                },
+            
+            DragGesture()
+                .updating($liveOffset) { value, state, _ in
+                    state = CGSize(width: 0, height: value.translation.height)
+                }
+                .onEnded { value in
+                    if value.translation.height > viewHeight * 0.25 {
+                        offset = CGSize(width: 0, height: value.translation.height)
+                        withAnimation {
+                            offset = CGSize(width: 0, height: viewHeight)
+                            altTextBinding.wrappedValue = nil
+                        }
+                    }
+                }
+        )
+    }
+}
+
+/// This button sets the displayAltText.wrappedValue to altText when tapped.  Use the AltTextOverlay to display the text in a dismissable view.
+/// The button is hidden from accessibility since accessibility users should have access to the alt text as a description of the media without performing a special action.
+struct AltTextButton: View {
+    let drawBorder: Bool
+    let altText: String
+    let displayAltText: Binding<String?>
+    
+    var body: some View {
+        Button {
+            displayAltText.wrappedValue = altText
+        } label: {
+            Text("ALT")
+                .foregroundStyle(.white)
+                .padding(.vertical, ButtonPadding.vertical)
+                .padding(.horizontal, ButtonPadding.horizontal)
+                .background() {
+                    RoundedRectangle(cornerRadius: CornerRadius.small)
+                        .fill(buttonBackgroundColor)
+                        .stroke(drawBorder ? Color.secondary : .clear)
+                }
+        }
+        .fixedSize()
+        .padding(standardPadding)
+        .buttonStyle(.borderless)
+        .accessibilityHidden(true)
+    }
+}

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/MastodonTimelineOverlayView/AltTextView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/MastodonTimelineOverlayView/AltTextView.swift
@@ -5,8 +5,8 @@ import SwiftUI
 
 struct AltTextView: View {
     let altTextString: String
-    let frameSize: CGSize
-  
+    @Environment(\.pageSize) private var pageSize
+    
     var body: some View {
         VStack {
             Spacer()
@@ -16,9 +16,9 @@ struct AltTextView: View {
                     .fixedSize(horizontal: false, vertical: true)
                     .padding()
                     .foregroundStyle(Color.white)
-                    .frame(maxWidth: min(300, frameSize.width * 0.85))
+                    .frame(maxWidth: min(300, pageSize.width * 0.85))
             }
-            .frame(maxHeight: frameSize.height * 0.8)
+            .frame(maxHeight: pageSize.height * 0.8)
             .environment(\.colorScheme, .dark)
             .background() {
                 RoundedRectangle(cornerRadius: CornerRadius.standard)

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
@@ -182,24 +182,29 @@ import MastodonSDK
     }
 }
 
-struct PageableImageGallery: View {
-    @Environment(ImageGalleryViewModel.self) var galleryViewModel
+extension EnvironmentValues {
+    @Entry var pageSize: CGSize = .zero
+}
+
+struct PageableZoomableView<Content: View>: View {
     @Environment(PageableZoomableViewModel.self) var pageableZoomableViewModel
     @GestureState private var liveScale: CGFloat = 1
     @GestureState private var liveOffset: CGSize = .zero
     @State private var lastLiveOffset: CGSize = .zero  // this allows us to smoothly animate page changes when the drag gesture ends
     @State private var offset: CGSize = .zero
     
+    let contentView: Content
+    
+    init(@ViewBuilder content: () -> Content) {
+        contentView = content()
+    }
+    
     var body: some View {
         GeometryReader { geo in
             ZStack(alignment: Alignment(horizontal: .leading, vertical: .center)) {
-                HStack(spacing: 0) {
-                    ForEach(galleryViewModel.imageAttachments, id: \.self.id) { imageInfo in
-                        ZoomableImageView(size: geo.size,
-                                          index: galleryViewModel.idToIndex[imageInfo.id] ?? 0)
-                    }
-                }
-                .offset(offset + (liveOffset == .zero ? lastLiveOffset : liveOffset))
+                contentView
+                    .environment(\.pageSize, geo.size)
+                    .offset(offset + (liveOffset == .zero ? lastLiveOffset : liveOffset))
                 
                 Color.clear
                     .contentShape(Rectangle())

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
@@ -23,7 +23,7 @@ import MastodonSDK
     private(set) var contentPageSizes: [CGSize]
     private(set) var contentsFittingSizes: [CGSize]
     
-    init(pageCount: Int, dismiss: @escaping ()->()) {
+    init(pageCount: Int, focusedPage: Int, dismiss: @escaping ()->()) {
         self.pageCount = pageCount
         self.dismiss = dismiss
         self.zoomScales = Array(repeating: 1, count: pageCount)
@@ -31,6 +31,7 @@ import MastodonSDK
         self.contentPageSizes = Array(repeating: .zero, count: pageCount)
         self.contentsFittingSizes = Array(repeating: .zero, count: pageCount)
         self.focusedPageContentsFittingSizes = Array(repeating: .zero, count: pageCount)
+        self.focusedPageIndex = focusedPage
     }
     
     func focus(page: Int) {
@@ -47,9 +48,10 @@ import MastodonSDK
         reclampExistingOffsetsAndScales()
     }
     
-    func updatePagingPageSize(_ newSize: CGSize) {
+    func updatePagingPageSizeAndReturnNewFocusedPageOffset(_ newSize: CGSize) -> CGSize {
         pagingPageSize = newSize
         reclampExistingOffsetsAndScales()
+        return CGSize(width: -pagingPageSize.width * CGFloat(focusedPageIndex), height: 0)
     }
     
     func reclampExistingOffsetsAndScales() {
@@ -206,10 +208,10 @@ struct PageableImageGallery: View {
                     .gesture(zoomAndPan) // putting the gesture on a stationary view keeps the motion smooth
             }
             .onAppear() {
-                pageableZoomableViewModel.updatePagingPageSize(geo.size)
+                offset = pageableZoomableViewModel.updatePagingPageSizeAndReturnNewFocusedPageOffset(geo.size)
             }
             .onChange(of: geo.size) { _, newValue in
-                pageableZoomableViewModel.updatePagingPageSize(newValue)
+                offset = pageableZoomableViewModel.updatePagingPageSizeAndReturnNewFocusedPageOffset(newValue)
             }
         }
         .ignoresSafeArea()

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import MastodonSDK
 
 @Observable class PageableZoomableViewModel {
+    let pageCount: Int
     let dismiss: ()->()
     
     private(set) var focusedPageIndex: Int = 0
@@ -10,17 +11,19 @@ import MastodonSDK
     let minZoom: CGFloat = 1
     
     private var focusedPageZoomScale: CGFloat = 1
-    private var focusedPageOffset: CGSize = .zero
+    private var focusedPageInternalOffset: CGSize = .zero
     
     private var focusedPageLiveZoomScale: CGFloat = 1
     private var focusedPageLiveOffset: CGSize = .zero
     
     private var excessScrollDirection: Axis?
 
-    private var focusedPageGeoSize: CGSize = .zero
+    private(set) var pagingPageSize: CGSize = .zero
+    private(set) var contentPageSize: CGSize = .zero
     private var focusedPageContentsFittingSize: CGSize = .zero
     
-    init(dismiss: @escaping ()->()) {
+    init(pageCount: Int, dismiss: @escaping ()->()) {
+        self.pageCount = pageCount
         self.dismiss = dismiss
     }
     
@@ -29,11 +32,23 @@ import MastodonSDK
         focusedPageIndex = page
     }
     
-    func updateFocusedPageGeometry(geoSize: CGSize, contentsFittingSize: CGSize) {
-        focusedPageGeoSize = geoSize
-        focusedPageContentsFittingSize = contentsFittingSize
+    func updateContentsFittingSize(_ newSize: CGSize) {
+        focusedPageContentsFittingSize = newSize
+    }
+    
+    func updateContentPageSize(_ newSize: CGSize) {
+        contentPageSize = newSize
+        reclampExistingOffsetAndScale()
+    }
+    
+    func updatePagingPageSize(_ newSize: CGSize) {
+        pagingPageSize = newSize
+        reclampExistingOffsetAndScale()
+    }
+    
+    func reclampExistingOffsetAndScale() {
         focusedPageZoomScale = clampZoom(focusedPageZoomScale)
-        focusedPageOffset = clampOffset(focusedPageOffset)
+        focusedPageInternalOffset = clampOffset(focusedPageInternalOffset)
     }
     
     private func resetPageTransforms(liveOnly: Bool) {
@@ -43,11 +58,11 @@ import MastodonSDK
         
         guard !liveOnly else { return }
         focusedPageZoomScale = 1
-        focusedPageOffset = .zero
+        focusedPageInternalOffset = .zero
     }
     
     var liveUpdatePageContentsOffset: CGSize {
-        focusedPageOffset + focusedPageLiveOffset
+        focusedPageInternalOffset + focusedPageLiveOffset
     }
     
     var liveUpdatePageContentsScale: CGFloat {
@@ -65,8 +80,8 @@ import MastodonSDK
         }
     }
     
-    func absorbLiveUpdateOffsetIntoFocusedPageAndReturnExcess(liveOffset: CGSize, gestureIsEnded: Bool) -> CGSize {
-        let proposedOffset = liveOffset + focusedPageOffset
+    func absorbLiveUpdateOffsetIntoFocusedPageAndReturnExcess(liveOffset: CGSize, currentOffset: CGSize, gestureIsEnded: Bool) -> CGSize {
+        let proposedOffset = liveOffset + focusedPageInternalOffset
         let clamped = clampOffset(proposedOffset)
        
         let excess = proposedOffset - clamped
@@ -88,13 +103,31 @@ import MastodonSDK
         }
 
         if gestureIsEnded {
-            focusedPageOffset = clamped
-            resetPageTransforms(liveOnly: true)
-            return .zero
+            focusedPageInternalOffset = clamped
+            switch excessScrollDirection {
+            case .horizontal:
+                let (newFocusedPage, newPagedOffset) = restingPagedOffset(unidirectionalExcessOffset + currentOffset)
+                resetPageTransforms(liveOnly: true)
+                focusedPageIndex = newFocusedPage
+                return newPagedOffset
+            case .vertical:
+                resetPageTransforms(liveOnly: true)
+                return unidirectionalExcessOffset
+            case nil:
+                assertionFailure("excessScrollDirection should be known as soon as gesture begins")
+                return .zero
+            }
         } else {
             focusedPageLiveOffset = clamped
             return unidirectionalExcessOffset
         }
+    }
+    
+    private func restingPagedOffset(_ rawOffset: CGSize) -> (Int, CGSize) {
+        // find the closest boundary. note that acceptable resting offsets are always <= 0.
+        let widthsOffsetNoFurtherThanFinalImage = max(-(CGFloat(pageCount - 1)), (rawOffset.width / pagingPageSize.width).rounded(.toNearestOrEven))
+        let widthsOffset = min(widthsOffsetNoFurtherThanFinalImage, 0)
+        return (Int(widthsOffset), CGSize(width: pagingPageSize.width * widthsOffset, height: 0))
     }
     
     func clampOffset(_ proposedOffset: CGSize) -> CGSize {
@@ -105,19 +138,19 @@ import MastodonSDK
         let maxY: CGFloat
         let minX: CGFloat
         let minY: CGFloat
-        if scaledSize.width < focusedPageGeoSize.width {
-            maxX = (focusedPageGeoSize.width - scaledSize.width) / 2.0
+        if scaledSize.width < contentPageSize.width {
+            maxX = (contentPageSize.width - scaledSize.width) / 2.0
             minX = maxX
         } else {
             maxX = 0
-            minX = focusedPageGeoSize.width - scaledSize.width
+            minX = contentPageSize.width - scaledSize.width
         }
-        if scaledSize.height < focusedPageGeoSize.height {
-            maxY = (focusedPageGeoSize.height - scaledSize.height) / 2.0
+        if scaledSize.height < contentPageSize.height {
+            maxY = (contentPageSize.height - scaledSize.height) / 2.0
             minY = maxY
         } else {
             maxY = 0
-            minY = focusedPageGeoSize.height - scaledSize.height
+            minY = contentPageSize.height - scaledSize.height
         }
         
         let maxOffset = CGSize(width: maxX, height: maxY)
@@ -143,7 +176,7 @@ struct PageableImageGallery: View {
     var body: some View {
         GeometryReader { geo in
             ZStack(alignment: Alignment(horizontal: .leading, vertical: .center)) {
-                HStack {
+                HStack(spacing: 0) {
                     ForEach(galleryViewModel.imageAttachments, id: \.self.id) { imageInfo in
                         ZoomableImageView(size: geo.size,
                                           index: galleryViewModel.idToIndex[imageInfo.id] ?? 0)
@@ -156,6 +189,12 @@ struct PageableImageGallery: View {
                     .frame(width: geo.size.width, height: geo.size.height)
                     .scaleEffect(pageableZoomableViewModel.liveUpdatePageContentsScale, anchor: .topLeading)
                     .gesture(zoomAndPan) // putting the gesture on a stationary view keeps the motion smooth
+            }
+            .onAppear() {
+                pageableZoomableViewModel.updatePagingPageSize(geo.size)
+            }
+            .onChange(of: geo.size) { _, newValue in
+                pageableZoomableViewModel.updatePagingPageSize(newValue)
             }
         }
         .ignoresSafeArea()
@@ -174,13 +213,17 @@ struct PageableImageGallery: View {
             
             DragGesture()
                 .updating($liveOffset) { value, state, _ in
-                    let excessOffset = pageableZoomableViewModel.absorbLiveUpdateOffsetIntoFocusedPageAndReturnExcess(liveOffset: value.translation, gestureIsEnded: false)
+                    let excessOffset = pageableZoomableViewModel.absorbLiveUpdateOffsetIntoFocusedPageAndReturnExcess(liveOffset: value.translation, currentOffset: offset, gestureIsEnded: false)
                     state = excessOffset
                     print("updating drag \(value.translation)")
                 }
                 .onEnded { value in
-                    let excessOffset = pageableZoomableViewModel.absorbLiveUpdateOffsetIntoFocusedPageAndReturnExcess(liveOffset: value.translation, gestureIsEnded: true)
-                    offset = excessOffset
+                    let excessOffset = pageableZoomableViewModel.absorbLiveUpdateOffsetIntoFocusedPageAndReturnExcess(liveOffset: value.translation, currentOffset: offset, gestureIsEnded: true)
+                    if abs(excessOffset.height) > (pageableZoomableViewModel.pagingPageSize.height / 2.0) {
+                        pageableZoomableViewModel.dismiss()
+                    } else {
+                        offset = CGSize(width: excessOffset.width, height: excessOffset.height)
+                    }
                 }
         )
     }
@@ -243,8 +286,9 @@ struct ZoomableImageView: View {
     }
     
     func updateGeometry(fromSize size: CGSize) {
+        pageableZoomableViewModel.updateContentPageSize(size)
         fittingSize = calculateFittingSize(fromContainerSize: size)
-        pageableZoomableViewModel.updateFocusedPageGeometry(geoSize: size, contentsFittingSize: fittingSize)
+        pageableZoomableViewModel.updateContentsFittingSize(fittingSize)
     }
     
     func calculateFittingSize(fromContainerSize containerSize: CGSize) -> CGSize {

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
@@ -1,27 +1,40 @@
 // Copyright © 2026 Mastodon gGmbH. All rights reserved.
 import SwiftUI
+import MastodonSDK
 
 struct PageableImageGallery: View {
     @Environment(ImageGalleryViewModel.self) var galleryViewModel
     
     var body: some View {
-        ZoomableImageView(index: 0)
+        GeometryReader { geo in
+            ScrollView(.horizontal) {
+                HStack {
+                    ForEach(galleryViewModel.imageAttachments, id: \.self.id) { imageInfo in
+                        ZoomableImageView(size: geo.size, index: galleryViewModel.idToIndex[imageInfo.id] ?? 0)
+                    }
+                }
+            }
+        }
+        .ignoresSafeArea()
     }
 }
 
 
 struct ZoomableImageView: View {
     @Environment(ImageGalleryViewModel.self) var galleryViewModel
+    let size: CGSize
     let index: Int
     
-    public init(index: Int) {
+    public init(size: CGSize, index: Int) {
+        self.size = size
         self.index = index
     }
     
     private let maxScale: CGFloat = 4
     private var minScale: CGFloat = 1
-    @State private var geoSize: CGSize = .zero
+    private let margin: CGFloat = standardPadding
     
+    @State private var geoSize: CGSize = .zero
     @State private var scale: CGFloat = 1
     @State private var offset: CGSize = .zero
     @State private var fittingSize: CGSize = .zero
@@ -69,16 +82,12 @@ struct ZoomableImageView: View {
                         .onAppear() {
                             updateGeometry(fromSize: geo.size)
                         }
-                    Rectangle()
-                        .fill(.clear)
-                        .frame(width: fittingSize.width, height: fittingSize.height)
-                    Rectangle()
-                        .fill(.clear)
-                        .frame(width: fittingSize.width * scale, height: fittingSize.height * scale)
                 }
             }
             .padding()
         }
+        .frame(width: size.width, height: size.height)
+        .clipped()
     }
     
     func updateGeometry(fromSize size: CGSize) {

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
@@ -10,8 +10,9 @@ import MastodonSDK
     let maxZoom: CGFloat = 4
     let minZoom: CGFloat = 1
     
-    private var focusedPageZoomScale: CGFloat = 1
-    private var focusedPageInternalOffset: CGSize = .zero
+    private var zoomScales: [CGFloat]
+    private var internalOffsets: [CGSize]
+    private var focusedPageContentsFittingSizes: [CGSize]
     
     private var focusedPageLiveZoomScale: CGFloat = 1
     private var focusedPageLiveOffset: CGSize = .zero
@@ -19,71 +20,83 @@ import MastodonSDK
     private var excessScrollDirection: Axis?
 
     private(set) var pagingPageSize: CGSize = .zero
-    private(set) var contentPageSize: CGSize = .zero
-    private var focusedPageContentsFittingSize: CGSize = .zero
+    private(set) var contentPageSizes: [CGSize]
+    private(set) var contentsFittingSizes: [CGSize]
     
     init(pageCount: Int, dismiss: @escaping ()->()) {
         self.pageCount = pageCount
         self.dismiss = dismiss
+        self.zoomScales = Array(repeating: 1, count: pageCount)
+        self.internalOffsets = Array(repeating: .zero, count: pageCount)
+        self.contentPageSizes = Array(repeating: .zero, count: pageCount)
+        self.contentsFittingSizes = Array(repeating: .zero, count: pageCount)
+        self.focusedPageContentsFittingSizes = Array(repeating: .zero, count: pageCount)
     }
     
     func focus(page: Int) {
-        resetPageTransforms(liveOnly: false)
+        resetLiveTransforms()
         focusedPageIndex = page
     }
     
-    func updateContentsFittingSize(_ newSize: CGSize) {
-        focusedPageContentsFittingSize = newSize
+    func updateContentsFittingSize(_ index: Int, newSize: CGSize) {
+        contentsFittingSizes[index] = newSize
     }
     
-    func updateContentPageSize(_ newSize: CGSize) {
-        contentPageSize = newSize
-        reclampExistingOffsetAndScale()
+    func updateContentPageSize(_ index: Int, newSize: CGSize) {
+        contentPageSizes[index] = newSize
+        reclampExistingOffsetsAndScales()
     }
     
     func updatePagingPageSize(_ newSize: CGSize) {
         pagingPageSize = newSize
-        reclampExistingOffsetAndScale()
+        reclampExistingOffsetsAndScales()
     }
     
-    func reclampExistingOffsetAndScale() {
-        focusedPageZoomScale = clampZoom(focusedPageZoomScale)
-        focusedPageInternalOffset = clampOffset(focusedPageInternalOffset)
+    func reclampExistingOffsetsAndScales() {
+        for (i, scale) in zoomScales.enumerated() {
+            zoomScales[i] = clampZoom(scale)
+        }
+        for (i, offset) in internalOffsets.enumerated() {
+            internalOffsets[i] = clampOffset(i, proposedOffset: offset)
+        }
     }
     
-    private func resetPageTransforms(liveOnly: Bool) {
+    private func resetLiveTransforms() {
         focusedPageLiveZoomScale = 1
         focusedPageLiveOffset = .zero
         excessScrollDirection = nil
-        
-        guard !liveOnly else { return }
-        focusedPageZoomScale = 1
-        focusedPageInternalOffset = .zero
     }
     
-    var liveUpdatePageContentsOffset: CGSize {
-        focusedPageInternalOffset + focusedPageLiveOffset
+    func liveUpdatePageContentsOffset(_ index: Int) -> CGSize {
+        if index == focusedPageIndex {
+            return internalOffsets[index] + focusedPageLiveOffset
+        } else {
+            return internalOffsets[index]
+        }
     }
     
-    var liveUpdatePageContentsScale: CGFloat {
-        focusedPageZoomScale * focusedPageLiveZoomScale
+    func liveUpdatePageContentsScale(_ index: Int) -> CGFloat {
+        if index == focusedPageIndex {
+            return zoomScales[index] * focusedPageLiveZoomScale
+        } else {
+            return zoomScales[index]
+        }
     }
     
     func absorbLiveUpdateZoomScaleIntoFocusedPage(liveScale: CGFloat, gestureIsEnded: Bool) {
-        let proposedScale = liveScale * focusedPageZoomScale
+        let proposedScale = liveScale * zoomScales[focusedPageIndex]
         let clamped = clampZoom(proposedScale)
-        focusedPageLiveZoomScale = clamped / focusedPageZoomScale
+        focusedPageLiveZoomScale = clamped / zoomScales[focusedPageIndex]
         
         if gestureIsEnded  {
-            focusedPageZoomScale = clamped
-            resetPageTransforms(liveOnly: true)
+            zoomScales[focusedPageIndex] = clamped
+            resetLiveTransforms()
         }
     }
     
     func absorbLiveUpdateOffsetIntoFocusedPageAndReturnExcess(liveOffset: CGSize, currentOffset: CGSize, gestureIsEnded: Bool) -> CGSize {
-        let proposedOffset = liveOffset + focusedPageInternalOffset
-        let clamped = clampOffset(proposedOffset)
-       
+        let proposedOffset = liveOffset + internalOffsets[focusedPageIndex]
+        let clamped = clampOffset(focusedPageIndex, proposedOffset: proposedOffset)
         let excess = proposedOffset - clamped
         
         if excessScrollDirection == nil {
@@ -101,24 +114,24 @@ import MastodonSDK
             assertionFailure("should have been assigned by now")
             break
         }
-
+        
         if gestureIsEnded {
-            focusedPageInternalOffset = clamped
+            internalOffsets[focusedPageIndex] = clamped
             switch excessScrollDirection {
             case .horizontal:
                 let (newFocusedPage, newPagedOffset) = restingPagedOffset(unidirectionalExcessOffset + currentOffset)
-                resetPageTransforms(liveOnly: true)
-                focusedPageIndex = newFocusedPage
+                resetLiveTransforms()
+                focus(page: newFocusedPage)
                 return newPagedOffset
             case .vertical:
-                resetPageTransforms(liveOnly: true)
+                resetLiveTransforms()
                 return unidirectionalExcessOffset
             case nil:
                 assertionFailure("excessScrollDirection should be known as soon as gesture begins")
                 return .zero
             }
         } else {
-            focusedPageLiveOffset = clamped
+            focusedPageLiveOffset = clamped - internalOffsets[focusedPageIndex]
             return unidirectionalExcessOffset
         }
     }
@@ -127,12 +140,13 @@ import MastodonSDK
         // find the closest boundary. note that acceptable resting offsets are always <= 0.
         let widthsOffsetNoFurtherThanFinalImage = max(-(CGFloat(pageCount - 1)), (rawOffset.width / pagingPageSize.width).rounded(.toNearestOrEven))
         let widthsOffset = min(widthsOffsetNoFurtherThanFinalImage, 0)
-        return (Int(widthsOffset), CGSize(width: pagingPageSize.width * widthsOffset, height: 0))
+        return (Int(-widthsOffset), CGSize(width: pagingPageSize.width * widthsOffset, height: 0))
     }
     
-    func clampOffset(_ proposedOffset: CGSize) -> CGSize {
-        let baseSize = focusedPageContentsFittingSize
-        let scaledSize = CGSize(width: baseSize.width * focusedPageZoomScale, height: baseSize.height * focusedPageZoomScale)
+    func clampOffset(_ index: Int, proposedOffset: CGSize) -> CGSize {
+        let baseSize = contentsFittingSizes[index]
+        let scaledSize = CGSize(width: baseSize.width * zoomScales[index], height: baseSize.height * zoomScales[index])
+        let contentPageSize = contentPageSizes[index]
         
         let maxX: CGFloat
         let maxY: CGFloat
@@ -171,6 +185,7 @@ struct PageableImageGallery: View {
     @Environment(PageableZoomableViewModel.self) var pageableZoomableViewModel
     @GestureState private var liveScale: CGFloat = 1
     @GestureState private var liveOffset: CGSize = .zero
+    @State private var lastLiveOffset: CGSize = .zero  // this allows us to smoothly animate page changes when the drag gesture ends
     @State private var offset: CGSize = .zero
     
     var body: some View {
@@ -182,12 +197,12 @@ struct PageableImageGallery: View {
                                           index: galleryViewModel.idToIndex[imageInfo.id] ?? 0)
                     }
                 }
-                .offset(offset + liveOffset)
+                .offset(offset + (liveOffset == .zero ? lastLiveOffset : liveOffset))
                 
                 Color.clear
                     .contentShape(Rectangle())
                     .frame(width: geo.size.width, height: geo.size.height)
-                    .scaleEffect(pageableZoomableViewModel.liveUpdatePageContentsScale, anchor: .topLeading)
+                    .scaleEffect(pageableZoomableViewModel.liveUpdatePageContentsScale(pageableZoomableViewModel.focusedPageIndex), anchor: .topLeading)
                     .gesture(zoomAndPan) // putting the gesture on a stationary view keeps the motion smooth
             }
             .onAppear() {
@@ -215,14 +230,19 @@ struct PageableImageGallery: View {
                 .updating($liveOffset) { value, state, _ in
                     let excessOffset = pageableZoomableViewModel.absorbLiveUpdateOffsetIntoFocusedPageAndReturnExcess(liveOffset: value.translation, currentOffset: offset, gestureIsEnded: false)
                     state = excessOffset
+                    lastLiveOffset = excessOffset
                     print("updating drag \(value.translation)")
                 }
                 .onEnded { value in
-                    let excessOffset = pageableZoomableViewModel.absorbLiveUpdateOffsetIntoFocusedPageAndReturnExcess(liveOffset: value.translation, currentOffset: offset, gestureIsEnded: true)
-                    if abs(excessOffset.height) > (pageableZoomableViewModel.pagingPageSize.height / 2.0) {
-                        pageableZoomableViewModel.dismiss()
-                    } else {
-                        offset = CGSize(width: excessOffset.width, height: excessOffset.height)
+                    offset = offset + lastLiveOffset
+                    lastLiveOffset = .zero
+                    withAnimation {
+                        let excessOffset = pageableZoomableViewModel.absorbLiveUpdateOffsetIntoFocusedPageAndReturnExcess(liveOffset: value.translation, currentOffset: offset, gestureIsEnded: true)
+                        if abs(excessOffset.height) > (pageableZoomableViewModel.pagingPageSize.height / 2.0) {
+                            pageableZoomableViewModel.dismiss()
+                        } else {
+                            offset = CGSize(width: excessOffset.width, height: excessOffset.height)
+                        }
                     }
                 }
         )
@@ -259,15 +279,10 @@ struct ZoomableImageView: View {
                         .frame(width: geo.size.width, height: geo.size.height)
                     BlurhashImageView(url: imageInfo.basicData.fullsizeUrl, imageDetails: imageInfo.imageDetails, blurhash: galleryViewModel.blurhashes[imageInfo.basicData.id])
                         .frame(width: fittingSize.width, height: fittingSize.height)
-                        .scaleEffect(index == pageableZoomableViewModel.focusedPageIndex
-                                     ? pageableZoomableViewModel.liveUpdatePageContentsScale
-                                     : 1,
+                        .scaleEffect(pageableZoomableViewModel.liveUpdatePageContentsScale(index),
                                      anchor: .topLeading
                         )
-                        .offset(index == pageableZoomableViewModel.focusedPageIndex
-                                ? pageableZoomableViewModel.liveUpdatePageContentsOffset
-                                : .zero
-                        )
+                        .offset(pageableZoomableViewModel.liveUpdatePageContentsOffset(index))
                         .preference(key: SizePreferenceKey.self,
                                     value: geo.size
                         )
@@ -286,9 +301,9 @@ struct ZoomableImageView: View {
     }
     
     func updateGeometry(fromSize size: CGSize) {
-        pageableZoomableViewModel.updateContentPageSize(size)
+        pageableZoomableViewModel.updateContentPageSize(index, newSize: size)
         fittingSize = calculateFittingSize(fromContainerSize: size)
-        pageableZoomableViewModel.updateContentsFittingSize(fittingSize)
+        pageableZoomableViewModel.updateContentsFittingSize(index, newSize: fittingSize)
     }
     
     func calculateFittingSize(fromContainerSize containerSize: CGSize) -> CGSize {

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
@@ -2,76 +2,205 @@
 import SwiftUI
 import MastodonSDK
 
+@Observable class PageableZoomableViewModel {
+    let dismiss: ()->()
+    
+    private(set) var focusedPageIndex: Int = 0
+    let maxZoom: CGFloat = 4
+    let minZoom: CGFloat = 1
+    
+    private var focusedPageZoomScale: CGFloat = 1
+    private var focusedPageOffset: CGSize = .zero
+    
+    private var focusedPageLiveZoomScale: CGFloat = 1
+    private var focusedPageLiveOffset: CGSize = .zero
+    
+    private var excessScrollDirection: Axis?
+
+    private var focusedPageGeoSize: CGSize = .zero
+    private var focusedPageContentsFittingSize: CGSize = .zero
+    
+    init(dismiss: @escaping ()->()) {
+        self.dismiss = dismiss
+    }
+    
+    func focus(page: Int) {
+        resetPageTransforms(liveOnly: false)
+        focusedPageIndex = page
+    }
+    
+    func updateFocusedPageGeometry(geoSize: CGSize, contentsFittingSize: CGSize) {
+        focusedPageGeoSize = geoSize
+        focusedPageContentsFittingSize = contentsFittingSize
+        focusedPageZoomScale = clampZoom(focusedPageZoomScale)
+        focusedPageOffset = clampOffset(focusedPageOffset)
+    }
+    
+    private func resetPageTransforms(liveOnly: Bool) {
+        focusedPageLiveZoomScale = 1
+        focusedPageLiveOffset = .zero
+        excessScrollDirection = nil
+        
+        guard !liveOnly else { return }
+        focusedPageZoomScale = 1
+        focusedPageOffset = .zero
+    }
+    
+    var liveUpdatePageContentsOffset: CGSize {
+        focusedPageOffset + focusedPageLiveOffset
+    }
+    
+    var liveUpdatePageContentsScale: CGFloat {
+        focusedPageZoomScale * focusedPageLiveZoomScale
+    }
+    
+    func absorbLiveUpdateZoomScaleIntoFocusedPage(liveScale: CGFloat, gestureIsEnded: Bool) {
+        let proposedScale = liveScale * focusedPageZoomScale
+        let clamped = clampZoom(proposedScale)
+        focusedPageLiveZoomScale = clamped / focusedPageZoomScale
+        
+        if gestureIsEnded  {
+            focusedPageZoomScale = clamped
+            resetPageTransforms(liveOnly: true)
+        }
+    }
+    
+    func absorbLiveUpdateOffsetIntoFocusedPageAndReturnExcess(liveOffset: CGSize, gestureIsEnded: Bool) -> CGSize {
+        let proposedOffset = liveOffset + focusedPageOffset
+        let clamped = clampOffset(proposedOffset)
+       
+        let excess = proposedOffset - clamped
+        
+        if excessScrollDirection == nil {
+            excessScrollDirection = abs(liveOffset.width / liveOffset.height) > 1 ? .horizontal : .vertical
+        }
+        
+        let unidirectionalExcessOffset: CGSize
+        switch excessScrollDirection {
+        case .horizontal:
+            unidirectionalExcessOffset = CGSize(width: excess.width, height: 0)
+        case .vertical:
+            unidirectionalExcessOffset = CGSize(width: 0, height: excess.height)
+        case nil:
+            unidirectionalExcessOffset = .zero
+            assertionFailure("should have been assigned by now")
+            break
+        }
+
+        if gestureIsEnded {
+            focusedPageOffset = clamped
+            resetPageTransforms(liveOnly: true)
+            return .zero
+        } else {
+            focusedPageLiveOffset = clamped
+            return unidirectionalExcessOffset
+        }
+    }
+    
+    func clampOffset(_ proposedOffset: CGSize) -> CGSize {
+        let baseSize = focusedPageContentsFittingSize
+        let scaledSize = CGSize(width: baseSize.width * focusedPageZoomScale, height: baseSize.height * focusedPageZoomScale)
+        
+        let maxX: CGFloat
+        let maxY: CGFloat
+        let minX: CGFloat
+        let minY: CGFloat
+        if scaledSize.width < focusedPageGeoSize.width {
+            maxX = (focusedPageGeoSize.width - scaledSize.width) / 2.0
+            minX = maxX
+        } else {
+            maxX = 0
+            minX = focusedPageGeoSize.width - scaledSize.width
+        }
+        if scaledSize.height < focusedPageGeoSize.height {
+            maxY = (focusedPageGeoSize.height - scaledSize.height) / 2.0
+            minY = maxY
+        } else {
+            maxY = 0
+            minY = focusedPageGeoSize.height - scaledSize.height
+        }
+        
+        let maxOffset = CGSize(width: maxX, height: maxY)
+        let minOffset = CGSize(width: minX, height: minY)
+        
+        let clamped = CGSize(width: max(minOffset.width, min(proposedOffset.width, maxOffset.width)), height: max(minOffset.height, min(proposedOffset.height, maxOffset.height)))
+        return clamped
+    }
+    
+    func clampZoom(_ proposedScale: CGFloat) -> CGFloat {
+        let clamped = min(maxZoom, max(proposedScale, minZoom))
+        return clamped
+    }
+}
+
 struct PageableImageGallery: View {
     @Environment(ImageGalleryViewModel.self) var galleryViewModel
+    @Environment(PageableZoomableViewModel.self) var pageableZoomableViewModel
+    @GestureState private var liveScale: CGFloat = 1
+    @GestureState private var liveOffset: CGSize = .zero
     @State private var offset: CGSize = .zero
-    @State private var liveOffset: CGSize = .zero
     
     var body: some View {
         GeometryReader { geo in
-            HStack {
-                ForEach(galleryViewModel.imageAttachments, id: \.self.id) { imageInfo in
-                    ZoomableImageView(size: geo.size,
-                                      index: galleryViewModel.idToIndex[imageInfo.id] ?? 0,
-                                      updateExcessGestureOffset: { additionalOffset in
-                        liveOffset = additionalOffset + liveOffset
-                    },
-                                      dragGestureDidEnd: { finalAdditionalOffset in
-                        let finalOffset = offset + liveOffset + finalAdditionalOffset
-                        liveOffset = .zero
-                        // find the closest boundary. note that acceptable resting offsets are always <= 0.
-                        let widthsOffsetNoFurtherThanFinalImage = max(-(CGFloat(galleryViewModel.imageAttachments.count) - 1), (finalOffset.width / geo.size.width).rounded(.toNearestOrEven))
-                        let widthsOffset = min(widthsOffsetNoFurtherThanFinalImage, 0)
-                        offset = CGSize(width: geo.size.width * widthsOffset, height: 0)
+            ZStack(alignment: Alignment(horizontal: .leading, vertical: .center)) {
+                HStack {
+                    ForEach(galleryViewModel.imageAttachments, id: \.self.id) { imageInfo in
+                        ZoomableImageView(size: geo.size,
+                                          index: galleryViewModel.idToIndex[imageInfo.id] ?? 0)
                     }
-                    )
                 }
+                .offset(offset + liveOffset)
+                
+                Color.clear
+                    .contentShape(Rectangle())
+                    .frame(width: geo.size.width, height: geo.size.height)
+                    .scaleEffect(pageableZoomableViewModel.liveUpdatePageContentsScale, anchor: .topLeading)
+                    .gesture(zoomAndPan) // putting the gesture on a stationary view keeps the motion smooth
             }
         }
         .ignoresSafeArea()
-        .offset(offset + liveOffset)
+    }
+    
+    var zoomAndPan: some Gesture {
+        SimultaneousGesture(
+            MagnificationGesture()
+                .updating($liveScale) { value, state, _ in
+                    state = value
+                    pageableZoomableViewModel.absorbLiveUpdateZoomScaleIntoFocusedPage(liveScale: value, gestureIsEnded: false)
+                }
+                .onEnded { value in
+                    pageableZoomableViewModel.absorbLiveUpdateZoomScaleIntoFocusedPage(liveScale: value, gestureIsEnded: true)
+                },
+            
+            DragGesture()
+                .updating($liveOffset) { value, state, _ in
+                    let excessOffset = pageableZoomableViewModel.absorbLiveUpdateOffsetIntoFocusedPageAndReturnExcess(liveOffset: value.translation, gestureIsEnded: false)
+                    state = excessOffset
+                    print("updating drag \(value.translation)")
+                }
+                .onEnded { value in
+                    let excessOffset = pageableZoomableViewModel.absorbLiveUpdateOffsetIntoFocusedPageAndReturnExcess(liveOffset: value.translation, gestureIsEnded: true)
+                    offset = excessOffset
+                }
+        )
     }
 }
 
 
 struct ZoomableImageView: View {
     @Environment(ImageGalleryViewModel.self) var galleryViewModel
+    @Environment(PageableZoomableViewModel.self) var pageableZoomableViewModel
     let size: CGSize
     let index: Int
-    let updateExcessGestureOffset: (CGSize)->()
-    let dragGestureDidEnd: (CGSize)->()
     
-    public init(size: CGSize, index: Int, updateExcessGestureOffset: @escaping (CGSize)->(), dragGestureDidEnd: @escaping (CGSize)->()) {
+    public init(size: CGSize, index: Int) {
         self.size = size
         self.index = index
-        self.updateExcessGestureOffset = updateExcessGestureOffset
-        self.dragGestureDidEnd = dragGestureDidEnd
     }
     
-    private let maxScale: CGFloat = 4
-    private var minScale: CGFloat = 1
     private let margin: CGFloat = standardPadding
     
-    @State private var geoSize: CGSize = .zero
-    @State private var scale: CGFloat = 1
-    @State private var offset: CGSize = .zero
     @State private var fittingSize: CGSize = .zero
-    
-    @GestureState private var currentGestureScale: CGFloat = 1
-    @GestureState private var currentGestureOffset: CGSize = .zero
-    
-    var liveUpdateOffset: CGSize {
-        let proposed = CGSize(
-            width: offset.width + currentGestureOffset.width,
-            height: offset.height + currentGestureOffset.height
-        )
-        return clampOffset(proposed)
-    }
-    
-    var liveUpdateScale: CGFloat {
-        let proposed = scale * currentGestureScale
-        return clampZoom(proposed)
-    }
     
     var imageInfo: MastodonImageAttachment {
         galleryViewModel.imageAttachments[index]
@@ -87,13 +216,18 @@ struct ZoomableImageView: View {
                         .frame(width: geo.size.width, height: geo.size.height)
                     BlurhashImageView(url: imageInfo.basicData.fullsizeUrl, imageDetails: imageInfo.imageDetails, blurhash: galleryViewModel.blurhashes[imageInfo.basicData.id])
                         .frame(width: fittingSize.width, height: fittingSize.height)
-                        .scaleEffect(liveUpdateScale, anchor: .topLeading)
-                        .offset(
-                            liveUpdateOffset
+                        .scaleEffect(index == pageableZoomableViewModel.focusedPageIndex
+                                     ? pageableZoomableViewModel.liveUpdatePageContentsScale
+                                     : 1,
+                                     anchor: .topLeading
                         )
-                        .gesture(zoomAndPan)
+                        .offset(index == pageableZoomableViewModel.focusedPageIndex
+                                ? pageableZoomableViewModel.liveUpdatePageContentsOffset
+                                : .zero
+                        )
                         .preference(key: SizePreferenceKey.self,
-                                    value: geo.size)
+                                    value: geo.size
+                        )
                         .onPreferenceChange(SizePreferenceKey.self) { newValue in
                             updateGeometry(fromSize: newValue)
                         }
@@ -109,84 +243,23 @@ struct ZoomableImageView: View {
     }
     
     func updateGeometry(fromSize size: CGSize) {
-        geoSize = size
-        offset = clampOffset(offset)
-        scale = clampZoom(scale)
         fittingSize = calculateFittingSize(fromContainerSize: size)
-    }
-    
-    func clampOffset(_ proposedOffset: CGSize) -> CGSize {
-        let baseSize = fittingSize
-        let scaledSize = CGSize(width: baseSize.width * scale, height: baseSize.height * scale)
-
-        let maxX: CGFloat
-        let maxY: CGFloat
-        let minX: CGFloat
-        let minY: CGFloat
-        if scaledSize.width < geoSize.width {
-            maxX = (geoSize.width - scaledSize.width) / 2.0
-            minX = maxX
-        } else {
-            maxX = 0
-            minX = geoSize.width - scaledSize.width
-        }
-        if scaledSize.height < geoSize.height {
-            maxY = (geoSize.height - scaledSize.height) / 2.0
-            minY = maxY
-        } else {
-            maxY = 0
-            minY = geoSize.height - scaledSize.height
-        }
-        
-        let maxOffset = CGSize(width: maxX, height: maxY)
-        let minOffset = CGSize(width: minX, height: minY)
-        
-        let clamped = CGSize(width: max(minOffset.width, min(proposedOffset.width, maxOffset.width)), height: max(minOffset.height, min(proposedOffset.height, maxOffset.height)))
-        return clamped
-    }
-    
-    func clampZoom(_ proposedScale: CGFloat) -> CGFloat {
-        let clamped = min(maxScale, max(proposedScale, minScale))
-        return clamped
+        pageableZoomableViewModel.updateFocusedPageGeometry(geoSize: size, contentsFittingSize: fittingSize)
     }
     
     func calculateFittingSize(fromContainerSize containerSize: CGSize) -> CGSize {
         guard let imageAspect = imageInfo.imageDetails.originalSize?.aspectRatio, let imageSize = imageInfo.imageDetails.originalSize else { return .zero }
-        if imageAspect < geoSize.aspectRatio {
+        if imageAspect < containerSize.aspectRatio {
             // image is taller.  make the height fit.
-            return CGSize(width: geoSize.width * imageAspect, height: geoSize.height)
+            return CGSize(width: containerSize.width * imageAspect, height: containerSize.height)
         } else {
             // image is squatter.  make the width fit.
-            let scale = geoSize.width / imageSize.width
-            return CGSize(width: geoSize.width, height: imageSize.height * scale)
+            let scale = containerSize.width / imageSize.width
+            return CGSize(width: containerSize.width, height: imageSize.height * scale)
         }
     }
     
-    var zoomAndPan: some Gesture {
-        SimultaneousGesture(
-            MagnificationGesture()
-                .updating($currentGestureScale) { value, state, _ in
-                    state = value
-                }
-                .onEnded { value in
-                    let proposedScale = scale * value
-                    scale = clampZoom(proposedScale)
-                },
-            
-            DragGesture()
-                .updating($currentGestureOffset) { value, state, _ in
-                    state = value.translation
-                    let clamped = clampOffset(value.translation)
-                    updateExcessGestureOffset(value.translation - clamped)
-                }
-                .onEnded { value in
-                    let proposedOffset = offset + value.translation
-                    offset = clampOffset(proposedOffset)
-                    let clamped = clampOffset(value.translation)
-                    dragGestureDidEnd(value.translation - clamped)
-                }
-        )
-    }
+
 }
 
 extension CGSize {

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
@@ -2,6 +2,7 @@
 import SwiftUI
 import MastodonSDK
 
+@MainActor
 @Observable class PageableZoomableViewModel {
     let pageCount: Int
     let dismiss: ()->()
@@ -321,6 +322,7 @@ struct ZoomableContentView<Content: View>: View {
         if contentAspect < containerSize.aspectRatio {
             // image is taller.  make the height fit.
             return CGSize(width: containerSize.width * contentAspect, height: containerSize.height)
+            return CGSize(width: containerSize.width / contentAspect, height: containerSize.height)
         } else {
             // image is squatter.  make the width fit.
             let scale = containerSize.width / contentFullSize.width

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
@@ -256,25 +256,24 @@ struct PageableZoomableView<Content: View>: View {
     }
 }
 
-
-struct ZoomableImageView: View {
-    @Environment(ImageGalleryViewModel.self) var galleryViewModel
+struct ZoomableContentView<Content: View>: View {
     @Environment(PageableZoomableViewModel.self) var pageableZoomableViewModel
-    let size: CGSize
+    let contentFullSize: CGSize
     let index: Int
+    let containerSize: CGSize
+    let contentView: Content
     
-    public init(size: CGSize, index: Int) {
-        self.size = size
+    public init(contentFullSize: CGSize, index: Int, containerSize: CGSize, @ViewBuilder content: () -> Content) {
+        self.contentFullSize = contentFullSize
         self.index = index
+        self.containerSize = containerSize
+        self.contentView = content()
     }
     
     private let margin: CGFloat = standardPadding
     
     @State private var fittingSize: CGSize = .zero
     
-    var imageInfo: MastodonImageAttachment {
-        galleryViewModel.imageAttachments[index]
-    }
     
     var body: some View {
         ZStack {
@@ -284,7 +283,7 @@ struct ZoomableImageView: View {
                 ZStack(alignment: Alignment(horizontal: .leading, vertical: .top)) {
                     Color.clear
                         .frame(width: geo.size.width, height: geo.size.height)
-                    BlurhashImageView(url: imageInfo.basicData.fullsizeUrl, imageDetails: imageInfo.imageDetails, blurhash: galleryViewModel.blurhashes[imageInfo.basicData.id])
+                    contentView
                         .frame(width: fittingSize.width, height: fittingSize.height)
                         .scaleEffect(pageableZoomableViewModel.liveUpdatePageContentsScale(index),
                                      anchor: .topLeading
@@ -303,7 +302,7 @@ struct ZoomableImageView: View {
             }
             .padding()
         }
-        .frame(width: size.width, height: size.height)
+        .frame(width: containerSize.width, height: containerSize.height)
         .clipped()
     }
     
@@ -314,14 +313,14 @@ struct ZoomableImageView: View {
     }
     
     func calculateFittingSize(fromContainerSize containerSize: CGSize) -> CGSize {
-        guard let imageAspect = imageInfo.imageDetails.originalSize?.aspectRatio, let imageSize = imageInfo.imageDetails.originalSize else { return .zero }
-        if imageAspect < containerSize.aspectRatio {
+        let contentAspect = contentFullSize.aspectRatio
+        if contentAspect < containerSize.aspectRatio {
             // image is taller.  make the height fit.
-            return CGSize(width: containerSize.width * imageAspect, height: containerSize.height)
+            return CGSize(width: containerSize.width * contentAspect, height: containerSize.height)
         } else {
             // image is squatter.  make the width fit.
-            let scale = containerSize.width / imageSize.width
-            return CGSize(width: containerSize.width, height: imageSize.height * scale)
+            let scale = containerSize.width / contentFullSize.width
+            return CGSize(width: containerSize.width, height: contentFullSize.height * scale)
         }
     }
     

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
@@ -264,19 +264,16 @@ struct PageableZoomableView<Content: View, Controls: View>: View {
 
 struct ZoomableContentView<Content: View>: View {
     @Environment(PageableZoomableViewModel.self) var pageableZoomableViewModel
+    @Environment(\.pageSize) private var pageSize
     let contentFullSize: CGSize
     let index: Int
-    let containerSize: CGSize
     let contentView: Content
     
-    public init(contentFullSize: CGSize, index: Int, containerSize: CGSize, @ViewBuilder content: () -> Content) {
+    public init(contentFullSize: CGSize, index: Int, @ViewBuilder content: () -> Content) {
         self.contentFullSize = contentFullSize
         self.index = index
-        self.containerSize = containerSize
         self.contentView = content()
     }
-    
-    private let margin: CGFloat = standardPadding
     
     @State private var fittingSize: CGSize = .zero
     
@@ -289,6 +286,7 @@ struct ZoomableContentView<Content: View>: View {
                 ZStack(alignment: Alignment(horizontal: .leading, vertical: .top)) {
                     Color.clear
                         .frame(width: geo.size.width, height: geo.size.height)
+                    
                     contentView
                         .frame(width: fittingSize.width, height: fittingSize.height)
                         .scaleEffect(pageableZoomableViewModel.liveUpdatePageContentsScale(index),
@@ -308,7 +306,7 @@ struct ZoomableContentView<Content: View>: View {
             }
             .padding()
         }
-        .frame(width: containerSize.width, height: containerSize.height)
+        .frame(width: pageSize.width, height: pageSize.height)
         .clipped()
     }
     

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
@@ -245,7 +245,6 @@ struct PageableZoomableView<Content: View, Controls: View>: View {
                     let excessOffset = pageableZoomableViewModel.absorbLiveUpdateOffsetIntoFocusedPageAndReturnExcess(liveOffset: value.translation, currentOffset: offset, gestureIsEnded: false)
                     state = excessOffset
                     lastLiveOffset = excessOffset
-                    print("updating drag \(value.translation)")
                 }
                 .onEnded { value in
                     offset = offset + lastLiveOffset

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
@@ -4,18 +4,32 @@ import MastodonSDK
 
 struct PageableImageGallery: View {
     @Environment(ImageGalleryViewModel.self) var galleryViewModel
+    @State private var offset: CGSize = .zero
+    @State private var liveOffset: CGSize = .zero
     
     var body: some View {
         GeometryReader { geo in
-            ScrollView(.horizontal) {
-                HStack {
-                    ForEach(galleryViewModel.imageAttachments, id: \.self.id) { imageInfo in
-                        ZoomableImageView(size: geo.size, index: galleryViewModel.idToIndex[imageInfo.id] ?? 0)
+            HStack {
+                ForEach(galleryViewModel.imageAttachments, id: \.self.id) { imageInfo in
+                    ZoomableImageView(size: geo.size,
+                                      index: galleryViewModel.idToIndex[imageInfo.id] ?? 0,
+                                      updateExcessGestureOffset: { additionalOffset in
+                        liveOffset = additionalOffset + liveOffset
+                    },
+                                      dragGestureDidEnd: { finalAdditionalOffset in
+                        let finalOffset = offset + liveOffset + finalAdditionalOffset
+                        liveOffset = .zero
+                        // find the closest boundary. note that acceptable resting offsets are always <= 0.
+                        let widthsOffsetNoFurtherThanFinalImage = max(-(CGFloat(galleryViewModel.imageAttachments.count) - 1), (finalOffset.width / geo.size.width).rounded(.toNearestOrEven))
+                        let widthsOffset = min(widthsOffsetNoFurtherThanFinalImage, 0)
+                        offset = CGSize(width: geo.size.width * widthsOffset, height: 0)
                     }
+                    )
                 }
             }
         }
         .ignoresSafeArea()
+        .offset(offset + liveOffset)
     }
 }
 
@@ -24,10 +38,14 @@ struct ZoomableImageView: View {
     @Environment(ImageGalleryViewModel.self) var galleryViewModel
     let size: CGSize
     let index: Int
+    let updateExcessGestureOffset: (CGSize)->()
+    let dragGestureDidEnd: (CGSize)->()
     
-    public init(size: CGSize, index: Int) {
+    public init(size: CGSize, index: Int, updateExcessGestureOffset: @escaping (CGSize)->(), dragGestureDidEnd: @escaping (CGSize)->()) {
         self.size = size
         self.index = index
+        self.updateExcessGestureOffset = updateExcessGestureOffset
+        self.dragGestureDidEnd = dragGestureDidEnd
     }
     
     private let maxScale: CGFloat = 4
@@ -100,7 +118,6 @@ struct ZoomableImageView: View {
     func clampOffset(_ proposedOffset: CGSize) -> CGSize {
         let baseSize = fittingSize
         let scaledSize = CGSize(width: baseSize.width * scale, height: baseSize.height * scale)
-        let restingOffset = CGSize(width: max(scaledSize.width - geoSize.width, 0) / 2.0, height: max(scaledSize.height - geoSize.height, 0) / 2.0)
 
         let maxX: CGFloat
         let maxY: CGFloat
@@ -159,11 +176,25 @@ struct ZoomableImageView: View {
             DragGesture()
                 .updating($currentGestureOffset) { value, state, _ in
                     state = value.translation
+                    let clamped = clampOffset(value.translation)
+                    updateExcessGestureOffset(value.translation - clamped)
                 }
                 .onEnded { value in
-                    let proposedOffset = CGSize(width:  offset.width + value.translation.width, height: offset.height + value.translation.height)
+                    let proposedOffset = offset + value.translation
                     offset = clampOffset(proposedOffset)
+                    let clamped = clampOffset(value.translation)
+                    dragGestureDidEnd(value.translation - clamped)
                 }
         )
+    }
+}
+
+extension CGSize {
+    static func +(lhs: CGSize, rhs: CGSize) -> CGSize {
+        CGSize(width: lhs.width + rhs.width, height: lhs.height + rhs.height)
+    }
+    
+    static func -(lhs: CGSize, rhs: CGSize) -> CGSize {
+        CGSize(width: lhs.width - rhs.width, height: lhs.height - rhs.height)
     }
 }

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
@@ -186,7 +186,7 @@ extension EnvironmentValues {
     @Entry var pageSize: CGSize = .zero
 }
 
-struct PageableZoomableView<Content: View>: View {
+struct PageableZoomableView<Content: View, Controls: View>: View {
     @Environment(PageableZoomableViewModel.self) var pageableZoomableViewModel
     @GestureState private var liveScale: CGFloat = 1
     @GestureState private var liveOffset: CGSize = .zero
@@ -194,9 +194,11 @@ struct PageableZoomableView<Content: View>: View {
     @State private var offset: CGSize = .zero
     
     let contentView: Content
+    let controlsView: Controls
     
-    init(@ViewBuilder content: () -> Content) {
+    init(@ViewBuilder content: () -> Content, @ViewBuilder controls: () -> Controls) {
         contentView = content()
+        controlsView = controls()
     }
     
     var body: some View {
@@ -206,11 +208,15 @@ struct PageableZoomableView<Content: View>: View {
                     .environment(\.pageSize, geo.size)
                     .offset(offset + (liveOffset == .zero ? lastLiveOffset : liveOffset))
                 
-                Color.clear
-                    .contentShape(Rectangle())
-                    .frame(width: geo.size.width, height: geo.size.height)
-                    .scaleEffect(pageableZoomableViewModel.liveUpdatePageContentsScale(pageableZoomableViewModel.focusedPageIndex), anchor: .topLeading)
-                    .gesture(zoomAndPan) // putting the gesture on a stationary view keeps the motion smooth
+                ZStack {
+                    Color.clear
+                        .contentShape(Rectangle())
+                        .frame(width: geo.size.width, height: geo.size.height)
+                        .scaleEffect(pageableZoomableViewModel.liveUpdatePageContentsScale(pageableZoomableViewModel.focusedPageIndex), anchor: .topLeading)
+                        .gesture(zoomAndPan) // putting the gesture on a stationary view keeps the motion smooth
+                    
+                    controlsView // in order to receive touch events, the controls have to be above the clear overlay that holds the zoomAndPan gesture
+                }
             }
             .onAppear() {
                 offset = pageableZoomableViewModel.updatePagingPageSizeAndReturnNewFocusedPageOffset(geo.size)

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
@@ -1,0 +1,160 @@
+// Copyright © 2026 Mastodon gGmbH. All rights reserved.
+import SwiftUI
+
+struct PageableImageGallery: View {
+    @Environment(ImageGalleryViewModel.self) var galleryViewModel
+    
+    var body: some View {
+        ZoomableImageView(index: 0)
+    }
+}
+
+
+struct ZoomableImageView: View {
+    @Environment(ImageGalleryViewModel.self) var galleryViewModel
+    let index: Int
+    
+    public init(index: Int) {
+        self.index = index
+    }
+    
+    private let maxScale: CGFloat = 4
+    private var minScale: CGFloat = 1
+    @State private var geoSize: CGSize = .zero
+    
+    @State private var scale: CGFloat = 1
+    @State private var offset: CGSize = .zero
+    @State private var fittingSize: CGSize = .zero
+    
+    @GestureState private var currentGestureScale: CGFloat = 1
+    @GestureState private var currentGestureOffset: CGSize = .zero
+    
+    var liveUpdateOffset: CGSize {
+        let proposed = CGSize(
+            width: offset.width + currentGestureOffset.width,
+            height: offset.height + currentGestureOffset.height
+        )
+        return clampOffset(proposed)
+    }
+    
+    var liveUpdateScale: CGFloat {
+        let proposed = scale * currentGestureScale
+        return clampZoom(proposed)
+    }
+    
+    var imageInfo: MastodonImageAttachment {
+        galleryViewModel.imageAttachments[index]
+    }
+    
+    var body: some View {
+        ZStack {
+            Color.dimmingBackground
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            GeometryReader { geo in
+                ZStack(alignment: Alignment(horizontal: .leading, vertical: .top)) {
+                    Color.clear
+                        .frame(width: geo.size.width, height: geo.size.height)
+                    BlurhashImageView(url: imageInfo.basicData.fullsizeUrl, imageDetails: imageInfo.imageDetails, blurhash: galleryViewModel.blurhashes[imageInfo.basicData.id])
+                        .frame(width: fittingSize.width, height: fittingSize.height)
+                        .scaleEffect(liveUpdateScale, anchor: .topLeading)
+                        .offset(
+                            liveUpdateOffset
+                        )
+                        .gesture(zoomAndPan)
+                        .preference(key: SizePreferenceKey.self,
+                                    value: geo.size)
+                        .onPreferenceChange(SizePreferenceKey.self) { newValue in
+                            updateGeometry(fromSize: newValue)
+                        }
+                        .onAppear() {
+                            updateGeometry(fromSize: geo.size)
+                        }
+                    Rectangle()
+                        .fill(.clear)
+                        .frame(width: fittingSize.width, height: fittingSize.height)
+                    Rectangle()
+                        .fill(.clear)
+                        .frame(width: fittingSize.width * scale, height: fittingSize.height * scale)
+                }
+            }
+            .padding()
+        }
+    }
+    
+    func updateGeometry(fromSize size: CGSize) {
+        geoSize = size
+        offset = clampOffset(offset)
+        scale = clampZoom(scale)
+        fittingSize = calculateFittingSize(fromContainerSize: size)
+    }
+    
+    func clampOffset(_ proposedOffset: CGSize) -> CGSize {
+        let baseSize = fittingSize
+        let scaledSize = CGSize(width: baseSize.width * scale, height: baseSize.height * scale)
+        let restingOffset = CGSize(width: max(scaledSize.width - geoSize.width, 0) / 2.0, height: max(scaledSize.height - geoSize.height, 0) / 2.0)
+
+        let maxX: CGFloat
+        let maxY: CGFloat
+        let minX: CGFloat
+        let minY: CGFloat
+        if scaledSize.width < geoSize.width {
+            maxX = (geoSize.width - scaledSize.width) / 2.0
+            minX = maxX
+        } else {
+            maxX = 0
+            minX = geoSize.width - scaledSize.width
+        }
+        if scaledSize.height < geoSize.height {
+            maxY = (geoSize.height - scaledSize.height) / 2.0
+            minY = maxY
+        } else {
+            maxY = 0
+            minY = geoSize.height - scaledSize.height
+        }
+        
+        let maxOffset = CGSize(width: maxX, height: maxY)
+        let minOffset = CGSize(width: minX, height: minY)
+        
+        let clamped = CGSize(width: max(minOffset.width, min(proposedOffset.width, maxOffset.width)), height: max(minOffset.height, min(proposedOffset.height, maxOffset.height)))
+        return clamped
+    }
+    
+    func clampZoom(_ proposedScale: CGFloat) -> CGFloat {
+        let clamped = min(maxScale, max(proposedScale, minScale))
+        return clamped
+    }
+    
+    func calculateFittingSize(fromContainerSize containerSize: CGSize) -> CGSize {
+        guard let imageAspect = imageInfo.imageDetails.originalSize?.aspectRatio, let imageSize = imageInfo.imageDetails.originalSize else { return .zero }
+        if imageAspect < geoSize.aspectRatio {
+            // image is taller.  make the height fit.
+            return CGSize(width: geoSize.width * imageAspect, height: geoSize.height)
+        } else {
+            // image is squatter.  make the width fit.
+            let scale = geoSize.width / imageSize.width
+            return CGSize(width: geoSize.width, height: imageSize.height * scale)
+        }
+    }
+    
+    var zoomAndPan: some Gesture {
+        SimultaneousGesture(
+            MagnificationGesture()
+                .updating($currentGestureScale) { value, state, _ in
+                    state = value
+                }
+                .onEnded { value in
+                    let proposedScale = scale * value
+                    scale = clampZoom(proposedScale)
+                },
+            
+            DragGesture()
+                .updating($currentGestureOffset) { value, state, _ in
+                    state = value.translation
+                }
+                .onEnded { value in
+                    let proposedOffset = CGSize(width:  offset.width + value.translation.width, height: offset.height + value.translation.height)
+                    offset = clampOffset(proposedOffset)
+                }
+        )
+    }
+}

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PageableImageGallery.swift
@@ -241,7 +241,7 @@ struct PageableImageGallery: View {
                         if abs(excessOffset.height) > (pageableZoomableViewModel.pagingPageSize.height / 2.0) {
                             pageableZoomableViewModel.dismiss()
                         } else {
-                            offset = CGSize(width: excessOffset.width, height: excessOffset.height)
+                            offset = CGSize(width: excessOffset.width, height: 0)
                         }
                     }
                 }

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PhotoCropperView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PhotoCropperView.swift
@@ -126,10 +126,10 @@ struct PhotoCropperView: View {
         let aspect = originalImage.size.aspectRatio
         if aspect < cropSize.aspectRatio {
             // image is taller.  make the width fit.
-            return CGSize(width: cropSize.width, height: cropSize.height * aspect)
+            return CGSize(width: cropSize.width, height: cropSize.width / aspect)
         } else {
             // image is squatter.  make the height fit.
-            return CGSize(width: cropSize.width * aspect, height: cropSize.height)
+            return CGSize(width: cropSize.height / aspect, height: cropSize.height)
         }
     }
     

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PhotoCropperView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PhotoCropperView.swift
@@ -57,11 +57,18 @@ struct PhotoCropperView: View {
                 }
                 
                 HStack {
-                    if let croppedImage {
-                        croppedImage
-                            .resizable()
-                            .frame(width: 100, height: 100)
+                    Button() {
+                        completion(nil)
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.title)
+                            .padding()
+                            .clipShape(.circle)
                     }
+                    .glassEffectIfAvailable(.regular, in: .circle)
+                    
+                    Spacer()
+                    
                     Button() {
 #if DEBUG && false
                         if let cropped = getCroppedImage() {
@@ -78,6 +85,7 @@ struct PhotoCropperView: View {
                     }
                     .glassEffectIfAvailable(.regular(interactive: true), in: .circle)
                 }
+                .padding()
             }
             .gesture(zoomAndPan)
             .preference(key: SizePreferenceKey.self,

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PhotoCropperView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/PhotoCropperView.swift
@@ -65,7 +65,7 @@ struct PhotoCropperView: View {
                             .padding()
                             .clipShape(.circle)
                     }
-                    .glassEffectIfAvailable(.regular, in: .circle)
+                    .glassEffectIfAvailable(.regular(interactive: true), in: .circle)
                     
                     Spacer()
                     

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/MastodonPostRowView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/MastodonPostRowView.swift
@@ -127,13 +127,14 @@ struct MastodonPostRowView: View {
                         if let attachment = viewModel.fullPost?.actionablePost?.content.attachment {
                             switch attachment {
                             case .media(let array):
-                                MediaAttachment(array, altTextTranslations: viewModel.altTextTranslations)
-                                    .view(showOverlay: { overlay in
-                                        actionHandler?.showOverlay(overlay)
-                                    }, presentScene: { scene, postID, transition in
-                                        actionHandler?.presentScene(scene, fromPost: postID, transition: transition)
-                                    })
-                                    .frame(width: contentWidth)
+                                MediaAttachmentView(
+                                    mediaAttachment: MediaAttachment(array, altTextTranslations: viewModel.altTextTranslations),
+                                                    showOverlay: { overlay in
+                                    actionHandler?.showOverlay(overlay)
+                                }, presentScene: { scene, postID, transition in
+                                    actionHandler?.presentScene(scene, fromPost: postID, transition: transition)
+                                })
+                                .frame(width: contentWidth)
                             case .poll(let poll):
                                 let emojis = viewModel.fullPost?.actionablePost?.content.htmlWithEntities?.emojis
                                 PollView(viewModel: PollViewModel(pollEntity: poll, emojis: emojis, optionTranslations: viewModel.isShowingTranslation == true ? viewModel.pollOptionTranslations : nil, containingPostID: viewModel.initialDisplayInfo.actionablePostID, actionHandler: actionHandler), contentWidth: contentWidth)

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/MastodonPostRowView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/MastodonPostRowView.swift
@@ -127,7 +127,12 @@ struct MastodonPostRowView: View {
                         if let attachment = viewModel.fullPost?.actionablePost?.content.attachment {
                             switch attachment {
                             case .media(let array):
-                                MediaAttachment(array, altTextTranslations: viewModel.altTextTranslations).view(actionHandler: actionHandler)
+                                MediaAttachment(array, altTextTranslations: viewModel.altTextTranslations)
+                                    .view(showOverlay: { overlay in
+                                        actionHandler?.showOverlay(overlay)
+                                    }, presentScene: { scene, postID, transition in
+                                        actionHandler?.presentScene(scene, fromPost: postID, transition: transition)
+                                    })
                                     .frame(width: contentWidth)
                             case .poll(let poll):
                                 let emojis = viewModel.fullPost?.actionablePost?.content.htmlWithEntities?.emojis

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/MastodonPostRowView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/MastodonPostRowView.swift
@@ -129,9 +129,9 @@ struct MastodonPostRowView: View {
                             case .media(let array):
                                 MediaAttachmentView(
                                     mediaAttachment: MediaAttachment(array, altTextTranslations: viewModel.altTextTranslations),
-                                                    showOverlay: { overlay in
-                                    actionHandler?.showOverlay(overlay)
-                                }, presentScene: { scene, postID, transition in
+                                                    containerOverlayBinding:
+                                    actionHandler?.containerOverlayBinding
+                                , presentScene: { scene, postID, transition in
                                     actionHandler?.presentScene(scene, fromPost: postID, transition: transition)
                                 })
                                 .frame(width: contentWidth)

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/EmbeddedPostView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/EmbeddedPostView.swift
@@ -203,16 +203,16 @@ struct EmbeddedPostContentDisplayedView: View {
                     } else {
                         switch attachmentInfo {
                         case .media(let array):
-                            MediaAttachment(array,
-                                            altTextTranslations: viewModel.altTextTranslations)
-                            .view(
+                            MediaAttachmentView(
+                                mediaAttachment: MediaAttachment(array,
+                                                                 altTextTranslations: viewModel.altTextTranslations),
                                 showOverlay: { overlay in
                                     actionHandler.showOverlay(overlay)
-                            },
+                                },
                                 presentScene: { scene, postID, transition in
                                     actionHandler.presentScene(scene, fromPost: postID, transition: transition)
                                 })
-                                .frame(width: contentWidth)
+                            .frame(width: contentWidth)
                         case .poll(let poll):
                             let emojis = viewModel.fullPost?.actionablePost?.content.htmlWithEntities?.emojis
                             PollView(viewModel: PollViewModel(pollEntity: poll, emojis: emojis, optionTranslations: viewModel.isShowingTranslation == true ? viewModel.pollOptionTranslations : nil, containingPostID: viewModel.initialDisplayInfo.actionablePostID, actionHandler: actionHandler), contentWidth: contentWidth)

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/EmbeddedPostView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/EmbeddedPostView.swift
@@ -203,7 +203,15 @@ struct EmbeddedPostContentDisplayedView: View {
                     } else {
                         switch attachmentInfo {
                         case .media(let array):
-                            MediaAttachment(array, altTextTranslations: viewModel.altTextTranslations).view(actionHandler: actionHandler)
+                            MediaAttachment(array,
+                                            altTextTranslations: viewModel.altTextTranslations)
+                            .view(
+                                showOverlay: { overlay in
+                                    actionHandler.showOverlay(overlay)
+                            },
+                                presentScene: { scene, postID, transition in
+                                    actionHandler.presentScene(scene, fromPost: postID, transition: transition)
+                                })
                                 .frame(width: contentWidth)
                         case .poll(let poll):
                             let emojis = viewModel.fullPost?.actionablePost?.content.htmlWithEntities?.emojis

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/EmbeddedPostView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/EmbeddedPostView.swift
@@ -206,9 +206,7 @@ struct EmbeddedPostContentDisplayedView: View {
                             MediaAttachmentView(
                                 mediaAttachment: MediaAttachment(array,
                                                                  altTextTranslations: viewModel.altTextTranslations),
-                                showOverlay: { overlay in
-                                    actionHandler.showOverlay(overlay)
-                                },
+                                containerOverlayBinding: actionHandler.containerOverlayBinding,
                                 presentScene: { scene, postID, transition in
                                     actionHandler.presentScene(scene, fromPost: postID, transition: transition)
                                 })

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
@@ -191,7 +191,7 @@ extension MediaAttachment {
             AudioPlayerView(media: self)
         case .gifv, .video:
             ConcealableMediaAttachmentView() {
-                VideoPlayerView(media: self)
+                VideoPlayerView(media: self, showOverlay: showOverlay)
             }
         case .openInBrowser(let url):
             Button {
@@ -226,16 +226,16 @@ extension MediaAttachment {
 
 struct ConcealableMediaAttachmentView<Content: View>: View {
     @Environment(ContentConcealViewModel.self) private var contentConcealViewModel
-    let contentViewBuilder: () -> Content
+    let contentView: Content
 
-    init(@ViewBuilder content: @escaping() -> Content) {
-        self.contentViewBuilder = content
+    init(@ViewBuilder content: () -> Content) {
+        self.contentView = content()
     }
     
     var body: some View {
         ZStack(alignment: .topTrailing) { // places the Hide/Show button, if there is one
             
-            contentViewBuilder()
+            contentView
             
             // Hide/Show button
             switch contentConcealViewModel.currentMode {
@@ -554,9 +554,9 @@ struct VideoPlayerView: View {
     let url: URL
     @Environment(ContentConcealViewModel.self) private var contentConcealViewModel
     @StateObject var playerObserver = PlayerObserver()
-    @State var waitingToShowFullSize = false
+    let showOverlay: (MastodonTimelineOverlayView)->()
     
-    init?(media: MediaAttachment) {
+    init?(media: MediaAttachment, showOverlay: @escaping (MastodonTimelineOverlayView)->()) {
         switch media {
         case .video, .gifv:
             break
@@ -566,6 +566,7 @@ struct VideoPlayerView: View {
         guard let attachmentInfo = media.attachmentInfo, let url = attachmentInfo.url else { return nil }
         self.media = media
         self.url = url
+        self.showOverlay = showOverlay
     }
     
     var respectDeviceSilentSetting: Bool {
@@ -590,25 +591,12 @@ struct VideoPlayerView: View {
             if let player = playerObserver.getPlayer() {
                 VideoPlayer(player: player)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background {
-                        if waitingToShowFullSize {
-                            FrameReader() { frame in
-                                playerObserver.mostRecentFrameInScreenCoordinates = frame
-                                if waitingToShowFullSize {
-                                    waitingToShowFullSize = false
-                                    Task { @MainActor in
-                                        showFullSize()
-                                    }
-                                }
-                            }
-                        }
-                    }
             }
         }
         .overlay {
             ZStack {
                 Button {
-                    waitingToShowFullSize = true
+                    showOverlay(.video(media))
                 } label: {
                     Rectangle().fill(.clear)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
@@ -591,17 +591,21 @@ struct VideoPlayerView: View {
     
     var body: some View {
         ZStack {
-            
-            if let blurImage = playerObserver.blurImage {
-                Image(uiImage: blurImage)
-                    .resizable()
-                    .scaledToFill()
-            }
-            
             if let player = playerObserver.getPlayer() {
                 VideoPlayer(player: player)
                     .opacity(playerObserver.isReadyToPlay ? 1 : 0)
                     .aspectRatio(originalSize.aspectRatio, contentMode: .fit)
+                    .background() {
+                        if let blurImage = playerObserver.blurImage {
+                            Image(uiImage: blurImage)
+                                .resizable()
+                                .scaledToFill()
+                        }
+                    }
+            } else if let blurImage = playerObserver.blurImage {
+                Image(uiImage: blurImage)
+                    .resizable()
+                    .scaledToFill()
             }
         }
         .clipped() // prevents the blurhash image from overhanging the video if it somehow has a slightly different aspect ratio

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
@@ -635,7 +635,6 @@ struct VideoPlayerView: View {
         guard originalSize != .zero else { return 200 }
         let aspect = originalSize.aspectRatio
         let fittingHeight = containerWidth / aspect
-        print("fitting size is \(containerWidth) x \(fittingHeight)")
         return fittingHeight
     }
     var shouldLoop: Bool {

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
@@ -191,7 +191,7 @@ extension MediaAttachment {
             AudioPlayerView(media: self)
         case .gifv, .video:
             ConcealableMediaAttachmentView() {
-                VideoPlayerView(media: self, showOverlay: showOverlay)
+                VideoPlayerView(media: self, originalSize: self.attachmentInfo?.imageDetails?.originalSize ?? .zero, showOverlay: showOverlay)
             }
         case .openInBrowser(let url):
             Button {
@@ -552,11 +552,12 @@ struct AudioPlayerView: View {
 struct VideoPlayerView: View {
     let media: MediaAttachment
     let url: URL
+    let originalSize: CGSize
     @Environment(ContentConcealViewModel.self) private var contentConcealViewModel
     @StateObject var playerObserver = PlayerObserver()
     let showOverlay: (MastodonTimelineOverlayView)->()
     
-    init?(media: MediaAttachment, showOverlay: @escaping (MastodonTimelineOverlayView)->()) {
+    init?(media: MediaAttachment, originalSize: CGSize, showOverlay: @escaping (MastodonTimelineOverlayView)->()) {
         switch media {
         case .video, .gifv:
             break
@@ -564,6 +565,7 @@ struct VideoPlayerView: View {
             return nil
         }
         guard let attachmentInfo = media.attachmentInfo, let url = attachmentInfo.url else { return nil }
+        self.originalSize = originalSize
         self.media = media
         self.url = url
         self.showOverlay = showOverlay
@@ -582,8 +584,6 @@ struct VideoPlayerView: View {
     
     var body: some View {
         ZStack {
-            Color.clear
-                .frame(width: width, height: aspectFittingHeightToFillWidth(containerWidth: width))
             
             if let blurImage = playerObserver.blurImage {
                 Image(uiImage: blurImage)
@@ -593,7 +593,7 @@ struct VideoPlayerView: View {
             
             if let player = playerObserver.getPlayer() {
                 VideoPlayer(player: player)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .aspectRatio(originalSize.aspectRatio, contentMode: .fit)
             }
         }
         .overlay {

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
@@ -608,6 +608,7 @@ struct VideoPlayerView: View {
                     .scaledToFill()
             }
         }
+        .border(playerObserver.isReadyToPlay ? .clear : .secondary)
         .clipped() // prevents the blurhash image from overhanging the video if it somehow has a slightly different aspect ratio
         .overlay {
             Button {

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
@@ -177,24 +177,25 @@ enum MediaAttachment {
 
 extension MediaAttachment {
     @MainActor
-    @ViewBuilder func view(actionHandler: MastodonPostMenuActionHandler?) -> some View {
+    @ViewBuilder func view(showOverlay: @escaping (MastodonTimelineOverlayView) -> (),
+                           presentScene: @escaping (SceneCoordinator.Scene, Mastodon.Entity.Status.ID?, SceneCoordinator.Transition) -> ()) -> some View {
         switch self {
         case .emptyAttachment:
             Image(systemName: "questionmark.square.dashed")
         case .images(let attachments, let altTextTranslations):
             ConcealableMediaAttachmentView() {
-                ImageGridView(actionHandler: actionHandler)
-                    .environment(ImageGalleryViewModel(imageAttachments: attachments, altTextTranslations: altTextTranslations, actionHandler: actionHandler))
+                ImageGridView(showOverlay: showOverlay)
+                    .environment(ImageGalleryViewModel(imageAttachments: attachments, altTextTranslations: altTextTranslations))
             }
         case .audio:
             AudioPlayerView(media: self)
         case .gifv, .video:
             ConcealableMediaAttachmentView() {
-                VideoPlayerView(media: self, actionHandler: actionHandler)
+                VideoPlayerView(media: self)
             }
         case .openInBrowser(let url):
             Button {
-                actionHandler?.presentScene(.safari(url: url), fromPost: nil, transition: .show)
+                presentScene(.safari(url: url), nil, .show)
             } label: {
                 HStack {
                     VStack(alignment: .leading) {
@@ -268,8 +269,7 @@ struct ConcealableMediaAttachmentView<Content: View>: View {
 struct ImageGridView: View {
     @Environment(ImageGalleryViewModel.self) private var viewModel
     @Environment(ContentConcealViewModel.self) private var contentConcealViewModel
-    let actionHandler: MastodonPostMenuActionHandler?
-    @State var waitingToShowFullSize: String? = nil
+    let showOverlay: (MastodonTimelineOverlayView)->()
     
     var body: some View {
         // The images
@@ -281,28 +281,15 @@ struct ImageGridView: View {
                         .clipped()
                         .accessibilityLabel(viewModel.altTextTranslations?[img.id] ?? img.basicData.altText ?? "")
                         .onTapGesture {
-                            waitingToShowFullSize = img.id
-                        }
-                        .background {
-                            if waitingToShowFullSize != nil {
-                                FrameReader() { updatedFrame in
-                                    viewModel.updateFrame(updatedFrame, forID: img.basicData.id)
-                                    if waitingToShowFullSize == img.id {
-                                        waitingToShowFullSize = nil
-                                        Task { @MainActor in
-                                            showImageGallery(focusing: img.id, withPlaceholderImages: viewModel.imageAttachments.map { viewModel.blurhashes[$0.id] })
-                                        }
-                                    }
-                                }
-                            }
+                            showOverlay(.images(focusedImage: img.id, viewModel))
                         }
                     
                     if let altText = img.basicData.altText, altText.isNotEmpty {
                         Button {
                             if let translation = viewModel.altTextTranslations?[img.id] {
-                                actionHandler?.showOverlay(.altText(translation))
+                                showOverlay(.altText(translation))
                             } else {
-                                actionHandler?.showOverlay(.altText(altText))
+                                showOverlay(.altText(altText))
                             }
                         } label: {
                             Text("ALT")
@@ -327,52 +314,6 @@ struct ImageGridView: View {
         .animation(.easeInOut, value: contentConcealViewModel.currentMode.isShowingMedia)
     }
     
-    func showImageGallery(focusing: Mastodon.Entity.Attachment.ID, withPlaceholderImages placeholderImages: [UIImage?]) {
-        guard let presentingViewController = viewModel.actionHandler?.mediaPreviewableViewController else { return }
-        
-        let focusedIndex = viewModel.imageAttachments.firstIndex { $0.id == focusing }
-        
-        let altTextTranslations = viewModel.altTextTranslations
-        let altTexts = viewModel.imageAttachments.map { altTextTranslations?[$0.id] ?? $0.basicData.altText }
-       
-        let previewItem: MediaPreviewViewModel.PreviewItem = .attachments(viewModel.imageAttachments.map{ $0._legacyEntity }, initialIndex: focusedIndex, placeholderImages: placeholderImages, altTexts: altTexts)
-        let mediaPreviewTransitionItem: MediaPreviewTransitionItem = {
-            @MainActor func clippingFrame(forID id: Mastodon.Entity.Attachment.ID) -> CGRect { viewModel.frame(forID: id) ?? CGRect(x: 50, y: 50, width: 50, height: 50)
-            }
-            let clippingFrames = viewModel.imageAttachments.map { clippingFrame(forID: $0.basicData.id) }
-            let item = MediaPreviewTransitionItem(source: .swiftUI(sourceFramesInScreenCoordinates: clippingFrames), previewableViewController: presentingViewController)
-            
-            item.initialClippingFrame = {
-                // this is the current frame of the image view
-                let initialFrame = clippingFrame(forID: focusing)
-                assert(initialFrame != .zero)
-                return initialFrame
-            }()
-            item.initialimageFrame = {
-                // this is the current frame of the image in the view, accounting for focus point if cropping
-                let initialFrame = viewModel.frame(forID: focusing) ?? CGRect(x: 50, y: 50, width: 50, height: 50)
-                assert(initialFrame != .zero)
-                return initialFrame
-            }()
-            
-            item.image = viewModel.blurhashes[focusing]
-            
-            item.aspectRatio = {
-                guard let focusedIndex else { return nil }
-                return viewModel.imageAttachments[focusedIndex].imageDetails.originalSize
-            }()
-            
-            return item
-        }()
-        
-        let mediaPreviewViewModel = MediaPreviewViewModel(
-            item: previewItem,
-            transitionItem: mediaPreviewTransitionItem)
-        actionHandler?.presentScene(.mediaPreview(viewModel: mediaPreviewViewModel),
-                                             fromPost: nil,
-                                             transition: .custom(transitioningDelegate: presentingViewController.mediaPreviewTransitionController)
-        )
-    }
 }
 
 struct BlurhashImageView: View {
@@ -423,12 +364,10 @@ class ImageGalleryViewModel {
     private var frames = [Mastodon.Entity.Attachment.ID : CGRect]()
     let altTextTranslations: [String : String]?
     var blurhashes = [ Mastodon.Entity.Attachment.ID : UIImage ]()
-    let actionHandler: MastodonPostMenuActionHandler?
     
-    init(imageAttachments: [MastodonImageAttachment], altTextTranslations: [String: String]?, actionHandler: MastodonPostMenuActionHandler?) {
+    init(imageAttachments: [MastodonImageAttachment], altTextTranslations: [String: String]?) {
         self.imageAttachments = imageAttachments
         self.altTextTranslations = altTextTranslations
-        self.actionHandler = actionHandler
         loadBlurhashes()
     }
     
@@ -611,10 +550,9 @@ struct VideoPlayerView: View {
     let url: URL
     @Environment(ContentConcealViewModel.self) private var contentConcealViewModel
     @StateObject var playerObserver = PlayerObserver()
-    let actionHandler: MastodonPostMenuActionHandler?
     @State var waitingToShowFullSize = false
     
-    init?(media: MediaAttachment, actionHandler: MastodonPostMenuActionHandler?) {
+    init?(media: MediaAttachment) {
         switch media {
         case .video, .gifv:
             break
@@ -624,7 +562,6 @@ struct VideoPlayerView: View {
         guard let attachmentInfo = media.attachmentInfo, let url = attachmentInfo.url else { return nil }
         self.media = media
         self.url = url
-        self.actionHandler = actionHandler
     }
     
     var respectDeviceSilentSetting: Bool {
@@ -733,33 +670,6 @@ struct VideoPlayerView: View {
     
     func showFullSize() {
         playerObserver.didPressPause()
-        guard let _legacyEntity = media.attachmentInfo?._legacyEntity, let previewableViewController = actionHandler?.mediaPreviewableViewController else { return }
-        let previewItem: MediaPreviewViewModel.PreviewItem = .attachments([_legacyEntity], initialIndex: 0, placeholderImages: [playerObserver.blurImage], altTexts: [media.attachmentInfo?.basicData.altText ?? ""])
-        let mediaPreviewTransitionItem: MediaPreviewTransitionItem = {
-            let item = MediaPreviewTransitionItem(source: .swiftUI(sourceFramesInScreenCoordinates: [playerObserver.mostRecentFrameInScreenCoordinates]), previewableViewController: previewableViewController)
-            
-            item.initialClippingFrame = {
-                // this is the current frame of the player
-                let initialFrame = playerObserver.mostRecentFrameInScreenCoordinates
-                assert(initialFrame != .zero)
-                return initialFrame
-            }()
-            item.initialimageFrame = CGRect(x: 0, y: 0, width: item.initialClippingFrame?.width ?? 1, height: item.initialimageFrame?.height ?? 1)
-            
-            item.image = playerObserver.blurImage
-            
-            item.aspectRatio = item.initialClippingFrame?.size
-            
-            return item
-        }()
-        
-        let mediaPreviewViewModel = MediaPreviewViewModel(
-            item: previewItem,
-            transitionItem: mediaPreviewTransitionItem)
-        actionHandler?.presentScene(.mediaPreview(viewModel: mediaPreviewViewModel),
-                                   fromPost: nil,
-                                   transition: .custom(transitioningDelegate: previewableViewController.mediaPreviewTransitionController)
-        )
     }
 }
 

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
@@ -364,10 +364,14 @@ class ImageGalleryViewModel {
     private var frames = [Mastodon.Entity.Attachment.ID : CGRect]()
     let altTextTranslations: [String : String]?
     var blurhashes = [ Mastodon.Entity.Attachment.ID : UIImage ]()
+    let idToIndex: [ Mastodon.Entity.Attachment.ID : Int ]
     
     init(imageAttachments: [MastodonImageAttachment], altTextTranslations: [String: String]?) {
         self.imageAttachments = imageAttachments
         self.altTextTranslations = altTextTranslations
+        idToIndex = imageAttachments.enumerated().reduce(into: [ Mastodon.Entity.Attachment.ID : Int ](), { partialResult, element in
+            partialResult[element.1.id] = element.0
+        })
         loadBlurhashes()
     }
     

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
@@ -611,6 +611,7 @@ struct VideoPlayerView: View {
         .clipped() // prevents the blurhash image from overhanging the video if it somehow has a slightly different aspect ratio
         .overlay {
             Button {
+                playerObserver.didPressPause()
                 showOverlay(.video(media))
             } label: {
                 Rectangle().fill(.clear)

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
@@ -582,6 +582,9 @@ struct VideoPlayerView: View {
     
     var body: some View {
         ZStack {
+            Color.clear
+                .frame(width: width, height: aspectFittingHeightToFillWidth(containerWidth: width))
+            
             if let blurImage = playerObserver.blurImage {
                 Image(uiImage: blurImage)
                     .resizable()
@@ -642,6 +645,13 @@ struct VideoPlayerView: View {
         }
     }
     
+    func aspectFittingHeightToFillWidth(containerWidth: CGFloat) -> CGFloat {
+        guard originalSize != .zero else { return 200 }
+        let aspect = originalSize.aspectRatio
+        let fittingHeight = containerWidth / aspect
+        print("fitting size is \(containerWidth) x \(fittingHeight)")
+        return fittingHeight
+    }
     var shouldLoop: Bool {
         switch media {
         case .gifv:
@@ -801,5 +811,29 @@ class PlayerObserver: ObservableObject {
     
     func getPlayer() -> AVPlayer? {
         return player
+    }
+    
+    @ViewBuilder func playButton(_ _playingState: AVPlayer.TimeControlStatus) -> some View {
+        switch _playingState {
+        case .paused:
+            Button {
+                self.didPressPlay()
+            } label: {
+                Image(systemName: "play.fill")
+                    .font(.title2)
+                    .padding(EdgeInsets(top: standardPadding, leading: doublePadding, bottom: standardPadding, trailing: doublePadding))
+                    .background() {
+                        Capsule()
+                            .fill(.ultraThinMaterial)
+                    }
+            }
+            .buttonStyle(.borderless)
+        case .waitingToPlayAtSpecifiedRate:
+            ProgressView().progressViewStyle(.circular)
+        case .playing:
+            EmptyView()
+        @unknown default:
+            EmptyView()
+        }
     }
 }

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
@@ -600,9 +600,11 @@ struct VideoPlayerView: View {
             
             if let player = playerObserver.getPlayer() {
                 VideoPlayer(player: player)
+                    .opacity(playerObserver.isReadyToPlay ? 1 : 0)
                     .aspectRatio(originalSize.aspectRatio, contentMode: .fit)
             }
         }
+        .clipped() // prevents the blurhash image from overhanging the video if it somehow has a slightly different aspect ratio
         .overlay {
             Button {
                 showOverlay(.video(media))
@@ -672,6 +674,7 @@ extension MediaAttachment {
 @MainActor
 class PlayerObserver: ObservableObject {
     @Published var playingState: AVPlayer.TimeControlStatus = .paused
+    @Published var isReadyToPlay = false
     @Published var totalSeconds: Double?
     @Published var currentTimeInSeconds: Double = 0.0
     @Published var blurImage: UIImage? = nil
@@ -680,6 +683,7 @@ class PlayerObserver: ObservableObject {
     private var player: AVPlayer?
     private var timeObserverToken: Any?
     private var playerStatusSubscription: AnyCancellable?
+    private var playerReadinessSubscription: AnyCancellable?
     private var playShouldSeekToStart = false
     private var respectDeviceSilentSetting = false
     
@@ -715,6 +719,18 @@ class PlayerObserver: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newValue in
                 self?.playingState = newValue
+            }
+        self.playerReadinessSubscription?.cancel()
+        self.playerReadinessSubscription = player.publisher(for: \.currentItem?.isPlaybackLikelyToKeepUp, options: [.initial, .new])
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newValue in
+                guard let self else { return }
+                let newDerivedValue = newValue == true
+                if newDerivedValue != self.isReadyToPlay {
+                    withAnimation {
+                        self.isReadyToPlay = newDerivedValue
+                    }
+                }
             }
         
         if timeObserverToken == nil {

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
@@ -177,7 +177,7 @@ enum MediaAttachment {
 
 struct MediaAttachmentView: View {
     let mediaAttachment: MediaAttachment
-    let showOverlay: (MastodonTimelineOverlayView) -> ()
+    let containerOverlayBinding: Binding<MastodonTimelineOverlayView?>?
     let presentScene: (SceneCoordinator.Scene, Mastodon.Entity.Status.ID?, SceneCoordinator.Transition) -> ()
     @StateObject var playerObserver = PlayerObserver()
     
@@ -187,7 +187,7 @@ struct MediaAttachmentView: View {
             Image(systemName: "questionmark.square.dashed")
         case .images(let attachments, let altTextTranslations):
             ConcealableMediaAttachmentView() {
-                ImageGridView(showOverlay: showOverlay)
+                ImageGridView(containerOverlayBinding: containerOverlayBinding)
                     .environment(ImageGalleryViewModel(imageAttachments: attachments, altTextTranslations: altTextTranslations))
             }
         case .audio:
@@ -195,7 +195,7 @@ struct MediaAttachmentView: View {
         case .gifv, .video:
             ConcealableMediaAttachmentView() {
                 ZStack {
-                    VideoPlayerView(playerObserver: playerObserver, media: self.mediaAttachment, originalSize: self.mediaAttachment.attachmentInfo?.imageDetails?.originalSize ?? .zero, showOverlay: showOverlay)
+                    VideoPlayerView(playerObserver: playerObserver, media: self.mediaAttachment, originalSize: self.mediaAttachment.attachmentInfo?.imageDetails?.originalSize ?? .zero, containerOverlayBinding: containerOverlayBinding)
                     playerObserver.playButton(playerObserver.playingState)
                 }
             }
@@ -275,7 +275,7 @@ struct ConcealableMediaAttachmentView<Content: View>: View {
 struct ImageGridView: View {
     @Environment(ImageGalleryViewModel.self) private var viewModel
     @Environment(ContentConcealViewModel.self) private var contentConcealViewModel
-    let showOverlay: (MastodonTimelineOverlayView)->()
+    let containerOverlayBinding: Binding<MastodonTimelineOverlayView?>?
     
     var body: some View {
         // The images
@@ -287,29 +287,26 @@ struct ImageGridView: View {
                         .clipped()
                         .accessibilityLabel(viewModel.altTextTranslations?[img.id] ?? img.basicData.altText ?? "")
                         .onTapGesture {
-                            showOverlay(.images(focusedImage: img.id, viewModel))
+                            containerOverlayBinding?.wrappedValue = .images(focusedImage: img.id, viewModel)
                         }
-                    
-                    if let altText = img.basicData.altText, altText.isNotEmpty {
-                        Button {
-                            if let translation = viewModel.altTextTranslations?[img.id] {
-                                showOverlay(.altText(translation))
-                            } else {
-                                showOverlay(.altText(altText))
-                            }
-                        } label: {
-                            Text("ALT")
-                                .foregroundStyle(.white)
-                                .padding(EdgeInsets(top: ButtonPadding.vertical, leading: ButtonPadding.horizontal, bottom: ButtonPadding.vertical, trailing: ButtonPadding.horizontal))
-                                .background() {
-                                    RoundedRectangle(cornerRadius: CornerRadius.small)
-                                        .fill(buttonBackgroundColor)
+                    if let altText = viewModel.altTextTranslations?[img.id] ?? img.basicData.altText {
+                        AltTextButton(drawBorder: false, altText: altText, displayAltText: Binding<String?>(
+                            get: {
+                                switch containerOverlayBinding?.wrappedValue {
+                                case .altText(let text):
+                                    return text
+                                default:
+                                    return nil
                                 }
-                        }
-                        .fixedSize()
-                        .padding(standardPadding)
-                        .buttonStyle(.borderless)
-                        .accessibilityHidden(true)
+                            },
+                            set: { newValue in
+                                if let newValue {
+                                    containerOverlayBinding?.wrappedValue = .altText(newValue)
+                                } else {
+                                    containerOverlayBinding?.wrappedValue = nil
+                                }
+                            }
+                        ))
                     }
                 }
                 .frame(maxHeight: useRestrictedHeight ? maxHeightForHiddenMedia : nil)
@@ -561,9 +558,9 @@ struct VideoPlayerView: View {
     let originalSize: CGSize
     @Environment(ContentConcealViewModel.self) private var contentConcealViewModel
     @ObservedObject var playerObserver: PlayerObserver
-    let showOverlay: (MastodonTimelineOverlayView)->()
+    let containerOverlay: Binding<MastodonTimelineOverlayView?>?
     
-    init?(playerObserver: PlayerObserver, media: MediaAttachment, originalSize: CGSize, showOverlay: @escaping (MastodonTimelineOverlayView)->()) {
+    init?(playerObserver: PlayerObserver, media: MediaAttachment, originalSize: CGSize, containerOverlayBinding: Binding<MastodonTimelineOverlayView?>?) {
         switch media {
         case .video, .gifv:
             break
@@ -575,7 +572,7 @@ struct VideoPlayerView: View {
         self.originalSize = originalSize
         self.media = media
         self.url = url
-        self.showOverlay = showOverlay
+        self.containerOverlay = containerOverlayBinding
     }
     
     var respectDeviceSilentSetting: Bool {
@@ -613,7 +610,7 @@ struct VideoPlayerView: View {
         .overlay {
             Button {
                 playerObserver.didPressPause()
-                showOverlay(.video(media))
+                containerOverlay?.wrappedValue = .video(media)
             } label: {
                 Rectangle().fill(.clear)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/Views/TimelineRowViews/Molecules/MediaAttachmentView.swift
@@ -175,11 +175,14 @@ enum MediaAttachment {
     }
 }
 
-extension MediaAttachment {
-    @MainActor
-    @ViewBuilder func view(showOverlay: @escaping (MastodonTimelineOverlayView) -> (),
-                           presentScene: @escaping (SceneCoordinator.Scene, Mastodon.Entity.Status.ID?, SceneCoordinator.Transition) -> ()) -> some View {
-        switch self {
+struct MediaAttachmentView: View {
+    let mediaAttachment: MediaAttachment
+    let showOverlay: (MastodonTimelineOverlayView) -> ()
+    let presentScene: (SceneCoordinator.Scene, Mastodon.Entity.Status.ID?, SceneCoordinator.Transition) -> ()
+    @StateObject var playerObserver = PlayerObserver()
+    
+    var body: some View {
+        switch mediaAttachment {
         case .emptyAttachment:
             Image(systemName: "questionmark.square.dashed")
         case .images(let attachments, let altTextTranslations):
@@ -188,10 +191,13 @@ extension MediaAttachment {
                     .environment(ImageGalleryViewModel(imageAttachments: attachments, altTextTranslations: altTextTranslations))
             }
         case .audio:
-            AudioPlayerView(media: self)
+            AudioPlayerView(media: mediaAttachment)
         case .gifv, .video:
             ConcealableMediaAttachmentView() {
-                VideoPlayerView(media: self, originalSize: self.attachmentInfo?.imageDetails?.originalSize ?? .zero, showOverlay: showOverlay)
+                ZStack {
+                    VideoPlayerView(playerObserver: playerObserver, media: self.mediaAttachment, originalSize: self.mediaAttachment.attachmentInfo?.imageDetails?.originalSize ?? .zero, showOverlay: showOverlay)
+                    playerObserver.playButton(playerObserver.playingState)
+                }
             }
         case .openInBrowser(let url):
             Button {
@@ -554,10 +560,10 @@ struct VideoPlayerView: View {
     let url: URL
     let originalSize: CGSize
     @Environment(ContentConcealViewModel.self) private var contentConcealViewModel
-    @StateObject var playerObserver = PlayerObserver()
+    @ObservedObject var playerObserver: PlayerObserver
     let showOverlay: (MastodonTimelineOverlayView)->()
     
-    init?(media: MediaAttachment, originalSize: CGSize, showOverlay: @escaping (MastodonTimelineOverlayView)->()) {
+    init?(playerObserver: PlayerObserver, media: MediaAttachment, originalSize: CGSize, showOverlay: @escaping (MastodonTimelineOverlayView)->()) {
         switch media {
         case .video, .gifv:
             break
@@ -565,6 +571,7 @@ struct VideoPlayerView: View {
             return nil
         }
         guard let attachmentInfo = media.attachmentInfo, let url = attachmentInfo.url else { return nil }
+        self.playerObserver = playerObserver
         self.originalSize = originalSize
         self.media = media
         self.url = url
@@ -597,39 +604,13 @@ struct VideoPlayerView: View {
             }
         }
         .overlay {
-            ZStack {
-                Button {
-                    showOverlay(.video(media))
-                } label: {
-                    Rectangle().fill(.clear)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                }
-                .buttonStyle(.borderless)
-                
-                if shouldShowPlayButton {
-                    switch playerObserver.playingState {
-                    case .paused:
-                        Button {
-                            playerObserver.didPressPlay()
-                        } label: {
-                            Image(systemName: "play.fill")
-                                .font(.title2)
-                                .padding(EdgeInsets(top: standardPadding, leading: doublePadding, bottom: standardPadding, trailing: doublePadding))
-                                .background() {
-                                    Capsule()
-                                        .fill(.ultraThinMaterial)
-                                }
-                        }
-                        .buttonStyle(.borderless)
-                    case .waitingToPlayAtSpecifiedRate:
-                        ProgressView().progressViewStyle(.circular)
-                    case .playing:
-                        EmptyView()
-                    @unknown default:
-                        EmptyView()
-                    }
-                }
+            Button {
+                showOverlay(.video(media))
+            } label: {
+                Rectangle().fill(.clear)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
+            .buttonStyle(.borderless)
         }
         .onAppear() {
             self.playerObserver.setPlayer(withAsset: AVURLAsset(url: url), respectDeviceSilentSetting: respectDeviceSilentSetting)
@@ -732,8 +713,9 @@ class PlayerObserver: ObservableObject {
         self.playerStatusSubscription?.cancel()
         self.playerStatusSubscription = player.publisher(for: \.timeControlStatus, options: [.initial, .new])
             .receive(on: DispatchQueue.main)
-            .map { $0 }
-            .assign(to: \.playingState, on: self)
+            .sink { [weak self] newValue in
+                self?.playingState = newValue
+            }
         
         if timeObserverToken == nil {
             let interval = CMTime(seconds: 0.5, preferredTimescale: CMTimeScale(NSEC_PER_SEC))

--- a/Mastodon/In Progress New Layout and Datamodel/Common Components/ZoomableScrollView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Common Components/ZoomableScrollView.swift
@@ -4,10 +4,10 @@
 import SwiftUI
 
 struct ZoomableScrollView<Content: View>: UIViewRepresentable {
-    var content: () -> Content
+    var contentView: Content
 
-    init(@ViewBuilder content: @escaping () -> Content) {
-        self.content = content
+    init(@ViewBuilder content: () -> Content) {
+        self.contentView = content()
     }
 
     func makeCoordinator() -> Coordinator {
@@ -37,7 +37,7 @@ struct ZoomableScrollView<Content: View>: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UIScrollView, context: Context) {
-        context.coordinator.hostingController.rootView = content()
+        context.coordinator.hostingController.rootView = contentView
         context.coordinator.hostingController.view.setNeedsLayout()
         context.coordinator.hostingController.view.layoutIfNeeded()
 
@@ -53,7 +53,7 @@ struct ZoomableScrollView<Content: View>: UIViewRepresentable {
 
         init(_ parent: ZoomableScrollView) {
             self.parent = parent
-            self.hostingController = UIHostingController(rootView: parent.content())
+            self.hostingController = UIHostingController(rootView: parent.contentView)
         }
 
         func viewForZooming(in scrollView: UIScrollView) -> UIView? {

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
@@ -347,10 +347,10 @@ struct ProfileAvatarAndBannerView: View {
             Text("Edit cover image")
                 .padding(.vertical, tinySpacing)
                 .padding(.horizontal)
+                .tintedBlurBackground()
                 .clipShape(.capsule)
-                .glassEffectIfAvailable(.regular(interactive: true), in: .capsule)
+                .glassEffectIfAvailable(.clear(interactive: true), in: .capsule)
                 .foregroundStyle(.white)
-                .environment(\.colorScheme, .dark)
         }
     }
     
@@ -360,10 +360,10 @@ struct ProfileAvatarAndBannerView: View {
                 Image(systemName: "camera")
                     .font(.headline)
                     .padding()
+                    .tintedBlurBackground()
                     .clipShape(Circle())
-                    .glassEffectIfAvailable(.regular(interactive: true), in: .circle)
+                    .glassEffectIfAvailable(.clear(interactive: true), in: .circle)
                     .foregroundStyle(.white)
-                    .environment(\.colorScheme, .dark)
             } else {
                 Color.clear
             }

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
@@ -184,7 +184,7 @@ struct ProfileView: View {
                             .background() {
                                 GeometryReader { embeddedGeo in
                                     Color.clear
-                                        .preference(key: VerticalPositionKey.self, value: ["embedded": embeddedGeo.frame(in: .global).minY])
+                                        .preference(key: VerticalPositionKey.self, value: ["embedded": embeddedGeo.frame(in: CoordinateSpace.named("scrollview")).minY])
                                 }
                             }
                             .opacity(embeddedActionBarHasCaughtUpToFloatingActionBar ? 1.0 : 0.0)
@@ -207,6 +207,7 @@ struct ProfileView: View {
                 }
                 .nestedScrollview(.outer)
                 .frame(width: geo.size.width, height: geo.size.height)
+                .coordinateSpace(name: "scrollview")
                 
                 VStack {
                     Spacer()
@@ -218,7 +219,7 @@ struct ProfileView: View {
                         .background() {
                             GeometryReader { floatingGeo in
                                 Color.clear
-                                    .preference(key: VerticalPositionKey.self, value: ["floating": floatingGeo.frame(in: .global).minY])
+                                    .preference(key: VerticalPositionKey.self, value: ["floating": floatingGeo.frame(in: CoordinateSpace.named("scrollview")).minY])
                             }
                         }
                         .opacity(embeddedActionBarHasCaughtUpToFloatingActionBar ? 0.0 : 1.0)

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
@@ -279,6 +279,7 @@ struct ProfileAvatarAndBannerView: View {
                         bannerView(width: width)
                             .frame(height: bannerFullHeight)
                             .clipped()
+                            .background(.secondary) // in case there is no image
                         
                         switch profileViewModel.editingStatus {
                         case .editing:

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
@@ -117,8 +117,12 @@ struct ProfileView: View {
                             break
                         case .pushingChanges(let success):
                             guard success == true else { break }
-                            viewModel.editingStatus = .notEditing
                             navigationPath.removeLast()
+                        }
+                    }
+                    .onChange(of: navigationPath) { oldValue, newValue in
+                        if newValue.isEmpty {
+                            viewModel.editingStatus = .notEditing
                         }
                     }
             }

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
@@ -123,6 +123,7 @@ struct ProfileView: View {
                     .onChange(of: navigationPath) { oldValue, newValue in
                         if newValue.isEmpty {
                             viewModel.editingStatus = .notEditing
+                            viewModel.resetEditingViewModel()
                         }
                     }
             }
@@ -929,6 +930,11 @@ enum EditingStatus: Equatable {
                 }
             }
         }
+    }
+    
+    public func resetEditingViewModel() {
+        guard let account else { return }
+        editingViewModel.setAccount(account)
     }
 }
 

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
@@ -349,6 +349,7 @@ struct ProfileAvatarAndBannerView: View {
                 .clipShape(.capsule)
                 .glassEffectIfAvailable(.regular(interactive: true), in: .capsule)
                 .foregroundStyle(.white)
+                .environment(\.colorScheme, .dark)
         }
     }
     
@@ -361,6 +362,7 @@ struct ProfileAvatarAndBannerView: View {
                     .clipShape(Circle())
                     .glassEffectIfAvailable(.regular(interactive: true), in: .circle)
                     .foregroundStyle(.white)
+                    .environment(\.colorScheme, .dark)
             } else {
                 Color.clear
             }

--- a/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Profile/ProfileView.swift
@@ -177,8 +177,7 @@ struct ProfileView: View {
                             .frame(height: doublePadding)
                         
                         ProfileActionBar(navigationStackNavigateToEditProfile: {
-                            viewModel.editingStatus = .editing(hasChanges: false)
-                            navigationPath.append(MastodonNavigationDestination.editProfile)
+                            navigateToEditProfile()
                         })
                             .padding(.horizontal, doublePadding)
                             .frame(width: min(maxFeedContentWidth, geo.size.width))
@@ -212,7 +211,7 @@ struct ProfileView: View {
                 VStack {
                     Spacer()
                     ProfileActionBar(navigationStackNavigateToEditProfile: {
-                        navigationPath.append(MastodonNavigationDestination.editProfile)
+                        navigateToEditProfile()
                     })
                         .padding(.horizontal, doublePadding)
                         .frame(width: min(maxFeedContentWidth, geo.size.width))
@@ -253,6 +252,11 @@ struct ProfileView: View {
         case .pages:
             ProfilePaginatingView()
         }
+    }
+    
+    private func navigateToEditProfile() {
+        viewModel.editingStatus = .editing(hasChanges: false)
+        navigationPath.append(MastodonNavigationDestination.editProfile)
     }
 }
 

--- a/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
@@ -1758,7 +1758,10 @@ struct TimelineListView: View {
         .sheet(isPresented: viewModel.sheetIsPresented) {
             viewModel.activeSheetContents
         }
-        .overlay {
+        .fullScreenCover(isPresented: Binding<Bool>(
+            get: { viewModel.activeOverlay != nil },
+            set: { newValue in if newValue == false { viewModel.activeOverlay = nil }}
+        )) {
             if let activeOverlay = viewModel.activeOverlay {
                 viewModel.overlayContents(activeOverlay)
             }
@@ -2164,7 +2167,9 @@ extension MastodonTimelineOverlayView {
             AltTextView(altTextString: altTextString, frameSize: frameSize)
         case .images(let focusedImage, let viewModel):
             if let img = viewModel.imageAttachments.first(where: { $0.id == focusedImage }) {
-                ZoomableBlurhashImageView(image: img, frameSize: frameSize)
+                PageableImageGallery()
+                    .environment(viewModel)
+                    .environment(ContentConcealViewModel.alwaysShow)
             }
         }
     }

--- a/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
@@ -2176,18 +2176,29 @@ extension MastodonTimelineOverlayView {
                 .environment(ContentConcealViewModel.alwaysShow)
             }
         case .video(let attachment):
-            let playerObserver = PlayerObserver()
-            PageableZoomableView() {
-                ZoomableContentView(contentFullSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero, index: 0, containerSize: frameSize) {
-                    VideoPlayerView(playerObserver: playerObserver, media: attachment, originalSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero,
-                                    showOverlay: { _ in })
-                }
-            } controls: {
-                playerObserver.playButton(playerObserver.playingState)
-            }
-            .environment(PageableZoomableViewModel(pageCount: 1, focusedPage: 0, dismiss: closeOverlay))
-            .environment(ContentConcealViewModel.alwaysShow)
+            FullSizeVideoOverlayView(attachment: attachment, frameSize: frameSize, dismiss: closeOverlay)
         }
+    }
+}
+
+struct FullSizeVideoOverlayView: View {
+    let attachment: MediaAttachment
+    let frameSize: CGSize
+    let dismiss: ()->()
+    
+    @StateObject private var playerObserver = PlayerObserver()
+    
+    var body: some View {
+        PageableZoomableView() {
+            ZoomableContentView(contentFullSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero, index: 0, containerSize: frameSize) {
+                VideoPlayerView(playerObserver: playerObserver, media: attachment, originalSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero,
+                                showOverlay: { _ in })
+            }
+        } controls: {
+            playerObserver.playButton(playerObserver.playingState)
+        }
+        .environment(PageableZoomableViewModel(pageCount: 1, focusedPage: 0, dismiss: dismiss))
+        .environment(ContentConcealViewModel.alwaysShow)
     }
 }
 

--- a/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
@@ -2169,6 +2169,7 @@ extension MastodonTimelineOverlayView {
             if let img = viewModel.imageAttachments.first(where: { $0.id == focusedImage }) {
                 PageableImageGallery()
                     .environment(viewModel)
+                    .environment(PageableZoomableViewModel(pageCount: viewModel.imageAttachments.count, dismiss: closeOverlay))
                     .environment(ContentConcealViewModel.alwaysShow)
             }
         }

--- a/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
@@ -2175,7 +2175,9 @@ extension MastodonTimelineOverlayView {
             }
         case .video(let attachment):
             PageableZoomableView() {
-                VideoPlayerView(media: attachment, showOverlay: { _ in })
+                ZoomableContentView(contentFullSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero, index: 0, containerSize: frameSize) {
+                    VideoPlayerView(media: attachment, showOverlay: { _ in })
+                }
             }
             .environment(PageableZoomableViewModel(pageCount: 1, focusedPage: 0, dismiss: closeOverlay))
             .environment(ContentConcealViewModel.alwaysShow)
@@ -2190,8 +2192,11 @@ struct PagingImageGalleryContent: View {
     var body: some View {
         HStack(spacing: 0) {
             ForEach(galleryViewModel.imageAttachments, id: \.self.id) { imageInfo in
-                ZoomableImageView(size: pageSize,
-                                  index: galleryViewModel.idToIndex[imageInfo.id] ?? 0)
+                let index = galleryViewModel.idToIndex[imageInfo.id] ?? 0
+                ZoomableContentView(contentFullSize: galleryViewModel.imageAttachments[index].imageDetails.originalSize ?? .zero,
+                                    index: index, containerSize: pageSize) {
+                    BlurhashImageView(url: imageInfo.basicData.fullsizeUrl, imageDetails: imageInfo.imageDetails, blurhash: galleryViewModel.blurhashes[imageInfo.basicData.id])
+                }
             }
         }
     }

--- a/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
@@ -752,7 +752,7 @@ enum MastodonTimelineSheet {
                             self?.activeOverlay = nil
                         }
                     
-                    overlay.view(sizedForFrame: geo.size, closeOverlay: { self.showOverlay(nil) })
+                    overlay.view(closeOverlay: { self.showOverlay(nil) })
                 }
                 
                 Button {
@@ -2160,10 +2160,13 @@ struct TimelineListView: View {
 
 extension MastodonTimelineOverlayView {
     @MainActor
-    @ViewBuilder func view(sizedForFrame frameSize: CGSize, closeOverlay: @escaping ()->()) -> some View {
+    @ViewBuilder func view(closeOverlay: @escaping ()->()) -> some View {
         switch self {
         case .altText(let altTextString):
-            AltTextView(altTextString: altTextString, frameSize: frameSize)
+            GeometryReader { geo in
+                AltTextView(altTextString: altTextString)
+                    .environment(\.pageSize, geo.size)
+            }
         case .images(let focusedImage, let viewModel):
             if let focusedIndex = viewModel.imageAttachments.firstIndex(where: { $0.id == focusedImage }) {
                 PageableZoomableView() {
@@ -2176,23 +2179,24 @@ extension MastodonTimelineOverlayView {
                 .environment(ContentConcealViewModel.alwaysShow)
             }
         case .video(let attachment):
-            FullSizeVideoOverlayView(attachment: attachment, frameSize: frameSize, dismiss: closeOverlay)
+            FullSizeVideoOverlayView(attachment: attachment, dismiss: closeOverlay)
         }
     }
 }
 
 struct FullSizeVideoOverlayView: View {
     let attachment: MediaAttachment
-    let frameSize: CGSize
     let dismiss: ()->()
     
     @StateObject private var playerObserver = PlayerObserver()
     
     var body: some View {
         PageableZoomableView() {
-            ZoomableContentView(contentFullSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero, index: 0, containerSize: frameSize) {
-                VideoPlayerView(playerObserver: playerObserver, media: attachment, originalSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero,
-                                showOverlay: { _ in })
+            HStack {
+                ZoomableContentView(contentFullSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero, index: 0) {
+                    VideoPlayerView(playerObserver: playerObserver, media: attachment, originalSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero,
+                                    showOverlay: { _ in })
+                }
             }
         } controls: {
             playerObserver.playButton(playerObserver.playingState)
@@ -2211,7 +2215,7 @@ struct PagingImageGalleryContent: View {
             ForEach(galleryViewModel.imageAttachments, id: \.self.id) { imageInfo in
                 let index = galleryViewModel.idToIndex[imageInfo.id] ?? 0
                 ZoomableContentView(contentFullSize: galleryViewModel.imageAttachments[index].imageDetails.originalSize ?? .zero,
-                                    index: index, containerSize: pageSize) {
+                                    index: index) {
                     BlurhashImageView(url: imageInfo.basicData.fullsizeUrl, imageDetails: imageInfo.imageDetails, blurhash: galleryViewModel.blurhashes[imageInfo.basicData.id])
                 }
             }

--- a/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
@@ -2166,10 +2166,10 @@ extension MastodonTimelineOverlayView {
         case .altText(let altTextString):
             AltTextView(altTextString: altTextString, frameSize: frameSize)
         case .images(let focusedImage, let viewModel):
-            if let img = viewModel.imageAttachments.first(where: { $0.id == focusedImage }) {
+            if let focusedIndex = viewModel.imageAttachments.firstIndex(where: { $0.id == focusedImage }) {
                 PageableImageGallery()
                     .environment(viewModel)
-                    .environment(PageableZoomableViewModel(pageCount: viewModel.imageAttachments.count, dismiss: closeOverlay))
+                    .environment(PageableZoomableViewModel(pageCount: viewModel.imageAttachments.count, focusedPage: focusedIndex, dismiss: closeOverlay))
                     .environment(ContentConcealViewModel.alwaysShow)
             }
         }

--- a/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
@@ -742,17 +742,27 @@ enum MastodonTimelineSheet {
     
     // MARK - Overlays
     var activeOverlay: MastodonTimelineOverlayView? = nil
+    
+    private func overlayIncludesDimmingBackground(_ overlay: MastodonTimelineOverlayView) -> Bool {
+        switch overlay {
+        case .altText: true
+        default: false
+        }
+    }
+    
     @ViewBuilder func overlayContents(_ overlay: MastodonTimelineOverlayView) -> some View {
         GeometryReader { geo in
             ZStack(alignment: .topLeading) {
                 ZStack {
-                    Color.dimmingBackground
-                        .ignoresSafeArea()
-                        .onTapGesture { [weak self] in
-                            self?.activeOverlay = nil
-                        }
+                    if !self.overlayIncludesDimmingBackground(overlay) {
+                        Color.dimmingBackground
+                            .ignoresSafeArea()
+                            .onTapGesture { [weak self] in
+                                self?.activeOverlay = nil
+                            }
+                    }
                     
-                    overlay.view(closeOverlay: { self.showOverlay(nil) })
+                    self.overlayView(overlay)
                 }
                 
                 Button {
@@ -764,6 +774,47 @@ enum MastodonTimelineSheet {
                 }
                 .padding(standardPadding)
             }
+        }
+    }
+    
+    @ViewBuilder private func overlayView(_ overlay: MastodonTimelineOverlayView) -> some View {
+        
+        switch overlay {
+        case .altText:
+            AltTextOverlay(altTextBinding: Binding<String?>(
+                get: {
+                    switch self.activeOverlay {
+                    case .altText(let string):
+                        return string
+                    default:
+                        return nil
+                    }
+                },
+                set: { newValue in
+                    if let newValue {
+                        self.activeOverlay = .altText(newValue)
+                    } else {
+                        switch self.activeOverlay {
+                        case .altText:
+                            self.activeOverlay = nil
+                        default:
+                            break
+                        }
+                    }
+                }
+            ))
+            
+        case .images(let focusedImage, let viewModel):
+            if let focusedIndex = viewModel.imageAttachments.firstIndex(where: { $0.id == focusedImage }) {
+                FullSizeImageGallery()
+                    .environment(viewModel)
+                    .environment(PageableZoomableViewModel(pageCount: viewModel.imageAttachments.count, focusedPage: focusedIndex, dismiss: { self.activeOverlay = nil }))
+                    .environment(ContentConcealViewModel.alwaysShow)
+            }
+        case .video(let attachment):
+            FullSizeVideoOverlayView(attachment: attachment)
+                .environment(PageableZoomableViewModel(pageCount: 1, focusedPage: 0, dismiss: { self.activeOverlay = nil }))
+                .environment(ContentConcealViewModel.alwaysShow)
         }
     }
     
@@ -2158,30 +2209,32 @@ struct TimelineListView: View {
     }
 }
 
-extension MastodonTimelineOverlayView {
-    @MainActor
-    @ViewBuilder func view(closeOverlay: @escaping ()->()) -> some View {
-        switch self {
-        case .altText(let altTextString):
-            GeometryReader { geo in
-                AltTextView(altTextString: altTextString)
-                    .environment(\.pageSize, geo.size)
+struct FullSizeImageGallery: View {
+    @Environment(ImageGalleryViewModel.self) private var viewModel
+    @Environment(PageableZoomableViewModel.self) private var pageableZoomableModel
+    
+    @State private var displayAltText: String?
+    
+    var body: some View {
+        PageableZoomableView() {
+            PagingImageGalleryContent()
+        } controls: {
+            let currentAttachment = viewModel.imageAttachments[pageableZoomableModel.focusedPageIndex]
+            if let currentPageAltText = viewModel.altTextTranslations?[currentAttachment.id] ?? currentAttachment.basicData.altText {
+                AltTextButton(drawBorder: true, altText: currentPageAltText, displayAltText: Binding<String?>(
+                    get: { displayAltText },
+                    set: { newValue in displayAltText = newValue}
+                ))
+                .padding(.horizontal, doublePadding)
+                .padding(.vertical, 100)
+                .frame(width: pageableZoomableModel.pagingPageSize.width, height: pageableZoomableModel.pagingPageSize.height, alignment: .topTrailing)
             }
-        case .images(let focusedImage, let viewModel):
-            if let focusedIndex = viewModel.imageAttachments.firstIndex(where: { $0.id == focusedImage }) {
-                PageableZoomableView() {
-                    PagingImageGalleryContent()
-                } controls: {
-                    EmptyView()
-                }
-                .environment(viewModel)
-                .environment(PageableZoomableViewModel(pageCount: viewModel.imageAttachments.count, focusedPage: focusedIndex, dismiss: closeOverlay))
-                .environment(ContentConcealViewModel.alwaysShow)
-            }
-        case .video(let attachment):
-            FullSizeVideoOverlayView(attachment: attachment)
-                .environment(PageableZoomableViewModel(pageCount: 1, focusedPage: 0, dismiss: closeOverlay))
-                .environment(ContentConcealViewModel.alwaysShow)
+        }
+        .overlay {
+            AltTextOverlay(altTextBinding: Binding<String?>(
+                get: { displayAltText },
+                set: { newValue in displayAltText = newValue}
+            ))
         }
     }
 }
@@ -2196,7 +2249,7 @@ struct FullSizeVideoOverlayView: View {
             HStack {
                 ZoomableContentView(contentFullSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero, index: 0) {
                     VideoPlayerView(playerObserver: playerObserver, media: attachment, originalSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero,
-                                    showOverlay: { _ in })
+                                    containerOverlayBinding: nil)
                 }
             }
         } controls: {
@@ -2240,8 +2293,11 @@ extension TimelineListViewModel: MastodonPostMenuActionHandler {
         return updatedPoll
     }
     
-    func showOverlay(_ overlay: MastodonTimelineOverlayView?) {
-        activeOverlay = overlay
+    var containerOverlayBinding: Binding<MastodonTimelineOverlayView?> {
+        Binding<MastodonTimelineOverlayView?>(
+            get: { self.activeOverlay },
+            set: { newValue in self.activeOverlay = newValue }
+        )
     }
     
     func showSheet(_ sheet: MastodonTimelineSheet?) {

--- a/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
@@ -2179,14 +2179,15 @@ extension MastodonTimelineOverlayView {
                 .environment(ContentConcealViewModel.alwaysShow)
             }
         case .video(let attachment):
-            FullSizeVideoOverlayView(attachment: attachment, dismiss: closeOverlay)
+            FullSizeVideoOverlayView(attachment: attachment)
+                .environment(PageableZoomableViewModel(pageCount: 1, focusedPage: 0, dismiss: closeOverlay))
+                .environment(ContentConcealViewModel.alwaysShow)
         }
     }
 }
 
 struct FullSizeVideoOverlayView: View {
     let attachment: MediaAttachment
-    let dismiss: ()->()
     
     @StateObject private var playerObserver = PlayerObserver()
     
@@ -2201,8 +2202,6 @@ struct FullSizeVideoOverlayView: View {
         } controls: {
             playerObserver.playButton(playerObserver.playingState)
         }
-        .environment(PageableZoomableViewModel(pageCount: 1, focusedPage: 0, dismiss: dismiss))
-        .environment(ContentConcealViewModel.alwaysShow)
     }
 }
 

--- a/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
@@ -2168,16 +2168,22 @@ extension MastodonTimelineOverlayView {
             if let focusedIndex = viewModel.imageAttachments.firstIndex(where: { $0.id == focusedImage }) {
                 PageableZoomableView() {
                     PagingImageGalleryContent()
+                } controls: {
+                    EmptyView()
                 }
                 .environment(viewModel)
                 .environment(PageableZoomableViewModel(pageCount: viewModel.imageAttachments.count, focusedPage: focusedIndex, dismiss: closeOverlay))
                 .environment(ContentConcealViewModel.alwaysShow)
             }
         case .video(let attachment):
+            let playerObserver = PlayerObserver()
             PageableZoomableView() {
                 ZoomableContentView(contentFullSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero, index: 0, containerSize: frameSize) {
-                    VideoPlayerView(media: attachment, originalSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero, showOverlay: { _ in })
+                    VideoPlayerView(playerObserver: playerObserver, media: attachment, originalSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero,
+                                    showOverlay: { _ in })
                 }
+            } controls: {
+                playerObserver.playButton(playerObserver.playingState)
             }
             .environment(PageableZoomableViewModel(pageCount: 1, focusedPage: 0, dismiss: closeOverlay))
             .environment(ContentConcealViewModel.alwaysShow)

--- a/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
@@ -627,6 +627,7 @@ extension MastodonPostMenuAction {
 
 enum MastodonTimelineOverlayView {
     case images(focusedImage: Mastodon.Entity.Attachment.ID, ImageGalleryViewModel)
+    case video(MediaAttachment)
     case altText(String)
 }
 
@@ -2157,8 +2158,6 @@ struct TimelineListView: View {
     }
 }
 
-
-
 extension MastodonTimelineOverlayView {
     @MainActor
     @ViewBuilder func view(sizedForFrame frameSize: CGSize, closeOverlay: @escaping ()->()) -> some View {
@@ -2167,10 +2166,32 @@ extension MastodonTimelineOverlayView {
             AltTextView(altTextString: altTextString, frameSize: frameSize)
         case .images(let focusedImage, let viewModel):
             if let focusedIndex = viewModel.imageAttachments.firstIndex(where: { $0.id == focusedImage }) {
-                PageableImageGallery()
-                    .environment(viewModel)
-                    .environment(PageableZoomableViewModel(pageCount: viewModel.imageAttachments.count, focusedPage: focusedIndex, dismiss: closeOverlay))
-                    .environment(ContentConcealViewModel.alwaysShow)
+                PageableZoomableView() {
+                    PagingImageGalleryContent()
+                }
+                .environment(viewModel)
+                .environment(PageableZoomableViewModel(pageCount: viewModel.imageAttachments.count, focusedPage: focusedIndex, dismiss: closeOverlay))
+                .environment(ContentConcealViewModel.alwaysShow)
+            }
+        case .video(let attachment):
+            PageableZoomableView() {
+                VideoPlayerView(media: attachment, showOverlay: { _ in })
+            }
+            .environment(PageableZoomableViewModel(pageCount: 1, focusedPage: 0, dismiss: closeOverlay))
+            .environment(ContentConcealViewModel.alwaysShow)
+        }
+    }
+}
+
+struct PagingImageGalleryContent: View {
+    @Environment(\.pageSize) var pageSize
+    @Environment(ImageGalleryViewModel.self) var galleryViewModel
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(galleryViewModel.imageAttachments, id: \.self.id) { imageInfo in
+                ZoomableImageView(size: pageSize,
+                                  index: galleryViewModel.idToIndex[imageInfo.id] ?? 0)
             }
         }
     }

--- a/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
@@ -2176,7 +2176,7 @@ extension MastodonTimelineOverlayView {
         case .video(let attachment):
             PageableZoomableView() {
                 ZoomableContentView(contentFullSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero, index: 0, containerSize: frameSize) {
-                    VideoPlayerView(media: attachment, showOverlay: { _ in })
+                    VideoPlayerView(media: attachment, originalSize: attachment.attachmentInfo?.imageDetails?.originalSize ?? .zero, showOverlay: { _ in })
                 }
             }
             .environment(PageableZoomableViewModel(pageCount: 1, focusedPage: 0, dismiss: closeOverlay))


### PR DESCRIPTION
Replace the UIKit-based fullsize media displays with SwiftUI, which will allow removing the conformance to MediaPreviewableViewController.

These changes also make some minor improvements to the new profile view. 