### PR TITLE
Fix language variant display in settings and compose toolbar

### DIFF
--- a/Mastodon/Scene/Settings/General Settings/GeneralSettingSelectionCell.swift
+++ b/Mastodon/Scene/Settings/General Settings/GeneralSettingSelectionCell.swift
@@ -59,7 +59,7 @@ class GeneralSettingSelectionCell: UITableViewCell {
         content.prefersSideBySideTextAndSecondaryText = true
         content.text = setting.title
         
-        if let text = LanguagePicker.availableLanguages().first(where: { $0.localeId == UserDefaults.shared.defaultPostLanguage })?.exonym {
+        if let text = LanguagePicker.availableLanguages().first(where: { $0.id == UserDefaults.shared.defaultPostLanguage })?.exonym {
             content.secondaryAttributedText = NSAttributedString(
                 string: text,
                 attributes: [

--- a/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView.swift
+++ b/MastodonSDK/Sources/MastodonUI/Scene/ComposeContent/Toolbar/ComposeContentToolbarView.swift
@@ -94,12 +94,13 @@ struct ComposeContentToolbarView: View {
                                         showingLanguagePicker = true
                                     }
                                 } label: {
-                                    let font = SwiftUI.Font.system(size: 11, weight: .semibold).width(viewModel.language.count == 3 ? .compressed : .standard)
+                                    let font = SwiftUI.Font.system(size: 11, weight: .semibold).width(viewModel.language.count >= 3 ? .compressed : .standard).leading(.tight)
                                     
-                                    Text(viewModel.language)
+                                    Text(viewModel.language.replacing("-", with: "").prefix(4))
                                         .font(font)
                                         .textCase(.uppercase)
                                         .padding(.horizontal, 4)
+                                        .padding(.vertical, 2)
                                         .minimumScaleFactor(0.5)
                                         .frame(width: 24, height: 24, alignment: .center)
                                         .overlay { RoundedRectangle(cornerRadius: 7).inset(by: 3).stroke(lineWidth: 1.5) }


### PR DESCRIPTION
This pull request fixes “Default Post Language” previews and improves the compose toolbar language indicator for language variants. 

The first commit 69c364f377871a88e63014439d956fefe96c70b3 addresses a trivial comparison error that resulted in language variants losing their preview in Settings.

The second commit f689a09cc improves the language indicator in the compose toolbar so longer variant codes fit more cleanly using compact uppercase abbreviations, tighter leading, and small vertical padding.

<img width="307" height="109" alt="Original" src="https://github.com/user-attachments/assets/a59334e0-f320-4d12-b51c-9de6353fa891" /> → <img width="251" height="89" alt="Improved" src="https://github.com/user-attachments/assets/17802c7c-a694-449e-8d2b-ca748973c9ba" />

**Note:** I didn’t opt for improving the multi-line legibility due to `.lineSpacing` being available only on iOS 26+ and there are only limited ways for me to tweak this without introducing too much complexity to code. I believe this PR strikes a good balance.

Please let me know if there’s comments or requests for improvements!