### PR TITLE
Fix stale notifications after returning from background (#1554, #1564)

### DIFF
--- a/Mastodon/In Progress New Layout and Datamodel/FeedLoader/MastodonFeedLoader.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/FeedLoader/MastodonFeedLoader.swift
@@ -88,6 +88,12 @@ public class MastodonFeedLoader<PublishedType: Identifiable, CachedType: Cacheab
         allRecords: [], nextBottomLoad: .initializing)
     @Published private(set) var currentError: Error? = nil
     
+    /// Last time `fetchResults` completed and records were published.
+    private(set) var lastSuccessfulFetchAt: Date? = nil
+    
+    /// Bumped to abandon in-flight fetches that iOS froze in the background or that pull-to-refresh superseded.
+    private var loadGeneration: Int = 0
+    
     init(_ cacheManager: (any MastodonFeedCacheManager<CachedType>)) {
         self.cacheManager = cacheManager
         
@@ -102,15 +108,36 @@ public class MastodonFeedLoader<PublishedType: Identifiable, CachedType: Cacheab
             }
     }
     
+    private var fetchStartedAt: Date? = nil
+    
+    var isActivelyFetching: Bool { isFetching }
+    
+    /// URLSession tasks suspended in the background often never complete, so `isFetching` stays true forever.
+    var fetchAppearsStuck: Bool {
+        guard isFetching, let fetchStartedAt else { return false }
+        return Date().timeIntervalSince(fetchStartedAt) > 15
+    }
+    
     private var isFetching: Bool = false {
         didSet {
+            if isFetching {
+                if fetchStartedAt == nil {
+                    fetchStartedAt = Date()
+                }
+            } else {
+                fetchStartedAt = nil
+            }
             if !isFetching, let waitingRequest = nextRequestThatCanBeLoadedNow() {
                 Task {
                     do {
                         try await load(waitingRequest)
                         currentError = nil
                     } catch {
-                        currentError = error
+                        if Self.isCancellation(error) {
+                            currentError = nil
+                        } else {
+                            currentError = error
+                        }
                     }
                 }
             }
@@ -123,6 +150,19 @@ public class MastodonFeedLoader<PublishedType: Identifiable, CachedType: Cacheab
         let nextRequest = loadRequestQueue.removeFirst()
         isFetching = true
         return nextRequest
+    }
+    
+    /// Drop queued work and make any in-flight `load` ignore its result. Call when entering the background so a frozen socket cannot pin `isFetching`.
+    func invalidateInFlightLoad() {
+        loadRequestQueue.removeAll()
+        loadGeneration += 1
+        isFetching = false
+    }
+    
+    private static func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError { return true }
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
     }
     
     func setRecords(_ records: MastodonFeedLoaderResult<PublishedType>) {
@@ -173,20 +213,22 @@ extension MastodonFeedLoader {
                     try await load(nextDoableRequest)
                     currentError = nil
                 } catch {
-                    currentError = error
+                    if Self.isCancellation(error) {
+                        currentError = nil
+                    } else {
+                        currentError = error
+                    }
                 }
             }
         }
     }
     
     /// Use only with pull to refresh, in order to properly update the progress spinner.
+    /// Always succeeds: a stuck in-flight fetch is abandoned so the user is never stuck needing a force-quit.
     public var permissionToLoadImmediately: Bool {
-        if isFetching {
-            return false
-        } else {
-            isFetching = true
-            return true
-        }
+        invalidateInFlightLoad()
+        isFetching = true
+        return true
     }
     /// Use only with pull to refresh, in order to properly update the progress spinner.
     public func loadImmediately(_ request: MastodonFeedLoaderRequest) async {
@@ -195,7 +237,11 @@ extension MastodonFeedLoader {
             try await load(request)
             currentError = nil
         } catch {
-            currentError = error
+            if Self.isCancellation(error) {
+                currentError = nil
+            } else {
+                currentError = error
+            }
         }
     }
     
@@ -204,9 +250,16 @@ extension MastodonFeedLoader {
         if request == .reloadForFilterChange, let resetTimeline = resetTimeline() {
             updateAfterInserting(newlyFetchedResults: resetTimeline, at: .replace)
         }
-        defer { isFetching = false }
+        let generation = loadGeneration
+        defer {
+            if generation == loadGeneration {
+                isFetching = false
+            }
+        }
         let unfiltered = try await fetchResults(for: request)
+        guard generation == loadGeneration else { return }
         updateAfterInserting(newlyFetchedResults: unfiltered, at: request.resultsInsertionPoint)
+        lastSuccessfulFetchAt = Date()
     }
     
     func updateAfterInserting(newlyFetchedResults: CachedType, at insertionPoint: MastodonFeedLoaderRequest.InsertLocation) {

--- a/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
@@ -1221,7 +1221,13 @@ enum MastodonTimelineSheet {
     /// REST feeds are not streamed. Refresh when the scene/tab becomes visible, otherwise the user keeps seeing a snapshot from the last successful fetch until force-quit.
     func reloadWhenBecomingVisible() {
         guard feedLoader != nil else { return }
-        guard timeline.canPullToRefresh else { return }
+        switch timeline {
+        case .homeTimeline, .notifications:
+            break
+        default:
+            // `.reload` replaces the whole page. Auto-refreshing bookmarks/hashtags/lists on resume would drop already-paginated older items.
+            return
+        }
         switch loadingState {
         case .initializing:
             return
@@ -1529,8 +1535,6 @@ enum MastodonTimelineSheet {
             loadingState = .requestedReloadFromTop
             if feedLoader.permissionToLoadImmediately {
                 await feedLoader.loadImmediately(.reload)
-            } else {
-                feedLoader.requestLoad(.reload)
             }
         case .activityFilterUpdated, .mediaFilterUpdated:
             loadingState = .initializing

--- a/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
+++ b/Mastodon/In Progress New Layout and Datamodel/Timeline/TimelineListViewController.swift
@@ -1,6 +1,7 @@
 // Copyright © 2025 Mastodon gGmbH. All rights reserved.
 
 import SwiftUI
+import UIKit
 import MastodonAsset
 import MastodonCore
 import MastodonLocalization
@@ -182,6 +183,21 @@ class TimelineListViewController: UIHostingController<AnyView>
         navigator.navigationType = .uiKit(self)
         
         setUpNavigationBar()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // SwiftUI onAppear does not run when returning from background, and often not when switching UITabBar tabs.
+        viewModel.reloadWhenBecomingVisible()
+    }
+    
+    func scrollToTopAndRefresh() {
+        viewModel.jumpToTopAfterNextReload = true
+        viewModel.scrollToTop()
+        viewModel.loadingState = .requestedReloadFromTop
+        Task {
+            await viewModel.refreshFromTop()
+        }
     }
     
     func setUpNavigationBar() {
@@ -887,6 +903,7 @@ enum MastodonTimelineSheet {
         case notificationFilterPolicyUpdated
         case userRequestedRefresh
         case notificationCountUpdated
+        case becameVisible
         case asyncRefreshResultsRequested
         case activityFilterUpdated
         case mediaFilterUpdated
@@ -901,6 +918,26 @@ enum MastodonTimelineSheet {
     var filteredNotificationsViewModel =
         FilteredNotificationsRowView.ViewModel(policy: nil)
     var needsReloadOnNextAppear = false
+    /// After a top-of-feed reload, jump the scroll position to the newest items instead of keeping the old anchor (which hides new rows above it).
+    var jumpToTopAfterNextReload = false
+    private var isReloadFromVisibilityScheduled = false
+    private var sceneLifecycleSubscriptions = Set<AnyCancellable>()
+    
+    private var isScrolledNearTop: Bool {
+        guard let anchorIndex = currentDisplaySlice.firstIndex(of: scrollAnchorItem) else {
+            return true
+        }
+        return anchorIndex <= 1
+    }
+    
+    private func topAnchorItem(in items: [TimelineItem]) -> TimelineItem {
+        switch timeline {
+        case .notifications(.everything), .notifications(.mentions):
+            return .filteredNotificationsInfo(filteredNotificationsViewModel.policy, filteredNotificationsViewModel)
+        default:
+            return items.first ?? .noItem
+        }
+    }
     
     // MARK - Overlays
     var hasActiveOverlay: Bool {
@@ -1158,8 +1195,56 @@ enum MastodonTimelineSheet {
                 self.authenticatedUser = AuthenticationServiceProvider.shared.currentActiveUser.value
             }
         
+        observeSceneLifecycle()
+        
         Task {
             try await doInitialLoad(navigator: navigator)
+        }
+    }
+    
+    private func observeSceneLifecycle() {
+        NotificationCenter.default.publisher(for: UIScene.didActivateNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.reloadWhenBecomingVisible()
+            }
+            .store(in: &sceneLifecycleSubscriptions)
+        
+        NotificationCenter.default.publisher(for: UIScene.didEnterBackgroundNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.feedLoader?.invalidateInFlightLoad()
+            }
+            .store(in: &sceneLifecycleSubscriptions)
+    }
+    
+    /// REST feeds are not streamed. Refresh when the scene/tab becomes visible, otherwise the user keeps seeing a snapshot from the last successful fetch until force-quit.
+    func reloadWhenBecomingVisible() {
+        guard feedLoader != nil else { return }
+        guard timeline.canPullToRefresh else { return }
+        switch loadingState {
+        case .initializing:
+            return
+        default:
+            break
+        }
+        let forceBecauseOfNewNotifications = needsReloadOnNextAppear
+        if !forceBecauseOfNewNotifications,
+           let last = feedLoader?.lastSuccessfulFetchAt,
+           Date().timeIntervalSince(last) < 3 {
+            return
+        }
+        if !forceBecauseOfNewNotifications,
+           (isReloadFromVisibilityScheduled || (feedLoader?.isActivelyFetching == true && feedLoader?.fetchAppearsStuck != true)) {
+            return
+        }
+        needsReloadOnNextAppear = false
+        isReloadFromVisibilityScheduled = true
+        jumpToTopAfterNextReload = isScrolledNearTop
+        loadingState = .requestedReloadFromTop
+        Task {
+            defer { isReloadFromVisibilityScheduled = false }
+            await forceReload(.becameVisible)
         }
     }
     
@@ -1245,7 +1330,35 @@ enum MastodonTimelineSheet {
             newItemsCount = 0 // ... so there will be no new items above the visible point
             safeToSetNewItemsImmediately = true
             
-        case .requestedReloadFromTop, .requestedPrependedHeightCalculations, .untracked:
+        case .requestedReloadFromTop:
+            let previousFirstItem = self.currentDisplaySlice.first(where: { $0.isRealItem })
+            let currentFeedIsEmpty = previousFirstItem == nil
+            let jumpToTop = jumpToTopAfterNextReload || isScrolledNearTop || currentFeedIsEmpty
+            jumpToTopAfterNextReload = false
+            // Always apply the new page. Holding it in `waitingReplacementItems` until the next pull-to-refresh made Notifications look frozen.
+            safeToSetNewItemsImmediately = true
+            if jumpToTop {
+                newScrollAnchor = topAnchorItem(in: items)
+                newItemsCount = 0
+            } else if let previousFirstItem, let newIndex = items.firstIndex(of: previousFirstItem) {
+                newScrollAnchor = nil
+                newItemsCount = newIndex
+            } else if let newIndex = items.firstIndex(of: self.scrollAnchorItem) {
+                newScrollAnchor = nil
+                newItemsCount = newIndex
+            } else {
+                newScrollAnchor = topAnchorItem(in: items)
+                newItemsCount = 0
+            }
+            
+        case .requestedPrependedHeightCalculations, .untracked:
+            if jumpToTopAfterNextReload {
+                jumpToTopAfterNextReload = false
+                safeToSetNewItemsImmediately = true
+                newScrollAnchor = topAnchorItem(in: items)
+                newItemsCount = 0
+                break
+            }
             // The new set of results may not include the current scroll anchor.  In that case, just show the new items snackbar and wait to do the actual reload (by tapping on the snackbar or doing a pull to refresh).
             let previousFirstItem = self.currentDisplaySlice.first(where: { $0.isRealItem })
             let currentFeedIsEmpty = previousFirstItem == nil
@@ -1380,10 +1493,13 @@ enum MastodonTimelineSheet {
     
     func refreshFromTop() async {
         assert(loadingState == .requestedReloadFromTop, "Caller must synchronously set loading state before requesting async reload.")
+        jumpToTopAfterNextReload = true
         if let waiting = waitingReplacementItems, !waiting.isEmpty {
             scrollToTop()
-        } else {
-            await _refreshFromTop()
+        }
+        await _refreshFromTop()
+        if let waiting = waitingReplacementItems, !waiting.isEmpty {
+            scrollToTop()
         }
         resetToUntrackedAfterDelay(from: loadingState)
     }
@@ -1401,11 +1517,21 @@ enum MastodonTimelineSheet {
         }
         needsReloadOnNextAppear = false
         switch reason {
-        case .notificationCountUpdated:
-            fetchFilteredNotificationsPolicy(andReloadFeed: true)
+        case .notificationCountUpdated, .becameVisible:
+            if timeline.canDisplayFilteredNotifications {
+                fetchFilteredNotificationsPolicy(andReloadFeed: false)
+            }
+            if feedLoader.permissionToLoadImmediately {
+                await feedLoader.loadImmediately(.reload)
+                commitToCache()
+            }
         case .notificationFilterPolicyUpdated:
             loadingState = .requestedReloadFromTop
-            feedLoader.requestLoad(.reload)
+            if feedLoader.permissionToLoadImmediately {
+                await feedLoader.loadImmediately(.reload)
+            } else {
+                feedLoader.requestLoad(.reload)
+            }
         case .activityFilterUpdated, .mediaFilterUpdated:
             loadingState = .initializing
             interactiveReloadTriggerModel.reset(triggered: true)
@@ -1563,8 +1689,9 @@ extension TimelineListViewModel {
         _ policy: Mastodon.Entity.NotificationPolicy?,
         andReloadFeed reload: Bool
     ) {
-        guard filteredNotificationsViewModel.policy != policy else { return }
-        filteredNotificationsViewModel.policy = policy
+        if filteredNotificationsViewModel.policy != policy {
+            filteredNotificationsViewModel.policy = policy
+        }
         guard reload else { return }
         
         switch loadingState {
@@ -1776,10 +1903,10 @@ extension TimelineListViewModel {
         
         var canReload: Bool {
             switch self {
-            case .untracked:
-                true
-            default:
+            case .initializing, .requestedPrependedHeightCalculations:
                 false
+            default:
+                true
             }
         }
     }
@@ -2046,12 +2173,7 @@ struct TimelineListView: View {
                 // clear the notification dot on the tab icon
                 NotificationService.shared.clearNotificationCountForActiveUser()
             }
-            if viewModel.needsReloadOnNextAppear {
-                viewModel.needsReloadOnNextAppear = false
-                Task {
-                    await viewModel.forceReload(.notificationCountUpdated)
-                }
-            }
+            viewModel.reloadWhenBecomingVisible()
         }
         .toolbar(viewModel.hasActiveOverlay ? .hidden : .visible, for: .navigationBar)
         .toolbar(viewModel.hasActiveOverlay ? .hidden : .visible, for: .tabBar)
@@ -3605,7 +3727,7 @@ struct Snackbar: View {
 extension MastodonTimelineType {
     var canDisplayNewItemsSnackbar: Bool {
         switch self {
-        case .homeTimeline:
+        case .homeTimeline, .notifications:
             true
         default:
             false

--- a/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
+++ b/Mastodon/Scene/Root/MainTab/MainTabBarController.swift
@@ -477,13 +477,12 @@ extension MainTabBarController: UITabBarControllerDelegate {
 
             switch (currentTab, previousTab) {
             case (.home, .home):
-                // When home is tapped again, scroll to top
-                (homeTimelineViewController as? TimelineListViewController)?.scrollToTop()
-                break
+                (homeTimelineViewController as? TimelineListViewController)?.scrollToTopAndRefresh()
+            case (.notifications, .notifications):
+                (notificationViewController as? TimelineListViewController)?.scrollToTopAndRefresh()
             case (.search, .search):
                 // When search is tapped again, expand and focus the search bar
                 searchViewController.searchBar.becomeFirstResponder()
-                break
             default:
                 break
             }

--- a/MastodonSDK/Sources/MastodonCore/Service/API/APIService.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/API/APIService.swift
@@ -30,6 +30,9 @@ public final class APIService {
         let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown"
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = ["User-Agent" : "mastodon-ios/" + appVersion]
+        // Default resource timeout is 7 days, which leaves zombie tasks after iOS freezes the socket in the background.
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 60
         self.session = URLSession(configuration: configuration)
 
         // setup cache. 10MB RAM + 50MB Disk

--- a/MastodonSDK/Sources/MastodonCore/Service/API/APIService.swift
+++ b/MastodonSDK/Sources/MastodonCore/Service/API/APIService.swift
@@ -31,7 +31,6 @@ public final class APIService {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = ["User-Agent" : "mastodon-ios/" + appVersion]
         // Default resource timeout is 7 days, which leaves zombie tasks after iOS freezes the socket in the background.
-        configuration.timeoutIntervalForRequest = 30
         configuration.timeoutIntervalForResource = 60
         self.session = URLSession(configuration: configuration)
 


### PR DESCRIPTION
Fixes #1554

## Summary

The official iOS app does not use the Mastodon streaming WebSocket. Home and Notifications are REST snapshots kept in memory. After the process is backgrounded, that snapshot is often never refreshed, so the lists look frozen until the user force-quits.

This is not a server or streaming-proxy misconfiguration. It is several client bugs stacked on top of each other.

## Problem

Leave the app in memory (switch away, lock the phone, or just keep Notifications open). New posts and notifications appear on the web and on other clients. In this app they do not. Pull-to-refresh may spin and do nothing. Switching Home → Notifications sometimes helps. Force-quitting always helps.

That matches how a large part of the user base has been living with the official app for years.

## Why this happens

### 1. Nothing fetches on resume

`sceneDidBecomeActive` updates the badge, filters, and the signed-in account. It does not reload Home or Notifications.

The SwiftUI `onAppear` on the timeline is not a substitute:

- it does not run when returning from the background if the view is already on screen
- inside a `UITabBarController` it often does not run again when switching back to the tab

So the list you see is whatever was fetched the last time the view model was created — usually at process launch.

### 2. The “reload on next appear” path never loads the feed

`needsReloadOnNextAppear` is set only when the unread **push** badge increases. Push delivery itself is unreliable on many instances, so the flag is often never set.

When the flag *is* set, `forceReload(.notificationCountUpdated)` fetches the notification **filter policy** and returns immediately if that policy is unchanged. It does not request `/api/v1/notifications` or grouped notifications. New rows are not loaded.

### 3. A request started before suspend pins `isFetching`

iOS freezes in-flight `URLSession` tasks in the background. They frequently never complete. The default resource timeout is seven days.

`MastodonFeedLoader.isFetching` stays `true`. Pull-to-refresh then no-ops:

- `permissionToLoadImmediately` returned `false` while a fetch was “in progress”
- `LoadingState.canReload` was true only for `.untracked`

Force-quit is the only thing that clears that flag. Switching tabs sometimes helped because `onDisappear` reset `loadingState` to `.untracked`, which unblocked the *next* pull, not the current screen.

### 4. A successful fetch can still look like a freeze

Reload keeps the previous scroll anchor. New items are inserted *above* it. Home has a “new items” snackbar; Notifications did not (`canDisplayNewItemsSnackbar` was home-only).

If the old anchor is missing from the new page, the result is stored in `waitingReplacementItems` and **not applied**. The first pull-to-refresh fetches; the second pull finally displays. That is the “pull twice” behaviour.

## Related reports

Same symptoms, not just “notifications” in general:

- [mastodon/mastodon-ios#1554](https://github.com/mastodon/mastodon-ios/issues/1554) (open) — Notifications do not show new items until pull-to-refresh **at least twice**; entering the tab does not refresh. This is `waitingReplacementItems` plus no fetch on appear.
- [mastodon/mastodon-ios#942](https://github.com/mastodon/mastodon-ios/issues/942) (closed 2023) — have to kill the app to see updates; home button and pull-to-refresh do nothing; switching tabs then back sometimes forces a refresh. A fix shipped for the old UIKit timeline; the same user-visible failure is present in the current SwiftUI timeline.
- [mastodon/mastodon-ios#1402](https://github.com/mastodon/mastodon-ios/issues/1402) (closed) — Notifications pull-to-refresh never updates contents (2025.01 regression). Same surface; closed as fixed, then #1554 reopened the behaviour.

Related but **not** this bug (left untouched here):

- [mastodon/mastodon-ios#1209](https://github.com/mastodon/mastodon-ios/issues/1209) — APNs banners never arrive. That is push subscription / Notification Service Extension, not the in-app list.
- [mastodon/mastodon#35097](https://github.com/mastodon/mastodon/issues/35097) — tab-bar badge count. Different layer.

## What this PR changes

- Invalidate in-flight feed loads when entering the background; ignore superseded results with a generation counter.
- Pull-to-refresh always proceeds (abandons a stuck fetch instead of returning).
- Cap `URLSession` `timeoutIntervalForResource` at 60s (default is 7 days).
- Auto-reload **only** Home and Notifications when the scene becomes active, the tab appears, or the tab is tapped again. Other timelines are left alone so a resume does not drop already-paginated older items.
- Apply new rows immediately. If the user was at the top, jump to the newest items. If they were scrolled down, show the new-items snackbar on Notifications as well.
- `notificationCountUpdated` reloads the feed, not only the filter policy.

## How to test

1. Open Notifications, leave it on screen, background the app for a minute, generate a notification from another client, come back. New rows should appear without a force-quit.
2. Stay on Home, background, return, switch to Notifications. Same.
3. Pull-to-refresh after a long background period should load, not spin and do nothing.
4. Re-tap the Notifications tab: scroll to top and reload.
5. If you were scrolled down in Notifications, a snackbar should offer jumping to the new items instead of yanking the scroll position.
6. Scroll a hashtag or bookmarks timeline, background the app, return: position and older pages should stay.

Co-Assisted-By: Grok
